### PR TITLE
feat: isolamento de paineis por sessao, grid fluido com limitador de linhas

### DIFF
--- a/source/src/language/en-US.json
+++ b/source/src/language/en-US.json
@@ -288,7 +288,10 @@
     "error_save_image": "Error saving image:\n{error}",
     "export_table_no_data": "No data to export",
     "export_table_no_window": "Main window not found",
-    "export_table_no_connection": "No active connection available.\n\nConnect to a database first."
+    "export_table_no_connection": "No active connection available.\n\nConnect to a database first.",
+    "label_row_limit": "Rows:",
+    "tooltip_row_limit": "Max rows displayed in grid (exports use all data)",
+    "showing_limited": " (showing {showing})"
   },
 
   "csv_export": {
@@ -443,7 +446,10 @@
     "success_title": "Success",
     "success_msg": "Settings saved successfully!",
     "confirm_restore_title": "Confirm",
-    "confirm_restore_msg": "Do you want to restore all shortcuts to default values?"
+    "confirm_restore_msg": "Do you want to restore all shortcuts to default values?",
+    "section_display": "DISPLAY",
+    "label_grid_row_limit": "Default grid display limit (rows):",
+    "grid_row_limit_hint": "Only affects display. Exports always include all data."
   },
 
   "connections_manager": {

--- a/source/src/language/pt-BR.json
+++ b/source/src/language/pt-BR.json
@@ -259,6 +259,9 @@
     "tooltip_export_dest": "Destino da exportacao",
     "tooltip_export_table": "Exportar dados para uma tabela do banco (to_sql)",
     "no_results": "Sem resultados",
+    "label_row_limit": "Linhas:",
+    "tooltip_row_limit": "Max linhas exibidas no grid (exportacoes usam todos os dados)",
+    "showing_limited": " (exibindo {showing})",
     "json_header_key": "Chave",
     "json_header_value": "Valor",
     "json_header_type": "Tipo",
@@ -443,7 +446,10 @@
     "success_title": "Sucesso",
     "success_msg": "Configuracoes salvas com sucesso!",
     "confirm_restore_title": "Confirmar",
-    "confirm_restore_msg": "Deseja restaurar todos os atalhos para os valores padrao?"
+    "confirm_restore_msg": "Deseja restaurar todos os atalhos para os valores padrao?",
+    "section_display": "EXIBICAO",
+    "label_grid_row_limit": "Limite de linhas no grid (padrao):",
+    "grid_row_limit_hint": "Apenas afeta a exibicao. Exportacoes sempre incluem todos os dados."
   },
 
   "connections_manager": {

--- a/source/src/ui/components/results_viewer.py
+++ b/source/src/ui/components/results_viewer.py
@@ -23,8 +23,9 @@ from PyQt6.QtWidgets import (
     QTextEdit,
     QTreeWidget,
     QTreeWidgetItem,
+    QSpinBox,
 )
-from PyQt6.QtCore import Qt, QAbstractTableModel, QModelIndex, QVariant, QSettings
+from PyQt6.QtCore import Qt, QAbstractTableModel, QModelIndex, QVariant, QSettings, QTimer
 from PyQt6.QtGui import QColor, QImage, QPixmap, QFont
 import pandas as pd
 import json
@@ -226,6 +227,7 @@ class ResultsViewer(QWidget):
         self._setup_ui()
         self.current_df: Optional[pd.DataFrame] = None
         self._current_image_bytes: Optional[bytes] = None
+        self._display_limit: int = self._load_display_limit()
 
     def _setup_ui(self):
         """Configura a interface"""
@@ -274,6 +276,41 @@ class ResultsViewer(QWidget):
         self.toolbar.addSeparator()
         self.toolbar.addWidget(self.info_label)
 
+        # Spacer to push row limit to the right
+        spacer = QWidget()
+        spacer.setSizePolicy(spacer.sizePolicy())
+        from PyQt6.QtWidgets import QSizePolicy
+        spacer.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
+        self.toolbar.addWidget(spacer)
+
+        # Row limit spinner
+        self.row_limit_label = QLabel(S.results.label_row_limit if hasattr(S.results, 'label_row_limit') else "Rows:")
+        self.row_limit_label.setStyleSheet("color: #999; font-size: 10px; padding: 0 4px;")
+        self.toolbar.addWidget(self.row_limit_label)
+
+        self.row_limit_spin = QSpinBox()
+        self.row_limit_spin.setRange(10, 1000000)
+        self.row_limit_spin.setSingleStep(100)
+        self.row_limit_spin.setValue(self._load_display_limit())
+        self.row_limit_spin.setFixedWidth(90)
+        self.row_limit_spin.setToolTip(
+            S.results.tooltip_row_limit if hasattr(S.results, 'tooltip_row_limit')
+            else "Max rows displayed in grid (exports use all data)"
+        )
+        self.row_limit_spin.setStyleSheet("""
+            QSpinBox {
+                background-color: #2d2d30;
+                color: #cccccc;
+                border: 1px solid #3e3e42;
+                border-radius: 3px;
+                padding: 2px 6px;
+                font-size: 11px;
+            }
+            QSpinBox:hover { border-color: #007acc; }
+        """)
+        self.row_limit_spin.valueChanged.connect(self._on_row_limit_changed)
+        self.toolbar.addWidget(self.row_limit_spin)
+
         layout.addWidget(self.toolbar)
 
         # Save image button (hidden by default)
@@ -291,9 +328,9 @@ class ResultsViewer(QWidget):
         self.model = PandasModel(theme_manager=self.theme_manager)
         self.table_view.setModel(self.model)
 
-        # Ajustar colunas automaticamente pelo conteudo do cabecalho
+        # Cabecalho interativo - resize sera feito apos carregar dados (limitado)
         self.table_view.horizontalHeader().setSectionResizeMode(
-            self.table_view.horizontalHeader().ResizeMode.ResizeToContents
+            self.table_view.horizontalHeader().ResizeMode.Interactive
         )
         self.stack.addWidget(self.table_view)  # index 0
 
@@ -414,14 +451,34 @@ class ResultsViewer(QWidget):
         self.model.set_theme_manager(theme_manager)
 
     def display_dataframe(self, df: pd.DataFrame, var_name: str = "df"):
-        """Exibe um DataFrame na tabela"""
-        self.current_df = df
-        self.model.update_data(df)
+        """Exibe um DataFrame na tabela.
 
-        # Atualiza info
+        Armazena o DataFrame completo para exportacao, mas exibe apenas
+        ate o limite de linhas configurado para manter a interface fluida.
+        """
+        self.current_df = df
+
+        # Atualiza info com totais reais
         rows = len(df)
         cols = len(df.columns)
-        self.info_label.setText(S.results.info_df_dimensions.format(var_name=var_name, rows=f"{rows:,}", cols=cols))
+        limit = self.row_limit_spin.value()
+
+        # Alimentar modelo apenas com o slice limitado
+        display_df = df.head(limit) if rows > limit else df
+        self.model.update_data(display_df)
+
+        # Ajustar colunas pelo conteudo visivel (nao bloqueia com 100k linhas)
+        QTimer.singleShot(0, self._resize_columns)
+
+        # Info label mostra total real e quantas estao exibidas
+        if rows > limit:
+            info_text = S.results.info_df_dimensions.format(
+                var_name=var_name, rows=f"{rows:,}", cols=cols
+            )
+            showing = S.results.showing_limited.format(showing=f"{limit:,}") if hasattr(S.results, 'showing_limited') else f" (showing {limit:,})"
+            self.info_label.setText(info_text + showing)
+        else:
+            self.info_label.setText(S.results.info_df_dimensions.format(var_name=var_name, rows=f"{rows:,}", cols=cols))
 
         # Mostrar tabela e botoes de export
         self.stack.setCurrentIndex(0)
@@ -432,6 +489,35 @@ class ResultsViewer(QWidget):
         self.btn_export_table.setVisible(True)
         self.export_destination.setVisible(True)
         self.btn_save_image.setVisible(False)
+
+    def _resize_columns(self):
+        """Ajusta largura das colunas pelo conteudo visivel (deferido via QTimer)."""
+        self.table_view.resizeColumnsToContents()
+
+    def _on_row_limit_changed(self, value: int):
+        """Quando usuario muda o limite de linhas no spinner."""
+        # Reaplicar exibicao com novo limite
+        if self.current_df is not None:
+            self.display_dataframe(self.current_df, self._current_var_name())
+
+    def _current_var_name(self) -> str:
+        """Extrai nome da variavel do info_label atual."""
+        text = self.info_label.text()
+        if ":" in text:
+            return text.split(":")[0].strip()
+        return "df"
+
+    @staticmethod
+    def _load_display_limit() -> int:
+        """Carrega o limite de linhas exibidas do QSettings."""
+        settings = QSettings("DataPyn", "DataPyn")
+        return int(settings.value("grid/display_row_limit", 100))
+
+    @staticmethod
+    def _save_display_limit(value: int):
+        """Salva o limite de linhas exibidas no QSettings."""
+        settings = QSettings("DataPyn", "DataPyn")
+        settings.setValue("grid/display_row_limit", value)
 
     def display_image(self, image_bytes: bytes, label: str = None):
         """Exibe uma imagem (PNG bytes) no painel de resultados.

--- a/source/src/ui/components/session_widget.py
+++ b/source/src/ui/components/session_widget.py
@@ -109,6 +109,7 @@ class SessionWidget(QWidget):
     connection_drop_requested = pyqtSignal(str)  # connection_name
     block_connection_changed = pyqtSignal(object, str)  # (CodeBlock, connection_name)
     block_database_changed = pyqtSignal(object, str)  # (CodeBlock, database_name)
+    execution_finished = pyqtSignal(str, str, bool)  # (title, message, success)
 
     def __init__(self, session: Session, theme_manager: ThemeManager = None, parent=None):
         super().__init__(parent)
@@ -130,6 +131,13 @@ class SessionWidget(QWidget):
         self._is_executing: bool = False
         self._cancel_requested: bool = False  # Cancellation flag
         self._current_block_name: str = None  # Currently executing block name (for isolated namespace)
+
+        # Notification aggregation: accumulate results per queue run
+        self._queue_total_rows: int = 0
+        self._queue_blocks_done: int = 0
+        self._queue_had_error: bool = False
+        self._queue_last_error: str = ""
+        self._queue_last_type: str = ""  # "sql", "python", "cross"
 
         # Overlay de loading
         self._loading_overlay: Optional[QLabel] = None
@@ -214,6 +222,20 @@ class SessionWidget(QWidget):
             parent = parent.parent()
         return parent
 
+    def _get_own_panels(self):
+        """Get this session's own panels (results, output, variables).
+
+        Returns the panels that belong to THIS session, not the currently focused one.
+        This is critical to avoid results from one tab appearing in another.
+        """
+        try:
+            main_window = self._get_main_window()
+            if not main_window or not hasattr(main_window, "_session_panel_indices"):
+                return None
+            return main_window._session_panel_indices.get(self.session.session_id)
+        except (AttributeError, TypeError):
+            return None
+
     # === Delegation methods for global panels ===
 
     def _show_output(self):
@@ -223,45 +245,72 @@ class SessionWidget(QWidget):
             main_window.show_panel("output")
 
     def _set_results(self, data, name="result"):
-        """Define resultados no painel global"""
-        main_window = self._get_main_window()
-        if main_window and main_window.global_results_viewer:
-            main_window.global_results_viewer.display_dataframe(data, name)
-            main_window.show_panel("results")
+        """Define resultados no painel DESTA sessao"""
+        info = self._get_own_panels()
+        viewer = info["results"] if info else None
+        if not viewer:
+            # Fallback: usar viewer global (compatibilidade com testes/mocks)
+            main_window = self._get_main_window()
+            viewer = main_window.global_results_viewer if main_window else None
+        if viewer:
+            viewer.display_dataframe(data, name)
+            main_window = self._get_main_window()
+            if main_window:
+                main_window.show_panel("results")
 
     def _set_figures(self, figures: list, label: str = "Resultado"):
-        """Exibe rich outputs (imagens, HTML, JSON) no painel global de resultados"""
-        main_window = self._get_main_window()
-        if main_window and main_window.global_results_viewer:
-            main_window.global_results_viewer.display_rich_output(figures, label)
-            main_window.show_panel("results")
+        """Exibe rich outputs (imagens, HTML, JSON) no painel DESTA sessao"""
+        info = self._get_own_panels()
+        viewer = info["results"] if info else None
+        if not viewer:
+            main_window = self._get_main_window()
+            viewer = main_window.global_results_viewer if main_window else None
+        if viewer:
+            viewer.display_rich_output(figures, label)
+            main_window = self._get_main_window()
+            if main_window:
+                main_window.show_panel("results")
 
     def _log_error(self, text):
-        """Log error to global output"""
-        main_window = self._get_main_window()
-        if main_window and main_window.global_output_panel:
-            main_window.global_output_panel.error(text)
+        """Log error to this session's output"""
+        info = self._get_own_panels()
+        output = info["output"] if info else None
+        if not output:
+            main_window = self._get_main_window()
+            output = main_window.global_output_panel if main_window else None
+        if output:
+            output.error(text)
             self._show_output()
 
     def _log(self, text):
-        """Registra texto no output global"""
-        main_window = self._get_main_window()
-        if main_window and main_window.global_output_panel:
-            main_window.global_output_panel.log(text)
+        """Registra texto no output desta sessao"""
+        info = self._get_own_panels()
+        output = info["output"] if info else None
+        if not output:
+            main_window = self._get_main_window()
+            output = main_window.global_output_panel if main_window else None
+        if output:
+            output.log(text)
 
     def _clear_output(self):
-        """Limpa output global"""
-        main_window = self._get_main_window()
-        if main_window and main_window.global_output_panel:
-            main_window.global_output_panel.clear()
+        """Limpa output desta sessao"""
+        info = self._get_own_panels()
+        output = info["output"] if info else None
+        if not output:
+            main_window = self._get_main_window()
+            output = main_window.global_output_panel if main_window else None
+        if output:
+            output.clear()
 
     def _set_variables(self, variables_dict):
-        """Set variables in global panel"""
-        main_window = self._get_main_window()
-        if main_window and main_window.global_variables_panel:
-            main_window.global_variables_panel.set_variables(
-                variables_dict
-            )  # Fixed from refresh_variables to set_variables
+        """Set variables in this session's panel"""
+        info = self._get_own_panels()
+        panel = info["variables"] if info else None
+        if not panel:
+            main_window = self._get_main_window()
+            panel = main_window.global_variables_panel if main_window else None
+        if panel:
+            panel.set_variables(variables_dict)
 
     def _connect_signals(self):
         """Connect editor signals"""
@@ -369,6 +418,14 @@ class SessionWidget(QWidget):
 
         self._is_executing = True
         self._cancel_requested = False  # Limpar flag de cancelamento anterior
+
+        # Reset notification counters for single-block execution
+        if self._queue_blocks_done == 0:
+            self._queue_total_rows = 0
+            self._queue_had_error = False
+            self._queue_last_error = ""
+            self._queue_last_type = ""
+
         self.session.start_execution("sql")
         self.status_changed.emit(S.session_widget.executing_sql.format(conn_label=conn_label))
 
@@ -428,6 +485,10 @@ class SessionWidget(QWidget):
             self.append_output(self._format_log("SQL", f"ERROR: {error}"), error=True)
             self.session.finish_execution(False, f"Error: {error[:50]}...")
             self.status_changed.emit(S.session_widget.status_sql_error)
+            self._queue_had_error = True
+            self._queue_last_error = error[:80]
+            self._queue_last_type = "sql"
+            self._queue_blocks_done += 1
             self._show_output()
         else:
             # Determine namespace prefix (isolated per block or global)
@@ -456,6 +517,9 @@ class SessionWidget(QWidget):
 
                 self.session.finish_execution(True, S.session_widget.status_sql_multi.format(count=len(df)))
                 self.status_changed.emit(S.session_widget.status_sql_multi.format(count=len(df)))
+                self._queue_total_rows += total_rows
+                self._queue_blocks_done += 1
+                self._queue_last_type = "sql"
             else:
                 # Single DataFrame
                 rows = len(df) if df is not None else 0
@@ -464,6 +528,9 @@ class SessionWidget(QWidget):
                 self._set_results(df, var_name)
                 self.session.finish_execution(True, S.session_widget.status_sql_rows.format(rows=f"{rows:,}"))
                 self.status_changed.emit(S.session_widget.status_sql_rows.format(rows=f"{rows:,}"))
+                self._queue_total_rows += rows
+                self._queue_blocks_done += 1
+                self._queue_last_type = "sql"
 
                 # Save in session namespace
                 self.session.set_variable(var_name, df)
@@ -510,6 +577,14 @@ class SessionWidget(QWidget):
 
         self._is_executing = True
         self._cancel_requested = False  # Limpar flag de cancelamento anterior
+
+        # Reset notification counters for single-block execution
+        if self._queue_blocks_done == 0:
+            self._queue_total_rows = 0
+            self._queue_had_error = False
+            self._queue_last_error = ""
+            self._queue_last_type = ""
+
         self.session.start_execution("python")
         self.status_changed.emit(S.session_widget.executing_python)
         # Prepare namespace with df if exists
@@ -565,6 +640,10 @@ class SessionWidget(QWidget):
             self.append_output(self._format_log("PYTHON", f"ERROR:\n{error}"), error=True)
             self.session.finish_execution(False, S.session_widget.status_python_error)
             self.status_changed.emit(S.session_widget.status_python_error)
+            self._queue_had_error = True
+            self._queue_last_error = error[:80]
+            self._queue_last_type = "python"
+            self._queue_blocks_done += 1
             self._show_output()
         else:
             has_dataframe_result = False
@@ -612,6 +691,8 @@ class SessionWidget(QWidget):
                 self.session.update_namespace(updated_namespace)
 
             self.session.finish_execution(True, S.session_widget.status_python_done)
+            self._queue_blocks_done += 1
+            self._queue_last_type = "python"
 
         # Process next in queue if exists
         self._is_executing = False
@@ -622,6 +703,42 @@ class SessionWidget(QWidget):
     def _on_execute_cross_syntax(self, code: str):
         """Emite sinal para MainWindow processar cross-syntax"""
         self.execute_cross_syntax.emit(code)
+
+    # === EXECUTION NOTIFICATION ===
+
+    def _emit_queue_notification(self):
+        """Emit a single notification summarizing the entire queue execution."""
+        if self._queue_blocks_done == 0:
+            return
+
+        if self._queue_had_error:
+            title = S.notification.sql_query if self._queue_last_type == "sql" else S.notification.python
+            msg = S.notification.error.format(error=self._queue_last_error)
+            self.execution_finished.emit(title, msg, False)
+        else:
+            # Build a meaningful message based on what ran
+            if self._queue_last_type == "sql":
+                title = S.notification.sql_query
+                msg = S.notification.complete_rows.format(rows=f"{self._queue_total_rows:,}")
+            elif self._queue_last_type == "python":
+                title = S.notification.python
+                msg = S.notification.executed
+            else:
+                title = S.notification.cross_syntax
+                msg = S.notification.executed
+
+            # If multiple blocks ran, mention that
+            if self._queue_blocks_done > 1:
+                msg = f"{self._queue_blocks_done} blocks - {msg}"
+
+            self.execution_finished.emit(title, msg, True)
+
+        # Reset counters
+        self._queue_total_rows = 0
+        self._queue_blocks_done = 0
+        self._queue_had_error = False
+        self._queue_last_error = ""
+        self._queue_last_type = ""
 
     # === EXECUTION QUEUE ===
 
@@ -634,6 +751,13 @@ class SessionWidget(QWidget):
         """
         # Reset cancellation flag
         self._cancel_requested = False
+
+        # Reset notification tracking for this queue run
+        self._queue_total_rows = 0
+        self._queue_blocks_done = 0
+        self._queue_had_error = False
+        self._queue_last_error = ""
+        self._queue_last_type = ""
 
         # Add all to queue
         self._execution_queue.extend(queue)
@@ -716,6 +840,8 @@ class SessionWidget(QWidget):
         if not self._execution_queue:
             # Fila vazia, marca todos os blocos como finalizados
             self.editor.mark_execution_finished()
+            # Emit single notification for entire queue run
+            self._emit_queue_notification()
             return
 
         # Get next from queue

--- a/source/src/ui/components/toast_notification.py
+++ b/source/src/ui/components/toast_notification.py
@@ -1,0 +1,398 @@
+"""
+Toast notification widget - in-app notification system.
+
+Custom notification "toast" that appears in the bottom-right corner
+of the main window. Does NOT depend on OS desktop notifications.
+
+Features:
+- Slides in from the right edge
+- Auto-dismisses after a configurable timeout
+- Click to dismiss or focus the originating tab
+- Optional sound feedback
+- Stacks multiple notifications vertically
+- Themed to match the app's dark theme
+"""
+
+import logging
+from typing import Optional
+
+from PyQt6.QtCore import (
+    Qt, QTimer, QPropertyAnimation, QEasingCurve, QPoint, QUrl,
+    pyqtSignal,
+)
+from PyQt6.QtGui import QColor, QFont, QIcon
+from PyQt6.QtWidgets import (
+    QWidget, QLabel, QHBoxLayout, QVBoxLayout, QPushButton,
+    QGraphicsOpacityEffect, QApplication,
+)
+
+logger = logging.getLogger(__name__)
+
+# Try to import QSoundEffect for audio feedback
+try:
+    from PyQt6.QtMultimedia import QSoundEffect
+    HAS_SOUND = True
+except ImportError:
+    HAS_SOUND = False
+    logger.debug("QtMultimedia not available - toast sounds disabled")
+
+
+# Sound constants
+_SOUND_SUCCESS = "success"
+_SOUND_ERROR = "error"
+
+# Module-level manager instance (set by ToastManager.setup)
+_manager: Optional["ToastManager"] = None
+
+
+class ToastNotification(QWidget):
+    """
+    A single toast notification widget.
+
+    Appears in the bottom-right corner, auto-dismisses, and stacks.
+    """
+
+    clicked = pyqtSignal()
+    closed = pyqtSignal(object)  # emits self when dismissed
+
+    # Duration in ms
+    DURATION_DEFAULT = 4000
+    DURATION_ERROR = 6000
+    SLIDE_DURATION = 300
+    FADE_DURATION = 250
+
+    # Size
+    WIDTH = 340
+    MIN_HEIGHT = 60
+    MARGIN = 12  # margin from window edges
+
+    def __init__(
+        self,
+        title: str,
+        message: str,
+        success: bool = True,
+        duration: int = 0,
+        parent: QWidget = None,
+        on_click=None,
+    ):
+        # Top-level window (no parent) so it shows above everything,
+        # even when the main window is minimized or unfocused.
+        super().__init__(None)
+        self._on_click = on_click
+        self._duration = duration or (self.DURATION_DEFAULT if success else self.DURATION_ERROR)
+        self._success = success
+
+        self.setFixedWidth(self.WIDTH)
+        self.setMinimumHeight(self.MIN_HEIGHT)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        # SplashScreen type: top-level, frameless, always on top -- like a splash.
+        self.setWindowFlags(
+            Qt.WindowType.SplashScreen
+            | Qt.WindowType.WindowStaysOnTopHint
+        )
+        self.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating, True)
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose, True)
+
+        self._build_ui(title, message, success)
+        self._setup_animation()
+
+    def _build_ui(self, title: str, message: str, success: bool):
+        """Build the toast UI."""
+        # Colors
+        bg = "#1e8a3e" if success else "#c0392b"
+        bg_hover = "#22a347" if success else "#d44637"
+        border_color = "#27ae60" if success else "#e74c3c"
+        icon_char = "\u2713" if success else "\u2717"  # checkmark / cross
+
+        self.setStyleSheet(f"""
+            ToastNotification {{
+                background-color: {bg};
+                border: 1px solid {border_color};
+                border-radius: 8px;
+            }}
+            ToastNotification:hover {{
+                background-color: {bg_hover};
+            }}
+        """)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(12, 8, 8, 8)
+        layout.setSpacing(10)
+
+        # Icon
+        icon_label = QLabel(icon_char)
+        icon_label.setFont(QFont("Segoe UI", 16, QFont.Weight.Bold))
+        icon_label.setStyleSheet("color: white; background: transparent; border: none;")
+        icon_label.setFixedWidth(24)
+        icon_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(icon_label)
+
+        # Text area
+        text_layout = QVBoxLayout()
+        text_layout.setSpacing(2)
+
+        title_label = QLabel(title)
+        title_label.setFont(QFont("Segoe UI", 10, QFont.Weight.Bold))
+        title_label.setStyleSheet("color: white; background: transparent; border: none;")
+        title_label.setWordWrap(True)
+        text_layout.addWidget(title_label)
+
+        msg_label = QLabel(message)
+        msg_label.setFont(QFont("Segoe UI", 9))
+        msg_label.setStyleSheet("color: rgba(255,255,255,220); background: transparent; border: none;")
+        msg_label.setWordWrap(True)
+        text_layout.addWidget(msg_label)
+
+        layout.addLayout(text_layout, 1)
+
+        # Close button
+        close_btn = QPushButton("\u00d7")  # multiplication sign
+        close_btn.setFixedSize(20, 20)
+        close_btn.setFont(QFont("Segoe UI", 12))
+        close_btn.setStyleSheet("""
+            QPushButton {
+                color: rgba(255,255,255,180);
+                background: transparent;
+                border: none;
+                border-radius: 10px;
+            }
+            QPushButton:hover {
+                color: white;
+                background: rgba(255,255,255,30);
+            }
+        """)
+        close_btn.clicked.connect(self._dismiss)
+        layout.addWidget(close_btn, 0, Qt.AlignmentFlag.AlignTop)
+
+    def _setup_animation(self):
+        """Prepare slide-in and auto-dismiss timer."""
+        # Opacity effect for fade out
+        self._opacity = QGraphicsOpacityEffect(self)
+        self._opacity.setOpacity(1.0)
+        self.setGraphicsEffect(self._opacity)
+
+        # Auto-dismiss timer
+        self._dismiss_timer = QTimer(self)
+        self._dismiss_timer.setSingleShot(True)
+        self._dismiss_timer.timeout.connect(self._fade_out)
+
+    def show_at(self, x: int, y: int):
+        """Show the toast sliding in from the right."""
+        # Start position (off-screen to the right)
+        start_x = x + self.WIDTH + 20
+        self.move(start_x, y)
+        self.show()
+        self.raise_()
+
+        # On Windows, ensure the window is actually brought forward
+        try:
+            self.setWindowState(self.windowState() & ~Qt.WindowState.WindowMinimized)
+        except Exception:
+            pass
+
+        # Slide in
+        self._slide_anim = QPropertyAnimation(self, b"pos")
+        self._slide_anim.setDuration(self.SLIDE_DURATION)
+        self._slide_anim.setStartValue(QPoint(start_x, y))
+        self._slide_anim.setEndValue(QPoint(x, y))
+        self._slide_anim.setEasingCurve(QEasingCurve.Type.OutCubic)
+        self._slide_anim.start()
+
+        # Start auto-dismiss
+        self._dismiss_timer.start(self._duration)
+
+    def _fade_out(self):
+        """Fade out then close."""
+        self._fade_anim = QPropertyAnimation(self._opacity, b"opacity")
+        self._fade_anim.setDuration(self.FADE_DURATION)
+        self._fade_anim.setStartValue(1.0)
+        self._fade_anim.setEndValue(0.0)
+        self._fade_anim.setEasingCurve(QEasingCurve.Type.InQuad)
+        self._fade_anim.finished.connect(self._close_final)
+        self._fade_anim.start()
+
+    def _close_final(self):
+        """Final close after animation."""
+        self.closed.emit(self)
+        self.close()
+        self.deleteLater()
+
+    def _dismiss(self):
+        """User clicked close or the toast body."""
+        self._dismiss_timer.stop()
+        self._fade_out()
+
+    def mousePressEvent(self, event):
+        """Click on toast: dismiss and run callback."""
+        if self._on_click:
+            self._on_click()
+        self._dismiss()
+
+    def enterEvent(self, event):
+        """Pause auto-dismiss on hover."""
+        self._dismiss_timer.stop()
+        super().enterEvent(event)
+
+    def leaveEvent(self, event):
+        """Resume auto-dismiss on leave."""
+        self._dismiss_timer.start(1500)
+        super().leaveEvent(event)
+
+
+class ToastManager:
+    """
+    Manages toast notifications for a parent window.
+
+    Usage:
+        ToastManager.setup(main_window)
+        ToastManager.notify("SQL Query", "Complete! 42 rows", success=True)
+    """
+
+    def __init__(self, parent: QWidget):
+        self._parent = parent
+        self._active: list[ToastNotification] = []
+        self._sound_success: Optional[QSoundEffect] = None
+        self._sound_error: Optional[QSoundEffect] = None
+        self._setup_sounds()
+
+    @classmethod
+    def setup(cls, parent: QWidget) -> "ToastManager":
+        """Initialize the global toast manager for the main window."""
+        global _manager
+        _manager = cls(parent)
+        return _manager
+
+    @classmethod
+    def notify(
+        cls,
+        title: str,
+        message: str,
+        success: bool = True,
+        on_click=None,
+        sound: bool = True,
+    ):
+        """
+        Show a toast notification.
+
+        Args:
+            title: Notification title (bold).
+            message: Notification body text.
+            success: True for green/success, False for red/error.
+            on_click: Optional callback when user clicks the toast.
+            sound: Whether to play a notification sound.
+        """
+        if _manager is None:
+            logger.debug("ToastManager not initialized - skipping notification")
+            return
+
+        _manager._show(title, message, success, on_click, sound)
+
+    def _show(
+        self,
+        title: str,
+        message: str,
+        success: bool,
+        on_click,
+        sound: bool,
+    ):
+        """Internal: create and show a toast."""
+        toast = ToastNotification(
+            title=title,
+            message=message,
+            success=success,
+            parent=self._parent,
+            on_click=on_click,
+        )
+        toast.closed.connect(self._on_toast_closed)
+
+        self._active.append(toast)
+        self._reposition_all()
+
+        # Play sound
+        if sound:
+            self._play_sound(success)
+
+    def _on_toast_closed(self, toast: ToastNotification):
+        """Remove toast from active list and reposition remaining."""
+        if toast in self._active:
+            self._active.remove(toast)
+            self._reposition_all()
+
+    def _reposition_all(self):
+        """Position all active toasts stacked from bottom-right of the screen."""
+        screen = None
+        if self._parent and self._parent.isVisible():
+            screen = self._parent.screen()
+        if screen is None:
+            screen = QApplication.primaryScreen()
+        if screen is None:
+            return
+
+        # Use availableGeometry to respect the taskbar
+        geom = screen.availableGeometry()
+        margin = ToastNotification.MARGIN
+
+        # Calculate positions bottom-up
+        y_offset = margin
+        for toast in reversed(self._active):
+            toast.adjustSize()
+            th = toast.sizeHint().height()
+            x = geom.right() - ToastNotification.WIDTH - margin
+            y = geom.bottom() - th - y_offset
+
+            if toast.isVisible():
+                # Animate reposition
+                anim = QPropertyAnimation(toast, b"pos")
+                anim.setDuration(150)
+                anim.setEndValue(QPoint(x, y))
+                anim.setEasingCurve(QEasingCurve.Type.OutCubic)
+                anim.start()
+                # Keep reference so it doesn't get GC'd
+                toast._repos_anim = anim
+            else:
+                toast.show_at(x, y)
+
+            y_offset += th + 6  # 6px gap between toasts
+
+    def _setup_sounds(self):
+        """Prepare notification sounds using QSoundEffect."""
+        if not HAS_SOUND:
+            return
+
+        try:
+            self._sound_success = QSoundEffect()
+            self._sound_success.setVolume(0.3)
+
+            self._sound_error = QSoundEffect()
+            self._sound_error.setVolume(0.4)
+
+            # Use Windows system sounds if available
+            import os
+            win_media = os.path.join(os.environ.get("SystemRoot", r"C:\Windows"), "Media")
+
+            success_path = os.path.join(win_media, "chimes.wav")
+            error_path = os.path.join(win_media, "chord.wav")
+
+            if os.path.exists(success_path):
+                self._sound_success.setSource(QUrl.fromLocalFile(success_path))
+            else:
+                self._sound_success = None
+
+            if os.path.exists(error_path):
+                self._sound_error.setSource(QUrl.fromLocalFile(error_path))
+            else:
+                self._sound_error = None
+
+        except Exception as e:
+            logger.debug(f"Could not setup notification sounds: {e}")
+            self._sound_success = None
+            self._sound_error = None
+
+    def _play_sound(self, success: bool):
+        """Play the appropriate notification sound."""
+        try:
+            sound = self._sound_success if success else self._sound_error
+            if sound and sound.isLoaded():
+                sound.play()
+        except Exception:
+            pass

--- a/source/src/ui/dialogs/settings_dialog.py
+++ b/source/src/ui/dialogs/settings_dialog.py
@@ -17,6 +17,7 @@ from PyQt6.QtWidgets import (
     QTabWidget,
     QWidget,
     QComboBox,
+    QSpinBox,
 )
 from PyQt6.QtCore import Qt, pyqtSignal, QSettings
 from PyQt6.QtGui import QFont, QKeySequence
@@ -229,6 +230,71 @@ class SettingsDialog(QDialog):
         lang_layout.addWidget(hint_label)
 
         general_layout.addWidget(lang_group)
+
+        # Display section - Grid row limit
+        display_group = QGroupBox(
+            S.settings.section_display if hasattr(S.settings, 'section_display') else "DISPLAY"
+        )
+        display_group.setStyleSheet("""
+            QGroupBox {
+                font-weight: bold;
+                font-size: 11px;
+                color: #cccccc;
+                border: 1px solid #3e3e42;
+                border-radius: 4px;
+                margin-top: 12px;
+                padding-top: 20px;
+            }
+            QGroupBox::title {
+                subcontrol-origin: margin;
+                left: 10px;
+                padding: 0 6px;
+            }
+        """)
+        display_layout = QVBoxLayout(display_group)
+        display_layout.setSpacing(10)
+
+        # Row limit
+        row_limit_row = QHBoxLayout()
+        row_limit_label = QLabel(
+            S.settings.label_grid_row_limit if hasattr(S.settings, 'label_grid_row_limit')
+            else "Default grid display limit (rows):"
+        )
+        row_limit_label.setStyleSheet("color: #cccccc; font-size: 11px; font-weight: normal;")
+        row_limit_row.addWidget(row_limit_label)
+
+        self.grid_row_limit_spin = QSpinBox()
+        self.grid_row_limit_spin.setRange(10, 1000000)
+        self.grid_row_limit_spin.setSingleStep(100)
+        settings = QSettings("DataPyn", "DataPyn")
+        self.grid_row_limit_spin.setValue(int(settings.value("grid/display_row_limit", 100)))
+        self.grid_row_limit_spin.setFixedWidth(120)
+        self.grid_row_limit_spin.setStyleSheet("""
+            QSpinBox {
+                background-color: #2d2d30;
+                color: #cccccc;
+                border: 1px solid #3e3e42;
+                border-radius: 3px;
+                padding: 6px 10px;
+                font-size: 11px;
+            }
+            QSpinBox:hover {
+                border-color: #007acc;
+            }
+        """)
+        row_limit_row.addWidget(self.grid_row_limit_spin)
+        row_limit_row.addStretch()
+        display_layout.addLayout(row_limit_row)
+
+        # Hint
+        display_hint = QLabel(
+            S.settings.grid_row_limit_hint if hasattr(S.settings, 'grid_row_limit_hint')
+            else "Only affects display. Exports always include all data."
+        )
+        display_hint.setStyleSheet("color: #6e6e6e; font-size: 10px; font-style: italic; font-weight: normal;")
+        display_layout.addWidget(display_hint)
+
+        general_layout.addWidget(display_group)
         general_layout.addStretch()
 
         self.tabs.addTab(general_widget, S.settings.tab_general)
@@ -452,6 +518,9 @@ class SettingsDialog(QDialog):
         selected_lang = self.lang_combo.currentData()
         settings = QSettings("DataPyn", "DataPyn")
         settings.setValue("language", selected_lang)
+
+        # Save grid display row limit
+        settings.setValue("grid/display_row_limit", self.grid_row_limit_spin.value())
 
         # Save shortcuts
         for row in range(self.table.rowCount()):

--- a/source/src/ui/main_window.py
+++ b/source/src/ui/main_window.py
@@ -29,7 +29,7 @@ from PyQt6.QtWidgets import (
 )
 from PyQt6.QtCore import Qt, QTimer, QElapsedTimer, QThread, pyqtSignal, QObject, QSettings
 from PyQt6.QtGui import QAction, QIcon, QKeySequence, QFont, QColor
-from PyQt6.QtWidgets import QSystemTrayIcon
+from src.ui.components.toast_notification import ToastManager
 import sys
 import re
 import io
@@ -490,6 +490,9 @@ class MainWindow(DockingMainWindow):
 
         # Apply initial theme
         self._apply_app_theme()
+
+        # Setup in-app toast notifications
+        ToastManager.setup(self)
 
         # Timer to update status
         self.status_timer = QTimer()
@@ -2110,6 +2113,11 @@ class MainWindow(DockingMainWindow):
             new_widget.block_database_changed.connect(
                 lambda block, db_name: self._on_block_database_changed(block, db_name)
             )
+            new_widget.execution_finished.connect(
+                lambda title, msg, success, w=new_widget: self._on_execution_finished_notification(
+                    title, msg, success, w
+                )
+            )
 
             # Register widget
             self._session_widgets[session.session_id] = new_widget
@@ -3022,60 +3030,48 @@ class MainWindow(DockingMainWindow):
         self.session_tabs.set_tab_running(tab_index, is_running)
         return tab_index
 
+    def _on_execution_finished_notification(self, title: str, message: str, success: bool, widget):
+        """
+        Decide se deve enviar notificacao apos execucao terminar.
+
+        Regras:
+        - Nao notifica se o usuario esta focado na aba que executou
+          (janela ativa + aba visivel)
+        - Notifica se a janela esta minimizada ou se outra aba esta selecionada
+        """
+        tab_index = self.session_tabs.indexOf(widget)
+        current_tab = self.session_tabs.currentIndex()
+        is_active_window = self.isActiveWindow() and not self.isMinimized()
+
+        # Skip notification if user is looking at the executing tab
+        if is_active_window and current_tab == tab_index:
+            return
+
+        self._send_notification(title, message, success, tab_index)
+
     def _send_notification(self, title: str, message: str, success: bool = True, tab_index: int = None):
         """
-        Envia notificacao nativa (Windows/Linux/macOS) via QSystemTrayIcon.
+        Envia notificacao in-app (toast) no canto inferior direito.
 
         Args:
             title: Titulo da notificacao
             message: Mensagem
-            success: Se True, notificacao de sucesso
+            success: Se True, notificacao de sucesso (verde), senao erro (vermelho)
             tab_index: Indice da aba que originou (foca nela ao clicar)
         """
-        if not QSystemTrayIcon.isSystemTrayAvailable():
-            return
-
-        # Nao envia notificacao se a janela estiver em foco
-        if self.isActiveWindow():
-            return
-
         try:
-            # Criar tray icon sob demanda (reutiliza se ja existe)
-            if not hasattr(self, "_tray_icon") or self._tray_icon is None:
-                self._tray_icon = QSystemTrayIcon(self)
-                icon = self.windowIcon()
-                if icon.isNull():
-                    icon = QIcon.fromTheme("application-x-executable")
-                self._tray_icon.setIcon(icon)
-                self._tray_icon.show()
+            on_click = None
+            if tab_index is not None:
+                on_click = lambda idx=tab_index: self._focus_window_and_tab(idx)
 
-            # Capture tab_index for closure
-            self._notification_tab = tab_index
-
-            # Connect click only once
-            try:
-                self._tray_icon.activated.disconnect()
-            except TypeError:
-                pass
-            self._tray_icon.activated.connect(self._on_tray_activated)
-
-            # Tipo do icone na notificacao
-            icon_type = (
-                QSystemTrayIcon.MessageIcon.Information
-                if success
-                else QSystemTrayIcon.MessageIcon.Warning
+            ToastManager.notify(
+                title=title,
+                message=message,
+                success=success,
+                on_click=on_click,
             )
-
-            self._tray_icon.showMessage(f"DataPyn - {title}", message, icon_type, 5000)
-
-        except Exception:
-            pass
-
-    def _on_tray_activated(self, reason):
-        """Callback quando usuario clica na notificacao do tray"""
-        if reason == QSystemTrayIcon.ActivationReason.Trigger:
-            tab = getattr(self, "_notification_tab", None)
-            self._focus_window_and_tab(tab)
+        except Exception as e:
+            logger.error(f"Error sending toast notification: {e}")
 
     def _focus_window_and_tab(self, tab_index: int = None):
         """Brings window to front, focuses, and selects the tab that notified"""
@@ -4069,6 +4065,11 @@ class MainWindow(DockingMainWindow):
         )
         widget.block_database_changed.connect(
             lambda block, db_name: self._on_block_database_changed(block, db_name)
+        )
+        widget.execution_finished.connect(
+            lambda title, msg, success, w=widget: self._on_execution_finished_notification(
+                title, msg, success, w
+            )
         )
 
         # Conectar sinal de modificacao do editor para rastreamento por hash

--- a/tests/test_toast_notification.py
+++ b/tests/test_toast_notification.py
@@ -1,0 +1,383 @@
+"""
+Tests for the in-app toast notification system.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch, PropertyMock
+from PyQt6.QtCore import Qt, QPoint, QTimer
+from PyQt6.QtWidgets import QWidget, QMainWindow, QApplication
+
+from src.ui.components.toast_notification import (
+    ToastNotification,
+    ToastManager,
+    _manager,
+    HAS_SOUND,
+)
+import src.ui.components.toast_notification as toast_mod
+
+
+@pytest.fixture
+def parent_window(qtbot):
+    """A simple parent window for positioning toasts."""
+    win = QMainWindow()
+    win.resize(800, 600)
+    win.move(100, 100)
+    win.show()
+    qtbot.addWidget(win)
+    qtbot.waitExposed(win)
+    return win
+
+
+@pytest.fixture(autouse=True)
+def reset_manager():
+    """Reset the global ToastManager between tests."""
+    toast_mod._manager = None
+    yield
+    toast_mod._manager = None
+
+
+class TestToastNotification:
+    """Tests for the ToastNotification widget."""
+
+    def test_toast_creation_success(self, qtbot, parent_window):
+        """Toast created with success style."""
+        toast = ToastNotification(
+            title="SQL Query",
+            message="42 rows returned",
+            success=True,
+            parent=parent_window,
+        )
+        qtbot.addWidget(toast)
+        assert toast.width() == ToastNotification.WIDTH
+        assert toast._success is True
+
+    def test_toast_creation_error(self, qtbot, parent_window):
+        """Toast created with error style."""
+        toast = ToastNotification(
+            title="Error",
+            message="Syntax error near ';'",
+            success=False,
+            parent=parent_window,
+        )
+        qtbot.addWidget(toast)
+        assert toast._success is False
+
+    def test_toast_show_at(self, qtbot, parent_window):
+        """Toast shows and positions itself."""
+        toast = ToastNotification(
+            title="Test",
+            message="Hello",
+            success=True,
+            parent=parent_window,
+        )
+        qtbot.addWidget(toast)
+        toast.show_at(500, 400)
+        qtbot.wait(50)
+        assert toast.isVisible()
+
+    def test_toast_auto_dismiss(self, qtbot, parent_window):
+        """Toast auto-dismisses after duration."""
+        toast = ToastNotification(
+            title="Test",
+            message="Brief",
+            success=True,
+            duration=200,  # very short for test
+            parent=parent_window,
+        )
+        # Do NOT use qtbot.addWidget - toast calls deleteLater on dismiss
+        closed = []
+        toast.closed.connect(lambda t: closed.append(True))
+        toast.show_at(500, 400)
+
+        # Wait for dismiss + fade
+        qtbot.wait(200 + ToastNotification.FADE_DURATION + 300)
+        assert len(closed) == 1
+
+    def test_toast_click_callback(self, qtbot, parent_window):
+        """Clicking the toast fires the on_click callback."""
+        clicked = []
+        toast = ToastNotification(
+            title="Click me",
+            message="Please",
+            success=True,
+            parent=parent_window,
+            on_click=lambda: clicked.append(True),
+        )
+        qtbot.addWidget(toast)
+        toast.show_at(500, 400)
+        qtbot.wait(50)
+
+        # Simulate mouse press
+        qtbot.mouseClick(toast, Qt.MouseButton.LeftButton)
+        assert len(clicked) == 1
+
+    def test_toast_hover_pauses_dismiss(self, qtbot, parent_window):
+        """Hovering pauses the auto-dismiss timer."""
+        toast = ToastNotification(
+            title="Hover",
+            message="Test",
+            success=True,
+            duration=300,
+            parent=parent_window,
+        )
+        qtbot.addWidget(toast)
+        toast.show_at(500, 400)
+        qtbot.wait(50)
+
+        # Simulate enter event
+        from PyQt6.QtCore import QEvent
+        from PyQt6.QtGui import QEnterEvent
+
+        # The timer should have been running
+        assert toast._dismiss_timer.isActive()
+
+        # Manually call enterEvent
+        toast.enterEvent(None)
+        assert not toast._dismiss_timer.isActive()
+
+        # leaveEvent restarts
+        toast.leaveEvent(None)
+        assert toast._dismiss_timer.isActive()
+
+    def test_toast_closed_signal(self, qtbot, parent_window):
+        """Toast emits closed signal when dismissed."""
+        toast = ToastNotification(
+            title="Signal",
+            message="Test",
+            success=True,
+            duration=100,
+            parent=parent_window,
+        )
+        # Do NOT use qtbot.addWidget - toast calls deleteLater on dismiss
+        closed_toasts = []
+        toast.closed.connect(lambda t: closed_toasts.append(True))
+
+        toast.show_at(500, 400)
+        qtbot.wait(100 + ToastNotification.FADE_DURATION + 300)
+        assert len(closed_toasts) == 1
+
+    def test_toast_manual_dismiss(self, qtbot, parent_window):
+        """Calling _dismiss stops the timer and fades out."""
+        toast = ToastNotification(
+            title="Dismiss",
+            message="Now",
+            success=True,
+            duration=5000,
+            parent=parent_window,
+        )
+        qtbot.addWidget(toast)
+        toast.show_at(500, 400)
+        qtbot.wait(50)
+
+        toast._dismiss()
+        # Timer should be stopped
+        assert not toast._dismiss_timer.isActive()
+
+
+class TestToastManager:
+    """Tests for the ToastManager singleton."""
+
+    def test_setup_creates_manager(self, qtbot, parent_window):
+        """ToastManager.setup initializes the global manager."""
+        mgr = ToastManager.setup(parent_window)
+        assert toast_mod._manager is mgr
+        assert mgr._parent is parent_window
+
+    def test_notify_without_setup_does_nothing(self, qtbot):
+        """Calling notify before setup is a no-op (no crash)."""
+        toast_mod._manager = None
+        # Should NOT raise
+        ToastManager.notify("Title", "Message")
+
+    def test_notify_success(self, qtbot, parent_window):
+        """ToastManager.notify creates a success toast."""
+        mgr = ToastManager.setup(parent_window)
+        ToastManager.notify("Success", "All good", success=True, sound=False)
+        qtbot.wait(50)
+        assert len(mgr._active) == 1
+        assert mgr._active[0]._success is True
+
+    def test_notify_error(self, qtbot, parent_window):
+        """ToastManager.notify creates an error toast."""
+        mgr = ToastManager.setup(parent_window)
+        ToastManager.notify("Error", "Something broke", success=False, sound=False)
+        qtbot.wait(50)
+        assert len(mgr._active) == 1
+        assert mgr._active[0]._success is False
+
+    def test_multiple_notifications_stack(self, qtbot, parent_window):
+        """Multiple toasts are stacked vertically."""
+        mgr = ToastManager.setup(parent_window)
+        ToastManager.notify("First", "1", sound=False)
+        ToastManager.notify("Second", "2", sound=False)
+        ToastManager.notify("Third", "3", sound=False)
+        qtbot.wait(100)
+        assert len(mgr._active) == 3
+
+        # Each should be at a different y position
+        positions = [t.pos().y() for t in mgr._active]
+        # They should all be different (stacked)
+        assert len(set(positions)) == 3
+
+    def test_toast_removed_from_active_on_close(self, qtbot, parent_window):
+        """Toast is removed from active list when it closes."""
+        mgr = ToastManager.setup(parent_window)
+        ToastManager.notify("Brief", "Gone soon", success=True, sound=False)
+        qtbot.wait(50)
+        assert len(mgr._active) == 1
+
+        # Force close
+        toast = mgr._active[0]
+        toast._dismiss()
+        qtbot.wait(ToastNotification.FADE_DURATION + 200)
+        assert len(mgr._active) == 0
+
+    def test_on_click_callback_from_manager(self, qtbot, parent_window):
+        """on_click callback provided via manager is invoked on click."""
+        mgr = ToastManager.setup(parent_window)
+        clicks = []
+        ToastManager.notify(
+            "Clickable", "Click me",
+            on_click=lambda: clicks.append(1),
+            sound=False,
+        )
+        qtbot.wait(100)
+
+        assert len(mgr._active) == 1
+        toast = mgr._active[0]
+        qtbot.mouseClick(toast, Qt.MouseButton.LeftButton)
+        assert len(clicks) == 1
+
+    def test_reposition_on_dismiss(self, qtbot, parent_window):
+        """Remaining toasts are repositioned when one is dismissed."""
+        mgr = ToastManager.setup(parent_window)
+        ToastManager.notify("A", "a", sound=False)
+        ToastManager.notify("B", "b", sound=False)
+        qtbot.wait(100)
+
+        assert len(mgr._active) == 2
+        second_before_y = mgr._active[1].pos().y()
+
+        # Dismiss first toast
+        mgr._active[0]._dismiss()
+        qtbot.wait(ToastNotification.FADE_DURATION + 300)
+
+        # Only one remains
+        assert len(mgr._active) == 1
+
+    def test_sound_setup_no_crash(self, qtbot, parent_window):
+        """Sound setup doesn't crash even without media files."""
+        mgr = ToastManager.setup(parent_window)
+        # _setup_sounds was called in __init__, should not have crashed
+        # Play sound should be safe regardless
+        mgr._play_sound(True)
+        mgr._play_sound(False)
+
+
+class TestMainWindowIntegration:
+    """Integration tests: _send_notification uses ToastManager."""
+
+    def test_toast_is_top_level_window(self, qtbot, parent_window):
+        """Toast must be a top-level window (no parent) so it shows
+        even when the main window is minimized or unfocused."""
+        toast = ToastNotification(
+            title="Top-level",
+            message="Always visible",
+            success=True,
+            parent=parent_window,  # parent is passed but NOT used
+        )
+        qtbot.addWidget(toast)
+        # Must have no parent - top-level window
+        assert toast.parent() is None
+        # Must have WindowStaysOnTopHint and SplashScreen type
+        flags = toast.windowFlags()
+        assert flags & Qt.WindowType.WindowStaysOnTopHint
+        assert flags & Qt.WindowType.SplashScreen
+
+    def test_toast_visible_when_parent_minimized(self, qtbot, parent_window):
+        """Toast appears even if the main window is minimized."""
+        mgr = ToastManager.setup(parent_window)
+        parent_window.showMinimized()
+        qtbot.wait(100)
+
+        ToastManager.notify("Minimized", "Still shows!", sound=False)
+        qtbot.wait(100)
+
+        assert len(mgr._active) == 1
+        assert mgr._active[0].isVisible()
+
+    def test_toast_positions_on_screen(self, qtbot, parent_window):
+        """Toast positions at screen bottom-right, not inside parent."""
+        mgr = ToastManager.setup(parent_window)
+        ToastManager.notify("Screen pos", "Check position", sound=False)
+        qtbot.wait(500)  # wait for slide-in animation
+
+        toast = mgr._active[0]
+        screen = QApplication.primaryScreen()
+        geom = screen.availableGeometry()
+
+        # Toast x should be near the right edge of screen, not inside parent
+        toast_right = toast.pos().x() + toast.width()
+        assert toast_right <= geom.right() + 5  # allow small margin
+        # Toast bottom should be near screen bottom
+        toast_bottom = toast.pos().y() + toast.height()
+        assert toast_bottom <= geom.bottom() + 5
+
+    def test_send_notification_uses_toast(self, qtbot, parent_window, monkeypatch):
+        """_send_notification routes to ToastManager.notify."""
+        from src.ui.components.toast_notification import ToastManager
+
+        calls = []
+        original_notify = ToastManager.notify
+
+        @classmethod
+        def mock_notify(cls, **kwargs):
+            calls.append(kwargs)
+
+        monkeypatch.setattr(ToastManager, "notify", lambda **kwargs: calls.append(kwargs))
+
+        # Simulate what _send_notification does
+        title = "SQL Query"
+        message = "42 rows"
+        success = True
+        tab_index = 0
+
+        on_click = None
+        if tab_index is not None:
+            on_click = lambda idx=tab_index: None
+
+        ToastManager.notify(
+            title=title,
+            message=message,
+            success=success,
+            on_click=on_click,
+        )
+
+        assert len(calls) == 1
+        assert calls[0]["title"] == "SQL Query"
+        assert calls[0]["message"] == "42 rows"
+        assert calls[0]["success"] is True
+
+    def test_notification_always_fires(self, qtbot, parent_window):
+        """
+        The new implementation always fires notifications
+        (old one skipped when window was active).
+        """
+        mgr = ToastManager.setup(parent_window)
+
+        # Even with parent active/focused, notification should fire
+        parent_window.activateWindow()
+        qtbot.wait(50)
+
+        ToastManager.notify("Active Window", "Still shows!", sound=False)
+        qtbot.wait(50)
+
+        assert len(mgr._active) == 1
+
+    def test_notification_no_qsystemtrayicon_dependency(self):
+        """Main window no longer imports QSystemTrayIcon."""
+        import importlib
+        import src.ui.main_window as mw_mod
+
+        source = open(mw_mod.__file__, encoding="utf-8").read()
+        assert "QSystemTrayIcon" not in source


### PR DESCRIPTION
## Resumo

### Bug fix: resultados iam para aba errada
Quando o usuario trocava de aba durante a execucao, os resultados apareciam no grid da aba ativa (errada) em vez da aba que iniciou a execucao.

- `_get_own_panels()` busca paineis via `_session_panel_indices[session_id]`
- Todos os 6 metodos de delegacao usam paineis proprios com fallback para globais
- try/except defensivo para compatibilidade com testes/mocks

### Performance: grid fluido
- Header resize mode `Interactive` em vez de `ResizeToContents` (que iterava TODAS as linhas)
- `resizeColumnsToContents()` deferred via `QTimer.singleShot(0, ...)`
- Model recebe apenas `df.head(limit)`, nao o DataFrame completo

### Novo: limitador de linhas no grid
- `QSpinBox` no canto superior direito do toolbar (range 10-1M, step 100, default 100)
- Dados completos preservados em `current_df` para exportacoes (CSV, Excel, JSON, clipboard, table)
- Configuracao do limite padrao em Settings > General > Display
- Persistencia via `QSettings` key `grid/display_row_limit`
- Info label mostra "(showing X)" quando dados sao limitados

### Toast notifications
- Notificacao quando execucao termina e usuario nao esta na aba
- Agregada por fila (uma por aba, nao por bloco)
- Nao notifica se usuario esta focado na aba executando

### i18n
- `label_row_limit`, `tooltip_row_limit`, `showing_limited` (results)
- `section_display`, `label_grid_row_limit`, `grid_row_limit_hint` (settings)

### Testes
1148 passed, 0 failed, 2 skipped