### PR TITLE
fix(ci): grep versao casava 2 linhas no pyproject.toml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,10 +70,16 @@ jobs:
         id: dry_run_version
         if: github.event_name == 'workflow_dispatch'
         run: |
-          VERSION=$(grep '^version' pyproject.toml | sed 's/.*"\(.*\)"/\1/')
+          VERSION=$(grep '^version = ' pyproject.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          if [ -z "$VERSION" ] || [ "$VERSION" = "0.0.0" ]; then
+            echo "::error::Could not read valid version from pyproject.toml (got: '$VERSION')"
+            echo "released=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
           echo "released=true" >> "$GITHUB_OUTPUT"
           echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Manual release: version=$VERSION tag=v${VERSION}"
 
   build-windows-msi:
     needs: release


### PR DESCRIPTION
## Problema

O CD `workflow_dispatch` falhava com:
```
Error: Invalid format 'pyproject.toml:project.version]'
```

O `grep '^version'` casava **duas linhas** no pyproject.toml:
1. `version = "1.5.1"` (correto)
2. `version_toml = ["pyproject.toml:project.version"]` (incorreto)

A segunda linha gerava output invalido no `$GITHUB_OUTPUT`.

## Correcao

- `grep '^version = '` (com espaco e `=`) + `head -1` para garantir apenas a linha correta
- Validacao: aborta se versao vazia ou `0.0.0`