### PR TITLE
feat: drag-drop na tela vazia, remover qt_material, estilizar UI nativa

### DIFF
--- a/source/main.py
+++ b/source/main.py
@@ -5,8 +5,8 @@ import sys
 import os
 import logging
 from PyQt6.QtWidgets import QApplication
-from PyQt6.QtGui import QIcon
-from qt_material import apply_stylesheet
+from PyQt6.QtGui import QIcon, QPalette, QColor
+from PyQt6.QtCore import Qt
 from src.ui import MainWindow
 from src.design_system.tokens import get_colors
 
@@ -33,25 +33,56 @@ def get_icon_path():
     return os.path.join(base_path, 'src', 'assets', 'datapyn-logo.ico')
 
 
+def _apply_dark_palette(app):
+    """Aplica paleta dark nativa via QPalette para visual consistente"""
+    palette = QPalette()
+
+    # Backgrounds
+    palette.setColor(QPalette.ColorRole.Window, QColor("#1e1e1e"))
+    palette.setColor(QPalette.ColorRole.Base, QColor("#252526"))
+    palette.setColor(QPalette.ColorRole.AlternateBase, QColor("#2d2d30"))
+
+    # Text
+    palette.setColor(QPalette.ColorRole.WindowText, QColor("#cccccc"))
+    palette.setColor(QPalette.ColorRole.Text, QColor("#cccccc"))
+    palette.setColor(QPalette.ColorRole.BrightText, QColor("#ffffff"))
+    palette.setColor(QPalette.ColorRole.PlaceholderText, QColor("#6e6e6e"))
+
+    # Buttons
+    palette.setColor(QPalette.ColorRole.Button, QColor("#2d2d30"))
+    palette.setColor(QPalette.ColorRole.ButtonText, QColor("#cccccc"))
+
+    # Highlights
+    palette.setColor(QPalette.ColorRole.Highlight, QColor("#3369FF"))
+    palette.setColor(QPalette.ColorRole.HighlightedText, QColor("#ffffff"))
+
+    # Misc
+    palette.setColor(QPalette.ColorRole.ToolTipBase, QColor("#252526"))
+    palette.setColor(QPalette.ColorRole.ToolTipText, QColor("#cccccc"))
+    palette.setColor(QPalette.ColorRole.Link, QColor("#3369FF"))
+
+    # Disabled
+    palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.WindowText, QColor("#5a5a5a"))
+    palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Text, QColor("#5a5a5a"))
+    palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.ButtonText, QColor("#5a5a5a"))
+
+    app.setPalette(palette)
+
+
 def main():
     """Funcao principal"""
     app = QApplication(sys.argv)
     app.setApplicationName("DataPyn")
     app.setOrganizationName("DataPyn")
-    
+
+    # Estilo Fusion para visual consistente cross-platform
+    app.setStyle("Fusion")
+
+    # Paleta dark nativa
+    _apply_dark_palette(app)
+
     # Obter cores do design system
     colors = get_colors()
-    
-    # APLICAR MATERIAL DESIGN THEME
-    extra = {
-        # Cores customizadas do design system
-        'danger': colors.danger,
-        'warning': colors.warning,
-        'success': colors.success,
-        'primaryColor': colors.interactive_primary,
-        'primaryLightColor': colors.interactive_primary_hover,
-    }
-    apply_stylesheet(app, theme='dark_blue.xml', extra=extra)
     
     # Definir ícone da aplicação (afeta todas as janelas)
     icon_path = get_icon_path()

