### PR TITLE
fix(installer): corrigir MSI - textos, assinatura e permissoes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,41 @@ jobs:
       - name: Build | Generate Windows EXE
         run: uv run pyinstaller scripts/datapyn.spec --clean
 
+      - name: Build | Generate Installer Assets
+        shell: pwsh
+        run: |
+          # Dialog bitmap (493x312, 24-bit BMP)
+          # Banner bitmap (493x58, 24-bit BMP)
+          # Using PowerShell to create simple placeholder bitmaps
+          Add-Type -AssemblyName System.Drawing
+          
+          # Dialog background (493x312)
+          $dialogBmp = New-Object System.Drawing.Bitmap(493, 312)
+          $graphics = [System.Drawing.Graphics]::FromImage($dialogBmp)
+          $graphics.Clear([System.Drawing.Color]::White)
+          $font = New-Object System.Drawing.Font("Arial", 24, [System.Drawing.FontStyle]::Bold)
+          $brush = New-Object System.Drawing.SolidBrush([System.Drawing.Color]::FromArgb(0, 120, 212))
+          $graphics.DrawString("DataPyn", $font, $brush, 150, 130)
+          $font2 = New-Object System.Drawing.Font("Arial", 12)
+          $brush2 = New-Object System.Drawing.SolidBrush([System.Drawing.Color]::Gray)
+          $graphics.DrawString("Data Analysis Tool", $font2, $brush2, 165, 170)
+          $graphics.Dispose()
+          $dialogBmp.Save("scripts\installer_dialog.bmp", [System.Drawing.Imaging.ImageFormat]::Bmp)
+          $dialogBmp.Dispose()
+          
+          # Banner (493x58)
+          $bannerBmp = New-Object System.Drawing.Bitmap(493, 58)
+          $graphics = [System.Drawing.Graphics]::FromImage($bannerBmp)
+          $graphics.Clear([System.Drawing.Color]::White)
+          $font = New-Object System.Drawing.Font("Arial", 16, [System.Drawing.FontStyle]::Bold)
+          $brush = New-Object System.Drawing.SolidBrush([System.Drawing.Color]::FromArgb(0, 120, 212))
+          $graphics.DrawString("DataPyn", $font, $brush, 10, 18)
+          $graphics.Dispose()
+          $bannerBmp.Save("scripts\installer_banner.bmp", [System.Drawing.Imaging.ImageFormat]::Bmp)
+          $bannerBmp.Dispose()
+          
+          Write-Host "Installer assets generated successfully"
+
       - name: Build | Create MSI Installer
         shell: pwsh
         run: |
@@ -138,6 +173,50 @@ jobs:
             -spdb `
             installer.wixobj heat.wixobj `
             -o "DataPyn-${version}-windows.msi"
