### PR TITLE
fix: suporte correto a GO como separador de batches SQL Server

### DIFF
--- a/source/src/database/database_connector.py
+++ b/source/src/database/database_connector.py
@@ -327,15 +327,50 @@ class DatabaseConnector:
         else:
             raise ValueError(f"Unsupported database type: {db_type}")
 
+    @staticmethod
+    def _split_sql_batches(query: str) -> list:
+        """Split SQL script into batches separated by GO statements.
+
+        GO is a batch separator used by SQL Server tools (SSMS, sqlcmd).
+        It is NOT a T-SQL statement - pyodbc does not understand it.
+        Each batch must be executed separately.
+
+        Handles:
+        - GO on its own line (with optional whitespace)
+        - Case-insensitive (GO, go, Go)
+        - GO with repeat count (GO 5) - split but count ignored
+        - Windows (CRLF) and Unix (LF) line endings
+        - Does NOT match GO inside identifiers (ALGO, category)
+
+        Args:
+            query: Full SQL script potentially containing GO separators
+
+        Returns:
+            List of non-empty batch strings
+        """
+        import re
+
+        # Pattern: line that contains only GO (optionally followed by a number)
+        # \b ensures we don't match inside words like ALGO, category
+        # Must be on its own line (possibly with whitespace)
+        batches = re.split(
+            r"^\s*\bGO\b\s*(?:\d+)?\s*$",
+            query,
+            flags=re.MULTILINE | re.IGNORECASE,
+        )
+        # Strip whitespace and filter empty batches
+        return [b.strip() for b in batches if b.strip()]
+
     def execute_query(self, query: str) -> Union[pd.DataFrame, List[pd.DataFrame]]:
         """
         Execute SQL query and return DataFrame or list of DataFrames
 
         Supports multiple SQL commands. For queries with multiple SELECTs,
         returns a list of DataFrames (one for each SELECT).
+        For SQL Server, GO batch separators are handled correctly.
 
         Args:
-            query: SQL query to execute (can contain multiple commands)
+            query: SQL query to execute (can contain multiple commands and GO separators)
 
         Returns:
             Union[pd.DataFrame, List[pd.DataFrame]]: Query result or list of results
@@ -354,19 +389,19 @@ class DatabaseConnector:
                 # Update current database
                 self.connection_params["database"] = new_db
 
-            # Remove GO commands (SQL Server)
-            query_clean = query.replace("GO\n", "\n").replace("GO ", " ")
-
-            # For SQL Server, execute as batch and capture results
+            # For SQL Server, split on GO and execute each batch separately
             if self.db_type == "sqlserver":
-                return self._execute_mssql_batch(query_clean)
+                batches = self._split_sql_batches(query)
+                if not batches:
+                    return pd.DataFrame({"Result": ["No SQL commands to execute."]})
+                return self._execute_mssql_batches(batches)
 
             # For Databricks, use specific method with cursor access for cancellation
             if self.db_type == "databricks":
-                return self._execute_databricks_query(query_clean)
+                return self._execute_databricks_query(query)
 
             # For other databases, use legacy logic
-            return self._execute_generic_query(query_clean)
+            return self._execute_generic_query(query)
 
         except Exception as e:
             logger.error(f"Error executing query: {str(e)}")
@@ -410,149 +445,158 @@ class DatabaseConnector:
         except Exception as e:
             logger.warning(f"Error cancelling query: {e}")
 
-    def _execute_mssql_batch(self, query: str) -> pd.DataFrame:
-        """Execute SQL Server batch and return last result"""
+    def _execute_mssql_batches(self, batches: list) -> Union[pd.DataFrame, List[pd.DataFrame]]:
+        """Execute multiple SQL Server batches on the same connection.
+
+        Each batch (separated by GO in the original script) is executed
+        as a separate cursor.execute() call. The same raw connection is
+        reused so that temp tables (#tables), temp procedures, and session
+        state persist across batches.
+
+        Like SSMS, if a batch fails the remaining batches still execute.
+        Errors are collected and reported together at the end.
+
+        Args:
+            batches: List of SQL batch strings (already split on GO)
+
+        Returns:
+            Union[pd.DataFrame, List[pd.DataFrame]]: Results from all batches
+        """
         import pyodbc
 
         self._cancelled = False
-        last_error = None  # Declare BEFORE try to be accessible in finally
         cursor = None
         raw_conn = None
+        dataframes = []
+        errors = []
 
         try:
-            # Use raw pyodbc connection to access nextset()
             raw_conn = self.engine.raw_connection()
-            self._active_raw_conn = raw_conn  # Expose for cancellation
-            cursor = raw_conn.cursor()
-            self._active_cursor = cursor  # Expose cursor for cancellation
+            self._active_raw_conn = raw_conn
 
-            # CRITICAL: Ensure this pool connection is in the correct database.
-            # SQLAlchemy pool can return any connection, and a previous USE
-            # command may have been executed in another pool connection.
+            # Set database context once at the start
             current_db = self.connection_params.get("database", "")
             if current_db:
                 try:
-                    cursor.execute(f"USE [{current_db}]")
-                    # Consume possible result set from USE
-                    while cursor.nextset():
+                    init_cursor = raw_conn.cursor()
+                    init_cursor.execute(f"USE [{current_db}]")
+                    while init_cursor.nextset():
                         pass
+                    init_cursor.close()
                 except Exception as e:
                     logger.warning(f"Failed to set database [{current_db}]: {e}")
 
-            # Execute complete query
-            cursor.execute(query)
+            for batch_idx, batch in enumerate(batches, start=1):
+                if self._cancelled:
+                    logger.info("Execution cancelled between batches")
+                    break
 
-            # Capture all result sets
-            dataframes = []
-            result_set_count = 0
+                logger.info(f"Executing batch {batch_idx}/{len(batches)} ({len(batch)} chars)")
 
-            # Process all result sets in a loop
-            while True:
-                result_set_count += 1
+                cursor = raw_conn.cursor()
+                self._active_cursor = cursor
 
+                batch_error = None
                 try:
-                    if cursor.description:  # Has columns (is a SELECT)
-                        # Preserve original column case
-                        columns = [col[0] for col in cursor.description]
-                        rows = cursor.fetchall()
-                        logger.info(f"Result set {result_set_count}: {len(rows)} rows, columns: {columns}")
-                        if rows:
-                            df = pd.DataFrame.from_records(rows, columns=columns)
-                            dataframes.append(df)
-                    else:
-                        logger.info(f"Result set {result_set_count}: no description (doesn't return data)")
+                    cursor.execute(batch)
                 except pyodbc.Error as e:
-                    last_error = str(e)
-                    logger.error(f"PYODBC error in result set {result_set_count}: {last_error}")
-                    break  # Stop on error
-                except Exception as e:
-                    last_error = str(e)
-                    logger.error(f"GENERIC error in result set {result_set_count}: {last_error}")
-                    break  # Stop on error
+                    batch_error = f"Batch {batch_idx}/{len(batches)}: {str(e)}"
+                    logger.warning(batch_error)
+                    errors.append(batch_error)
+                    try:
+                        cursor.close()
+                    except Exception:
+                        pass
+                    cursor = None
+                    continue  # Continue to next batch (like SSMS)
 
-                # Try next result set
-                try:
-                    logger.info(f"Trying nextset after result set {result_set_count}...")
-                    has_next = cursor.nextset()
-                    logger.info(f"nextset returned: {has_next}")
-
-                    # CRITICAL: pyodbc DOESN'T throw exception in nextset() when there's an error!
-                    # The error stays in cursor.messages - we need to check BEFORE continuing
-                    if hasattr(cursor, "messages") and cursor.messages:
-                        logger.info(f"Messages after nextset: {cursor.messages}")
-                        for msg in cursor.messages:
-                            # Messages are tuples: (sql_state, message)
-                            if len(msg) >= 2:
-                                sql_state = msg[0]
-                                error_msg = msg[1]
-                                logger.info(f"SQL State: {sql_state}, Message: {error_msg}")
-
-                                # SQL error states start with class 01-99 (except 01 which is warning)
-                                # 42S02 = Invalid object name
-                                # 42000 = Syntax error
-                                if sql_state and sql_state != "01000":  # 01000 is informational
-                                    last_error = error_msg
-                                    logger.error(f"SQL ERROR detected in messages: {last_error}")
-                                    break
-
-                    if last_error:
-                        break  # Stop if error found in messages
-
-                    if not has_next:
+                # Collect all result sets from this batch
+                while True:
+                    try:
+                        if cursor.description:
+                            columns = [col[0] for col in cursor.description]
+                            rows = cursor.fetchall()
+                            if rows:
+                                df = pd.DataFrame.from_records(rows, columns=columns)
+                                dataframes.append(df)
+                    except pyodbc.Error as e:
+                        batch_error = f"Batch {batch_idx}/{len(batches)}: {str(e)}"
                         break
-                except pyodbc.Error as e:
-                    # Error trying next result set - could be SQL error
-                    last_error = str(e)
-                    logger.error(f"PYODBC error processing nextset: {last_error}")
-                    break
-                except Exception as e:
-                    last_error = str(e)
-                    logger.error(f"GENERIC error processing nextset: {last_error}")
-                    break
+                    except Exception as e:
+                        batch_error = f"Batch {batch_idx}/{len(batches)}: {str(e)}"
+                        break
 
-            # If there was an error, throw exception to report to user
-            if last_error:
-                raise Exception(last_error)
+                    try:
+                        has_next = cursor.nextset()
 
-            # Commit
+                        # Check cursor.messages for deferred errors
+                        if hasattr(cursor, "messages") and cursor.messages:
+                            for msg in cursor.messages:
+                                if len(msg) >= 2:
+                                    sql_state, error_msg = msg[0], msg[1]
+                                    if sql_state and sql_state != "01000":
+                                        batch_error = f"Batch {batch_idx}/{len(batches)}: {error_msg}"
+                                        break
+
+                        if batch_error:
+                            break
+                        if not has_next:
+                            break
+                    except pyodbc.Error as e:
+                        batch_error = f"Batch {batch_idx}/{len(batches)}: {str(e)}"
+                        break
+                    except Exception as e:
+                        batch_error = f"Batch {batch_idx}/{len(batches)}: {str(e)}"
+                        break
+
+                try:
+                    cursor.close()
+                except Exception:
+                    pass
+                cursor = None
+
+                if batch_error:
+                    logger.warning(batch_error)
+                    errors.append(batch_error)
+                    # Continue to next batch (like SSMS)
+
+            # Commit after all batches (even if some failed)
             raw_conn.commit()
 
-            logger.info(f"Total result sets: {result_set_count}, DataFrames captured: {len(dataframes)}")
+            logger.info(
+                f"Executed {len(batches)} batch(es): "
+                f"{len(dataframes)} result set(s), {len(errors)} error(s)."
+            )
 
-            # If captured multiple results, return list of DataFrames
+            # Build error summary if there were failures
+            if errors:
+                error_summary = "\n".join(errors)
+                if dataframes:
+                    # Append error info as an extra DataFrame so the user sees both results and errors
+                    error_df = pd.DataFrame({"Error": errors})
+                    dataframes.append(error_df)
+                else:
+                    raise Exception(error_summary)
+
             if len(dataframes) > 1:
-                logger.info(f"Returning list with {len(dataframes)} DataFrames")
                 return dataframes
-
-            # If captured single result, return directly
             if dataframes:
-                logger.info(f"Returning single DataFrame with {len(dataframes[0])} rows")
                 return dataframes[0]
 
-            # No results - return success message
-            rows_affected = cursor.rowcount
-            if rows_affected >= 0:
-                msg = f"Command executed successfully. {rows_affected} row(s) affected."
-            else:
-                msg = "Command executed successfully."
-
-            logger.info(msg)
-            return pd.DataFrame({"Result": [msg]})
+            return pd.DataFrame({"Result": ["Command(s) executed successfully."]})
 
         except Exception as e:
-            logger.error(f"Error executing SQL Server batch: {str(e)}")
-            raise  # Re-throw error for user to see
+            logger.error(f"Error executing SQL Server batches: {str(e)}")
+            raise
 
         finally:
-            self._active_raw_conn = None  # Clear reference
-            self._active_cursor = None  # Clear cursor reference
-            # Close cursor and connection
+            self._active_raw_conn = None
+            self._active_cursor = None
             if cursor:
                 try:
                     cursor.close()
                 except Exception:
                     pass
-
             if raw_conn:
                 try:
                     raw_conn.close()

--- a/tests/test_database_connector.py
+++ b/tests/test_database_connector.py
@@ -354,7 +354,7 @@ class TestUseDatabasePersistence:
         assert use_match.group(1) == "esim"
 
     def test_mssql_batch_sends_use_before_query(self):
-        """_execute_mssql_batch deve enviar USE antes da query"""
+        """_execute_mssql_batches deve enviar USE antes da query"""
         from database.database_connector import DatabaseConnector
 
         connector = DatabaseConnector()
@@ -367,20 +367,22 @@ class TestUseDatabasePersistence:
         mock_cursor.fetchall.return_value = [(1, "a")]
         mock_cursor.nextset.return_value = False
 
+        mock_init_cursor = MagicMock()
+        mock_init_cursor.nextset.return_value = False
+
         mock_raw_conn = MagicMock()
-        mock_raw_conn.cursor.return_value = mock_cursor
+        mock_raw_conn.cursor.side_effect = [mock_init_cursor, mock_cursor]
 
         mock_engine = MagicMock()
         mock_engine.raw_connection.return_value = mock_raw_conn
         connector.engine = mock_engine
 
-        connector._execute_mssql_batch("SELECT 1")
+        connector._execute_mssql_batches(["SELECT 1"])
 
-        # Deve ter executado USE [esim] antes da query principal
-        calls = mock_cursor.execute.call_args_list
-        assert len(calls) >= 2, f"Deveria ter chamado execute ao menos 2 vezes (USE + query), mas chamou {len(calls)}"
-        assert "USE [esim]" in calls[0][0][0]
-        assert "SELECT 1" in calls[1][0][0]
+        # init_cursor deve ter executado USE [esim]
+        mock_init_cursor.execute.assert_called_once_with("USE [esim]")
+        # batch cursor deve ter executado a query
+        mock_cursor.execute.assert_called_once_with("SELECT 1")
 
     @patch("database.database_connector.pyodbc.drivers", return_value=_MOCK_ODBC_DRIVERS)
     def test_checkout_event_registered_for_sqlserver(self, _mock_drivers):
@@ -403,3 +405,196 @@ class TestUseDatabasePersistence:
 
                 # Deve ter registrado evento "checkout" no pool
                 mock_event.listens_for.assert_called_once_with(mock_engine, "checkout")
+
+
+class TestSplitSqlBatches:
+    """Testes para split de batches SQL no separador GO"""
+
+    def _split(self, query):
+        from database.database_connector import DatabaseConnector
+        return DatabaseConnector._split_sql_batches(query)
+
+    def test_single_batch_no_go(self):
+        """Query sem GO deve retornar um unico batch"""
+        result = self._split("SELECT 1")
+        assert result == ["SELECT 1"]
+
+    def test_two_batches_separated_by_go(self):
+        """Duas queries separadas por GO"""
+        sql = "SELECT 1\nGO\nSELECT 2"
+        result = self._split(sql)
+        assert len(result) == 2
+        assert result[0] == "SELECT 1"
+        assert result[1] == "SELECT 2"
+
+    def test_go_case_insensitive(self):
+        """GO deve ser case-insensitive"""
+        sql = "SELECT 1\ngo\nSELECT 2\nGo\nSELECT 3"
+        result = self._split(sql)
+        assert len(result) == 3
+
+    def test_go_with_leading_whitespace(self):
+        """GO com espacos antes deve funcionar"""
+        sql = "SELECT 1\n   GO\nSELECT 2"
+        result = self._split(sql)
+        assert len(result) == 2
+
+    def test_go_with_trailing_whitespace(self):
+        """GO com espacos depois deve funcionar"""
+        sql = "SELECT 1\nGO   \nSELECT 2"
+        result = self._split(sql)
+        assert len(result) == 2
+
+    def test_go_with_repeat_count(self):
+        """GO N (repeat count) deve ser tratado como separador"""
+        sql = "INSERT INTO t VALUES(1)\nGO 5\nSELECT 1"
+        result = self._split(sql)
+        assert len(result) == 2
+
+    def test_go_does_not_match_inside_identifier(self):
+        """GO dentro de palavras como ALGO, category nao deve separar"""
+        sql = "SELECT ALGO FROM category WHERE gopher = 1"
+        result = self._split(sql)
+        assert len(result) == 1
+        assert "ALGO" in result[0]
+        assert "category" in result[0]
+        assert "gopher" in result[0]
+
+    def test_go_crlf_line_endings(self):
+        """GO com line endings Windows (CRLF) deve funcionar"""
+        sql = "SELECT 1\r\nGO\r\nSELECT 2"
+        result = self._split(sql)
+        assert len(result) == 2
+
+    def test_empty_batches_filtered(self):
+        """Batches vazios entre GOs consecutivos devem ser ignorados"""
+        sql = "SELECT 1\nGO\n\nGO\nSELECT 2"
+        result = self._split(sql)
+        assert len(result) == 2
+
+    def test_go_at_end_of_script(self):
+        """GO no final do script nao deve gerar batch vazio"""
+        sql = "SELECT 1\nGO"
+        result = self._split(sql)
+        assert len(result) == 1
+        assert result[0] == "SELECT 1"
+
+    def test_go_at_start_of_script(self):
+        """GO no inicio do script nao deve gerar batch vazio"""
+        sql = "GO\nSELECT 1"
+        result = self._split(sql)
+        assert len(result) == 1
+
+    def test_complex_tsql_script(self):
+        """Script T-SQL complexo com CREATE PROCEDURE entre GOs"""
+        sql = (
+            "USE Gecon;\n"
+            "GO\n"
+            "DECLARE @x INT = 1\n"
+            "SELECT @x\n"
+            "GO\n"
+            "CREATE PROCEDURE #MyProc AS SELECT 1\n"
+            "GO\n"
+            "EXEC #MyProc\n"
+            "GO\n"
+        )
+        result = self._split(sql)
+        assert len(result) == 4
+        assert "USE Gecon" in result[0]
+        assert "DECLARE @x" in result[1]
+        assert "CREATE PROCEDURE" in result[2]
+        assert "EXEC #MyProc" in result[3]
+
+    def test_go_not_in_string_literal(self):
+        """GO sozinho na linha sempre separa (mesmo conceito do SSMS)"""
+        # In SSMS, GO on its own line always separates regardless of context
+        sql = "SELECT 'some text'\nGO\nSELECT 2"
+        result = self._split(sql)
+        assert len(result) == 2
+
+
+class TestMssqlBatchesExecution:
+    """Testes para execucao de multiplos batches SQL Server"""
+
+    def test_multiple_batches_executed_sequentially(self):
+        """Cada batch deve ser executado em sequencia na mesma conexao"""
+        from database.database_connector import DatabaseConnector
+
+        connector = DatabaseConnector()
+        connector.db_type = "sqlserver"
+        connector.connection_params = {}
+
+        mock_cursor1 = MagicMock()
+        mock_cursor1.description = None
+        mock_cursor1.nextset.return_value = False
+
+        mock_cursor2 = MagicMock()
+        mock_cursor2.description = [("col1",)]
+        mock_cursor2.fetchall.return_value = [(42,)]
+        mock_cursor2.nextset.return_value = False
+
+        mock_raw_conn = MagicMock()
+        mock_raw_conn.cursor.side_effect = [mock_cursor1, mock_cursor2]
+
+        mock_engine = MagicMock()
+        mock_engine.raw_connection.return_value = mock_raw_conn
+        connector.engine = mock_engine
+
+        result = connector._execute_mssql_batches(["CREATE TABLE #t (id INT)", "SELECT * FROM #t"])
+
+        mock_cursor1.execute.assert_called_once_with("CREATE TABLE #t (id INT)")
+        mock_cursor2.execute.assert_called_once_with("SELECT * FROM #t")
+
+    def test_batch_error_continues_and_reports(self):
+        """Erro num batch deve continuar executando os demais (como SSMS)"""
+        import pyodbc
+        from database.database_connector import DatabaseConnector
+
+        connector = DatabaseConnector()
+        connector.db_type = "sqlserver"
+        connector.connection_params = {}
+
+        # First batch fails, second succeeds
+        mock_cursor_bad = MagicMock()
+        mock_cursor_bad.execute.side_effect = pyodbc.Error("42000", "Syntax error")
+
+        mock_cursor_ok = MagicMock()
+        mock_cursor_ok.description = [("col1",)]
+        mock_cursor_ok.fetchall.return_value = [(1,)]
+        mock_cursor_ok.nextset.return_value = False
+
+        mock_raw_conn = MagicMock()
+        mock_raw_conn.cursor.side_effect = [mock_cursor_bad, mock_cursor_ok]
+
+        mock_engine = MagicMock()
+        mock_engine.raw_connection.return_value = mock_raw_conn
+        connector.engine = mock_engine
+
+        # Should NOT raise - continues past the error
+        result = connector._execute_mssql_batches(["BAD SQL", "SELECT 1"])
+        # Second batch produced a result, plus error DataFrame appended
+        assert isinstance(result, list)
+        # At least one result DF and one error DF
+        assert len(result) >= 2
+
+    def test_all_batches_fail_raises_error(self):
+        """Se todos os batches falharem, deve levantar excecao"""
+        import pyodbc
+        from database.database_connector import DatabaseConnector
+
+        connector = DatabaseConnector()
+        connector.db_type = "sqlserver"
+        connector.connection_params = {}
+
+        mock_cursor = MagicMock()
+        mock_cursor.execute.side_effect = pyodbc.Error("42000", "Syntax error")
+
+        mock_raw_conn = MagicMock()
+        mock_raw_conn.cursor.return_value = mock_cursor
+
+        mock_engine = MagicMock()
+        mock_engine.raw_connection.return_value = mock_raw_conn
+        connector.engine = mock_engine
+
+        with pytest.raises(Exception, match="Batch 1/2"):
+            connector._execute_mssql_batches(["BAD SQL", "ALSO BAD"])


### PR DESCRIPTION
- Novo _split_sql_batches() com regex para separar batches no GO
- Cada batch executado separadamente na mesma conexao (temp tables persistem)
- Continua executando batches seguintes quando um falha (igual SSMS)
- Erros coletados e exibidos como DataFrame extra nos resultados
- Removido replace('GO\n') naive que quebrava scripts complexos
- 16 testes novos (split patterns + execucao multi-batch)