--- a/source/src/ui/components/session_tabs.py
+++ b/source/src/ui/components/session_tabs.py
@@ -27,28 +27,32 @@ class SessionTabBar(QTabBar):
     def _setup_style(self):
         """Configura estilo"""
         self.setStyleSheet("""
+            QTabBar {
+                background-color: #252526;
+            }
             QTabBar::tab {
                 background-color: #2d2d30;
-                color: #cccccc;
-                padding: 8px 20px;
+                color: #999999;
+                padding: 6px 16px;
                 padding-right: 28px;
-                border: 1px solid #3e3e42;
-                border-bottom: none;
-                margin-right: 2px;
+                border: none;
+                border-bottom: 2px solid transparent;
+                margin-right: 1px;
+                min-width: 80px;
             }
             QTabBar::tab:selected {
                 background-color: #1e1e1e;
                 color: #ffffff;
+                border-bottom: 2px solid #3369FF;
             }
             QTabBar::tab:hover:!selected {
-                background-color: #3e3e42;
+                background-color: #37373d;
+                color: #cccccc;
             }
             QTabBar::close-button {
                 subcontrol-position: right;
-                margin-right: 20px;
+                margin-right: 4px;
                 padding: 0px;
-                width: 50px;
-                height: 50px;
             }
             QTabBar::close-button:hover {
                 background-color: rgba(231, 76, 60, 0.9);
@@ -266,26 +270,27 @@ class SessionTabs(QTabWidget):
         
         # Criar botão customizado compacto e elegante com ícone X
         close_btn = QToolButton()
-        close_btn.setIcon(qta.icon('mdi.close', color='#cccccc', scale_factor=1.0))
-        close_btn.setFixedSize(50, 50)
+        close_btn.setIcon(qta.icon('mdi.close', color='#999999', scale_factor=0.7))
+        close_btn.setFixedSize(18, 18)
         close_btn.setCursor(Qt.CursorShape.PointingHandCursor)
         close_btn.setStyleSheet("""
             QToolButton {
                 background: transparent;
                 border: none;
+                border-radius: 3px;
             }
             QToolButton:hover {
                 background-color: rgba(231, 76, 60, 0.8);
             }
         """)
         
-        # Atualizar ícone no hover para branco
+        # Atualizar icone no hover para branco
         def on_hover_enter(event):
-            close_btn.setIcon(qta.icon('mdi.close', color='#ffffff', scale_factor=1.0))
+            close_btn.setIcon(qta.icon('mdi.close', color='#ffffff', scale_factor=0.7))
             QToolButton.enterEvent(close_btn, event)
         
         def on_hover_leave(event):
-            close_btn.setIcon(qta.icon('mdi.close', color='#cccccc', scale_factor=1.0))
+            close_btn.setIcon(qta.icon('mdi.close', color='#999999', scale_factor=0.7))
             QToolButton.leaveEvent(close_btn, event)
         
         close_btn.enterEvent = on_hover_enter
@@ -310,7 +315,8 @@ class SessionTabs(QTabWidget):
         """Configura estilo"""
         self.setStyleSheet("""
             QTabWidget::pane {
-                border: 1px solid #3e3e42;
+                border: none;
+                border-top: 1px solid #3e3e42;
                 background-color: #1e1e1e;
             }
             QTabWidget::tab-bar {

--- a/source/src/ui/components/session_widget.py
+++ b/source/src/ui/components/session_widget.py
@@ -199,14 +199,7 @@ class SessionWidget(QWidget):
         """Mostra o painel de output"""
         main_window = self._get_main_window()
         if main_window:
-            main_window.show_panel('results')
-            # Seleciona aba Output
-            results_panel = main_window.get_panel('results')
-            if results_panel:
-                for i in range(results_panel.tab_widget.count()):
-                    if results_panel.tab_widget.tabText(i) == 'Output':
-                        results_panel.tab_widget.setCurrentIndex(i)
-                        break
+            main_window.show_panel('output')
     
     def _set_results(self, data, name="result"):
         """Define resultados no painel global"""

--- a/source/src/ui/components/statusbar.py
+++ b/source/src/ui/components/statusbar.py
@@ -1,5 +1,5 @@
 """
-StatusBar Material Design
+StatusBar da aplicacao
 """
 from PyQt6.QtWidgets import QStatusBar, QLabel
 from PyQt6.QtCore import QTimer, QElapsedTimer
@@ -7,14 +7,30 @@ import qtawesome as qta
 
 
 class MainStatusBar(QStatusBar):
-    """StatusBar Material"""
+    """StatusBar principal"""
     
     def __init__(self, theme_manager=None, parent=None):
         super().__init__(parent)
         
         self.theme_manager = theme_manager
+        self._setup_style()
         self._setup_widgets()
         self._setup_timer()
+    
+    def _setup_style(self):
+        """Configura estilo da statusbar"""
+        self.setStyleSheet("""
+            QStatusBar {
+                background-color: #252526;
+                border-top: 1px solid #3e3e42;
+                color: #999999;
+                font-size: 12px;
+            }
+            QStatusBar QLabel {
+                color: #999999;
+                padding: 0px 6px;
+            }
+        """)
     
     def _update_connection_icon(self, connected: bool, text: str = ""):
         """Atualiza ícone de conexão"""

--- a/source/src/ui/components/toolbar.py
+++ b/source/src/ui/components/toolbar.py
@@ -1,5 +1,5 @@
 """
-Toolbar principal da aplicação - Material Design
+Toolbar principal da aplicacao
 """
 from PyQt6.QtWidgets import QToolBar, QWidget, QPushButton, QSizePolicy
 from PyQt6.QtCore import pyqtSignal, QSize
@@ -7,7 +7,7 @@ import qtawesome as qta
 
 
 class MainToolbar(QToolBar):
-    """Toolbar Material Design"""
+    """Toolbar principal"""
     
     new_connection_clicked = pyqtSignal()
     new_tab_clicked = pyqtSignal()
@@ -17,22 +17,62 @@ class MainToolbar(QToolBar):
         super().__init__("Principal", parent)
         self.theme_manager = theme_manager
         self.setMovable(False)
-        self.setIconSize(QSize(20, 20))
+        self.setIconSize(QSize(18, 18))
+        self._setup_style()
         self._setup_buttons()
     
+    def _setup_style(self):
+        """Configura estilo da toolbar"""
+        self.setStyleSheet("""
+            QToolBar {
+                background-color: #252526;
+                border: none;
+                border-bottom: 1px solid #3e3e42;
+                padding: 2px 4px;
+                spacing: 2px;
+            }
+            QToolBar::separator {
+                background-color: #3e3e42;
+                width: 1px;
+                margin: 4px 2px;
+            }
+            QPushButton {
+                background-color: transparent;
+                color: #cccccc;
+                border: none;
+                padding: 4px 10px;
+                font-size: 12px;
+                border-radius: 3px;
+            }
+            QPushButton:hover {
+                background-color: #37373d;
+                color: #ffffff;
+            }
+            QPushButton:pressed {
+                background-color: #2d2d30;
+            }
+            QPushButton#success {
+                color: #4caf50;
+            }
+            QPushButton#success:hover {
+                background-color: rgba(76, 175, 80, 0.15);
+                color: #66bb6a;
+            }
+        """)
+    
     def _setup_buttons(self):
-        """Botões com ícones Material"""
+        """Botoes com icones"""
         # Nova Aba
         self.btn_new_tab = QPushButton(" Nova Aba")
-        self.btn_new_tab.setIcon(qta.icon('mdi.tab-plus', color='white'))
+        self.btn_new_tab.setIcon(qta.icon('mdi.tab-plus', color='#cccccc'))
         self.btn_new_tab.clicked.connect(self.new_tab_clicked.emit)
         self.addWidget(self.btn_new_tab)
         
         self.addSeparator()
         
-        # Nova Conexão
-        self.btn_new_conn = QPushButton(" Conexão")
-        self.btn_new_conn.setIcon(qta.icon('mdi.database-plus', color='white'))
+        # Nova Conexao
+        self.btn_new_conn = QPushButton(" Conexao")
+        self.btn_new_conn.setIcon(qta.icon('mdi.database-plus', color='#cccccc'))
         self.btn_new_conn.clicked.connect(self.new_connection_clicked.emit)
         self.addWidget(self.btn_new_conn)
         

--- a/source/src/ui/docking/docking_manager.py
+++ b/source/src/ui/docking/docking_manager.py
@@ -491,7 +491,7 @@ class DockingManager(QObject):
     def eventFilter(self, obj, event):
         """Filtro de eventos para capturar drags globais"""
         # Captura eventos de mouse para finalizar drag quando solto fora
-        if self.is_dragging and event.type() in [event.Type.MouseButtonRelease, event.Type.Drop]:
+        if getattr(self, 'is_dragging', False) and event.type() in [event.Type.MouseButtonRelease, event.Type.Drop]:
             if hasattr(event, 'button') and event.button() == Qt.MouseButton.LeftButton:
                 print(f"DEBUG: Mouse release detectado durante drag - criando painel flutuante")
                 # Drop fora de área válida - criar painel flutuante

--- a/tests/test_block_editor.py
+++ b/tests/test_block_editor.py
@@ -753,34 +753,34 @@ class TestFileDragAndDrop:
         return editor
     
     def test_generate_import_code_csv(self, editor):
-        """Deve gerar código de importação para CSV"""
+        """Deve gerar codigo de importacao para CSV"""
         code = editor._generate_import_code('/path/to/data.csv')
         assert code is not None
-        assert 'import pandas as pd' in code
+        assert 'import pandas' not in code
         assert "pd.read_csv('/path/to/data.csv')" in code
         assert 'df = ' in code
     
     def test_generate_import_code_json(self, editor):
-        """Deve gerar código de importação para JSON"""
+        """Deve gerar codigo de importacao para JSON"""
         code = editor._generate_import_code('/path/to/data.json')
         assert code is not None
-        assert 'import pandas as pd' in code
+        assert 'import pandas' not in code
         assert "pd.read_json('/path/to/data.json')" in code
         assert 'df = ' in code
     
     def test_generate_import_code_xlsx(self, editor):
-        """Deve gerar código de importação para XLSX"""
+        """Deve gerar codigo de importacao para XLSX"""
         code = editor._generate_import_code('/path/to/data.xlsx')
         assert code is not None
-        assert 'import pandas as pd' in code
+        assert 'import pandas' not in code
         assert "pd.read_excel('/path/to/data.xlsx')" in code
         assert 'df = ' in code
     
     def test_generate_import_code_xls(self, editor):
-        """Deve gerar código de importação para XLS"""
+        """Deve gerar codigo de importacao para XLS"""
         code = editor._generate_import_code('/path/to/data.xls')
         assert code is not None
-        assert 'import pandas as pd' in code
+        assert 'import pandas' not in code
         assert "pd.read_excel('/path/to/data.xls')" in code
         assert 'df = ' in code
     
@@ -922,9 +922,9 @@ class TestFileDragAndDrop:
         new_block = blocks[-1]
         assert new_block.get_language() == 'python'
         
-        # Deve conter código de importação
+        # Deve conter codigo de importacao
         code = new_block.get_code()
-        assert 'import pandas as pd' in code
+        assert 'import pandas' not in code
         assert 'pd.read_csv' in code
         assert '/path/to/data.csv' in code
     
@@ -957,9 +957,9 @@ class TestFileDragAndDrop:
         new_block = blocks[-1]
         assert new_block.get_language() == 'python'
         
-        # Deve conter código de importação
+        # Deve conter codigo de importacao
         code = new_block.get_code()
-        assert 'import pandas as pd' in code
+        assert 'import pandas' not in code
         assert 'pd.read_json' in code
         assert '/path/to/data.json' in code
     
@@ -992,9 +992,9 @@ class TestFileDragAndDrop:
         new_block = blocks[-1]
         assert new_block.get_language() == 'python'
         
-        # Deve conter código de importação
+        # Deve conter codigo de importacao
         code = new_block.get_code()
-        assert 'import pandas as pd' in code
+        assert 'import pandas' not in code
         assert 'pd.read_excel' in code
         assert '/path/to/data.xlsx' in code
     


### PR DESCRIPTION
- Drag-and-drop na tela inicial (empty state) para CSV, JSON, XLSX, SQL, PY, DPW
- Drag-and-drop no block editor tambem aceita SQL e PY (carrega conteudo)
- Removido qt_material: usar Fusion + QPalette dark nativa
- Toolbar estilizada: background #252526, botoes transparentes, hover sutil
- Abas de sessao estilo VS Code: barra azul na aba ativa, sem bordas laterais
- Botao X das abas compacto (18x18)
- Statusbar estilizada com background consistente
- Labels do empty state com background transparente
- Removido import pandas do codigo gerado por drag-drop (pd ja disponivel)
- Fix: docking_manager eventFilter com getattr guard para is_dragging
- Testes atualizados para refletir remocao do import pandas