### PR TITLE
fix(installer): corrigir MSI - textos, assinatura e permissoes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,13 @@ jobs:
           $bannerBmp.Save("scripts\installer_banner.bmp", [System.Drawing.Imaging.ImageFormat]::Bmp)
           $bannerBmp.Dispose()
           
-          Write-Host "Installer assets generated successfully"
+          # Copy to dist folder where WiX expects them (relative to SourceDir)
+          New-Item -ItemType Directory -Path "dist\scripts" -Force | Out-Null
+          Copy-Item "scripts\installer_dialog.bmp" "dist\scripts\" -Force
+          Copy-Item "scripts\installer_banner.bmp" "dist\scripts\" -Force
+          Copy-Item "scripts\license.rtf" "dist\scripts\" -Force
+          
+          Write-Host "Installer assets generated and copied successfully"
 
       - name: Build | Create MSI Installer
         shell: pwsh


### PR DESCRIPTION
## Resumo

Correcoes no instalador MSI para resolver os 3 problemas reportados:

### 1. Texto "Lorem ipsum" corrigido
- Substituidos textos genericos por descricoes do DataPyn
- Adicionada licenca RTF customizada com MIT License
- Trocado `WixUI_Minimal` por `WixUI_InstallDir` (dialogo mais completo)

### 2. Assinatura de codigo configurada
- Adicionado step opcional para assinar o MSI com certificado
- Usa secrets `CODE_SIGNING_CERT_BASE64` e `CODE_SIGNING_CERT_PASSWORD`
- Se nao configurado, pula a assinatura automaticamente
- Documentacao em `docs/CODE_SIGNING.md`

### 3. Erro de permissao de administrador resolvido
- Mudado de `perMachine` para `perUser`
- Instala em `%LocalAppData%\DataPyn` (nao requer admin)
- Atalhos criados no perfil do usuario
- Registry entries em HKCU (nao HKLM)

## Arquivos modificados
- `scripts/installer.wxs` - configuracao WiX
- `.github/workflows/release.yml` - workflow CD com geracao de assets
- `scripts/license.rtf` - licenca para o instalador (novo)
- `docs/CODE_SIGNING.md` - documentacao de assinatura (novo)

## Teste
Executar o workflow "Continuous Delivery - PSR" com dry_run=true nesta branch para validar a geracao do MSI.