+
+      # Optional: Sign the MSI if a code signing certificate is configured
+      # To use this, add these secrets to your GitHub repository:
+      # - CODE_SIGNING_CERT_BASE64: Base64-encoded PFX certificate
+      # - CODE_SIGNING_CERT_PASSWORD: Password for the PFX file
+      - name: Build | Sign MSI (if certificate available)
+        if: ${{ env.HAS_CODE_SIGNING_CERT == 'true' }}
+        env:
+          HAS_CODE_SIGNING_CERT: ${{ secrets.CODE_SIGNING_CERT_BASE64 != '' }}
+          CODE_SIGNING_CERT_BASE64: ${{ secrets.CODE_SIGNING_CERT_BASE64 }}
+          CODE_SIGNING_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CERT_PASSWORD }}
+        shell: pwsh
+        run: |
+          $version = "${{ needs.release.outputs.version }}"
+          $msiPath = "DataPyn-${version}-windows.msi"
+          
+          # Decode certificate from base64
+          $certBytes = [Convert]::FromBase64String($env:CODE_SIGNING_CERT_BASE64)
+          $certPath = "codesigning.pfx"
+          [IO.File]::WriteAllBytes($certPath, $certBytes)
+          
+          # Find signtool.exe
+          $signtool = Get-ChildItem -Path "${env:ProgramFiles(x86)}\Windows Kits" -Recurse -Filter signtool.exe | 
+                      Where-Object { $_.FullName -like "*x64*" } | 
+                      Select-Object -First 1 -ExpandProperty FullName
+          
+          if ($signtool) {
+            Write-Host "Signing MSI with signtool..."
+            & $signtool sign /f $certPath /p $env:CODE_SIGNING_CERT_PASSWORD `
+              /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 `
+              /d "DataPyn" /du "https://github.com/datapyn/datapyn" `
+              $msiPath
+            
+            if ($LASTEXITCODE -eq 0) {
+              Write-Host "MSI signed successfully!"
+            } else {
+              Write-Warning "Failed to sign MSI, continuing with unsigned installer"
+            }
+          } else {
+            Write-Warning "signtool.exe not found, skipping signing"
+          }
+          
+          # Clean up certificate file
+          Remove-Item -Path $certPath -Force -ErrorAction SilentlyContinue
 
       - name: Publish | Upload MSI to GitHub Release
         if: "!(github.event.inputs.dry_run == 'true')"

--- a/docs/CODE_SIGNING.md
+++ b/docs/CODE_SIGNING.md
@@ -1,0 +1,89 @@
+# Assinatura de Codigo para o MSI do DataPyn
+
+Este documento explica como configurar a assinatura de codigo para o instalador MSI do DataPyn.
+
+## Por que assinar o MSI?
+
+Instaladores nao assinados sao frequentemente detectados como ameacas pelo Windows Defender e outros antivirus. A assinatura de codigo:
+
+1. Confirma a identidade do publicador
+2. Garante que o arquivo nao foi alterado
+3. Evita avisos de "editor desconhecido" do Windows
+4. Reduz deteccoes de falso positivo por antivirus
+
+## Tipos de Certificados
+
+### Certificado EV (Extended Validation)
+
+- **Recomendado para distribuicao publica**
+- Requer validacao rigorosa da identidade da empresa
+- Custo: $300-500/ano
+- Provedores: DigiCert, Sectigo, GlobalSign
+
+### Certificado OV (Organization Validation)
+
+- Validacao menos rigorosa
+- Custo: $70-200/ano
+- Pode levar mais tempo para construir reputacao no SmartScreen
+
+### Certificado Self-Signed (apenas para testes)
+
+- Gratuito
+- **NAO recomendado para distribuicao** - nao resolve o problema de deteccao
+
+## Configurando a Assinatura no GitHub Actions
+
+### 1. Obter um Certificado de Code Signing
+
+Compre um certificado de code signing de uma CA confiavel. Voce recebera um arquivo .pfx ou .p12.
+
+### 2. Converter para Base64
+
+```powershell
+# No PowerShell
+$pfxBytes = [System.IO.File]::ReadAllBytes("seu-certificado.pfx")
+$base64 = [Convert]::ToBase64String($pfxBytes)
+$base64 | Set-Clipboard  # Copia para a area de transferencia
+```
+
+### 3. Adicionar Secrets no GitHub
+
+Va em: Repository > Settings > Secrets and variables > Actions
+
+Adicione dois secrets:
+
+| Secret Name | Valor |
+|-------------|-------|
+| `CODE_SIGNING_CERT_BASE64` | O certificado em base64 (do passo 2) |
+| `CODE_SIGNING_CERT_PASSWORD` | A senha do arquivo PFX |
+
+### 4. Pronto!
+
+O workflow de release ira automaticamente:
+1. Decodificar o certificado
+2. Assinar o MSI com timestamp
+3. Limpar o certificado temporario
+
+## Verificando a Assinatura
+
+Apos baixar o MSI assinado:
+
+```powershell
+# Verificar assinatura
+Get-AuthenticodeSignature "DataPyn-*.msi"
+```
+
+Deve mostrar `Status: Valid` e o nome do certificado.
+
+## Alternativa: Azure Trusted Signing (preview)
+
+A Microsoft oferece um servico de assinatura na nuvem que nao requer certificado local:
+https://learn.microsoft.com/en-us/azure/trusted-signing/
+
+## Solucao Temporaria (sem certificado)
+
+Enquanto nao tiver um certificado:
+
+1. O MSI funcionara, mas mostrara avisos
+2. Usuarios podem clicar em "More info" > "Run anyway"
+3. Considere distribuir tambem um ZIP portatil como alternativa

--- a/scripts/installer.wxs
+++ b/scripts/installer.wxs
@@ -10,23 +10,32 @@
            Name="DataPyn"
            Language="1033"
            Version="$(var.ProductVersion)"
-           Manufacturer="DataPyn"
+           Manufacturer="DataPyn Team"
            UpgradeCode="{E8A3B02D-7F14-4C6A-9D5E-1B8F0A2C3D4E}">
 
     <Package InstallerVersion="200"
              Compressed="yes"
-             InstallScope="perMachine"
-             Description="DataPyn - Data Analysis Tool"
-             Comments="Instalador MSI gerado automaticamente pelo CI." />
+             InstallScope="perUser"
+             Description="DataPyn - Ferramenta de analise de dados com Python e SQL"
+             Comments="DataPyn - Data Analysis Tool" />
 
     <MajorUpgrade DowngradeErrorMessage="Uma versao mais recente do [ProductName] ja esta instalada." />
     <MediaTemplate EmbedCab="yes" />
 
     <!-- ============================================================ -->
-    <!-- Estrutura de diretorios                                      -->
+    <!-- Textos customizados para a UI do instalador                  -->
+    <!-- ============================================================ -->
+    <Property Id="WIXUI_EXITDIALOGOPTIONALTEXT" Value="DataPyn foi instalado com sucesso. Clique em Finish para fechar o instalador." />
+    <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Abrir DataPyn apos a instalacao" />
+    <WixVariable Id="WixUILicenseRtf" Value="$(var.SourceDir)\..\scripts\license.rtf" />
+    <WixVariable Id="WixUIDialogBmp" Value="$(var.SourceDir)\..\scripts\installer_dialog.bmp" />
+    <WixVariable Id="WixUIBannerBmp" Value="$(var.SourceDir)\..\scripts\installer_banner.bmp" />
+
+    <!-- ============================================================ -->
+    <!-- Estrutura de diretorios (per-user: LocalAppData)             -->
     <!-- ============================================================ -->
     <Directory Id="TARGETDIR" Name="SourceDir">
-      <Directory Id="ProgramFilesFolder">
+      <Directory Id="LocalAppDataFolder">
         <Directory Id="INSTALLFOLDER" Name="DataPyn" />
       </Directory>
       <Directory Id="DesktopFolder" Name="Desktop" />
@@ -90,9 +99,12 @@
     <!-- ============================================================ -->
     <Icon Id="DataPynIcon" SourceFile="$(var.SourceDir)\DataPyn.exe" />
     <Property Id="ARPPRODUCTICON" Value="DataPynIcon" />
+    <Property Id="ARPHELPLINK" Value="https://github.com/datapyn/datapyn" />
+    <Property Id="ARPURLINFOABOUT" Value="https://github.com/datapyn/datapyn" />
 
-    <!-- UI minima com dialogo de licenca removido -->
-    <UIRef Id="WixUI_Minimal" />
+    <!-- UI com dialogo de diretorio de instalacao -->
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
+    <UIRef Id="WixUI_InstallDir" />
 
   </Product>
 </Wix>

--- a/scripts/license.rtf
+++ b/scripts/license.rtf
@@ -1,0 +1,31 @@
+{\rtf1\ansi\ansicpg1252\deff0\nouicompat\deflang1033
+{\fonttbl{\f0\fswiss\fcharset0 Arial;}}
+{\*\generator Riched20 10.0.19041}
+\viewkind4\uc1 
+\pard\sa200\sl276\slmult1\qc\b\f0\fs28 DataPyn - Licenca de Uso\b0\fs22\par
+\pard\sa200\sl276\slmult1\par
+\b LICENCA MIT\b0\par
+\par
+Copyright (c) 2024-2026 DataPyn Team\par
+\par
+A permissao e concedida, gratuitamente, a qualquer pessoa que obtenha uma copia deste software e arquivos de documentacao associados (o "Software"), para lidar no Software sem restricao, incluindo, sem limitacao, os direitos de usar, copiar, modificar, mesclar, publicar, distribuir, sublicenciar e/ou vender copias do Software, e permitir que as pessoas a quem o Software e fornecido o facam, sujeito as seguintes condicoes:\par
+\par
+O aviso de copyright acima e este aviso de permissao devem ser incluidos em todas as copias ou partes substanciais do Software.\par
+\par
+O SOFTWARE E FORNECIDO "COMO ESTA", SEM GARANTIA DE QUALQUER TIPO, EXPRESSA OU IMPLICITA, INCLUINDO, MAS NAO SE LIMITANDO AS GARANTIAS DE COMERCIALIZACAO, ADEQUACAO A UM PROPOSITO ESPECIFICO E NAO INFRACAO. EM NENHUM CASO OS AUTORES OU DETENTORES DE DIREITOS AUTORAIS SERAO RESPONSAVEIS POR QUALQUER RECLAMACAO, DANOS OU OUTRA RESPONSABILIDADE, SEJA EM UMA ACAO DE CONTRATO, DELITO OU DE OUTRA FORMA, DECORRENTE DE, OU EM CONEXAO COM O SOFTWARE OU O USO OU OUTRAS NEGOCIACOES NO SOFTWARE.\par
+\par
+\pard\sa200\sl276\slmult1\qc ---\par
+\pard\sa200\sl276\slmult1\par
+\b Sobre o DataPyn\b0\par
+\par
+DataPyn e uma ferramenta de analise de dados que combina a flexibilidade do Python com a simplicidade do SQL. Projetado para analistas de dados, cientistas de dados e desenvolvedores que precisam trabalhar com dados de forma eficiente.\par
+\par
+\b Recursos principais:\b0\par
+- Editor de codigo com blocos Python e SQL\par
+- Conexao com multiplos bancos de dados\par
+- Visualizacao de resultados em tabelas\par
+- Export de dados para diversos formatos\par
+- Integracao com bibliotecas populares de analise de dados\par
+\par
+Para mais informacoes, visite: https://github.com/datapyn/datapyn\par
+}


### PR DESCRIPTION
- Substituir textos genericos por descricoes do DataPyn
- Adicionar licenca RTF customizada
- Mudar de perMachine para perUser (sem necessidade de admin)
- Instalar em LocalAppData ao inves de Program Files
- Adicionar step opcional para assinatura de codigo
- Usar WixUI_InstallDir para dialogo mais completo
- Gerar bitmaps do instalador dinamicamente no CI

Docs: docs/CODE_SIGNING.md com instrucoes para certificado