### PR TITLE
fix: retry automatico quando OAuth token do Databricks expira

### DIFF
--- a/source/src/database/database_connector.py
+++ b/source/src/database/database_connector.py
@@ -129,8 +129,28 @@ class DatabaseConnector:
                             pass  # Silence - USE in batch will catch error
 
             # Test connection
-            with self.engine.connect() as conn:
-                conn.execute(text("SELECT 1"))
+            try:
+                with self.engine.connect() as conn:
+                    conn.execute(text("SELECT 1"))
+            except KeyError as e:
+                # Databricks OAuth: cached refresh token expired/invalid.
+                # The SDK raises KeyError('access_token') when the server
+                # response to a token refresh lacks the expected field.
+                # Delete stale cache and retry to trigger fresh browser OAuth.
+                if db_type == "databricks" and "access_token" in str(e):
+                    logger.warning("Databricks OAuth token expired. Clearing cache and retrying...")
+                    cache_path = _get_oauth_token_cache_path(host)
+                    if cache_path.exists():
+                        cache_path.unlink()
+                        logger.info(f"Deleted stale OAuth cache: {cache_path}")
+                    self.engine.dispose()
+                    self.engine = create_engine(
+                        connection_string, pool_pre_ping=True, connect_args=connect_args
+                    )
+                    with self.engine.connect() as conn:
+                        conn.execute(text("SELECT 1"))
+                else:
+                    raise
 
             self.db_type = db_type
             self.connection_params = {"host": host, "port": port, "database": database, "username": username}

--- a/tests/test_database_connector.py
+++ b/tests/test_database_connector.py
@@ -598,3 +598,109 @@ class TestMssqlBatchesExecution:
 
         with pytest.raises(Exception, match="Batch 1/2"):
             connector._execute_mssql_batches(["BAD SQL", "ALSO BAD"])
+
+
+class TestDatabricksOAuthRetry:
+    """Testes para retry automatico quando OAuth token do Databricks expira"""
+
+    @patch("database.database_connector._get_oauth_token_cache_path")
+    @patch("database.database_connector.create_engine")
+    def test_retry_on_expired_oauth_token(self, mock_create_engine, mock_cache_path):
+        """Deve limpar cache e reconectar quando token OAuth expira"""
+        from database.database_connector import DatabaseConnector
+
+        # First engine raises KeyError('access_token') on connect,
+        # second engine succeeds
+        mock_conn_fail = MagicMock()
+        mock_conn_fail.__enter__ = MagicMock(side_effect=KeyError("access_token"))
+        mock_conn_fail.__exit__ = MagicMock(return_value=False)
+
+        mock_conn_ok = MagicMock()
+        mock_conn_ok.__enter__ = MagicMock(return_value=mock_conn_ok)
+        mock_conn_ok.__exit__ = MagicMock(return_value=False)
+
+        mock_engine_fail = MagicMock()
+        mock_engine_fail.connect.return_value = mock_conn_fail
+
+        mock_engine_ok = MagicMock()
+        mock_engine_ok.connect.return_value = mock_conn_ok
+
+        mock_create_engine.side_effect = [mock_engine_fail, mock_engine_ok]
+
+        # Mock cache path that exists
+        mock_path = MagicMock()
+        mock_path.exists.return_value = True
+        mock_cache_path.return_value = mock_path
+
+        connector = DatabaseConnector()
+        result = connector.connect(
+            "databricks", "my-workspace.databricks.com", 443, "",
+            username="", password="",
+            http_path="/sql/1.0/warehouses/abc"
+        )
+
+        assert result is True
+        # Cache file should have been deleted
+        mock_path.unlink.assert_called_once()
+        # Engine should have been created twice (original + retry)
+        assert mock_create_engine.call_count == 2
+        # First engine should have been disposed
+        mock_engine_fail.dispose.assert_called_once()
+
+    @patch("database.database_connector.create_engine")
+    def test_non_databricks_keyerror_propagates(self, mock_create_engine):
+        """KeyError que nao e de OAuth Databricks deve propagar normalmente"""
+        from database.database_connector import DatabaseConnector
+
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(side_effect=KeyError("something_else"))
+        mock_conn.__exit__ = MagicMock(return_value=False)
+
+        mock_engine = MagicMock()
+        mock_engine.connect.return_value = mock_conn
+        mock_create_engine.return_value = mock_engine
+
+        connector = DatabaseConnector()
+        with pytest.raises(KeyError, match="something_else"):
+            connector.connect(
+                "databricks", "host.databricks.com", 443, "",
+                username="", password="",
+                http_path="/sql/1.0/warehouses/abc"
+            )
+
+    @patch("database.database_connector._get_oauth_token_cache_path")
+    @patch("database.database_connector.create_engine")
+    def test_retry_works_even_without_cache_file(self, mock_create_engine, mock_cache_path):
+        """Retry deve funcionar mesmo se arquivo de cache nao existir"""
+        from database.database_connector import DatabaseConnector
+
+        mock_conn_fail = MagicMock()
+        mock_conn_fail.__enter__ = MagicMock(side_effect=KeyError("access_token"))
+        mock_conn_fail.__exit__ = MagicMock(return_value=False)
+
+        mock_conn_ok = MagicMock()
+        mock_conn_ok.__enter__ = MagicMock(return_value=mock_conn_ok)
+        mock_conn_ok.__exit__ = MagicMock(return_value=False)
+
+        mock_engine_fail = MagicMock()
+        mock_engine_fail.connect.return_value = mock_conn_fail
+
+        mock_engine_ok = MagicMock()
+        mock_engine_ok.connect.return_value = mock_conn_ok
+
+        mock_create_engine.side_effect = [mock_engine_fail, mock_engine_ok]
+
+        # Cache file does NOT exist
+        mock_path = MagicMock()
+        mock_path.exists.return_value = False
+        mock_cache_path.return_value = mock_path
+
+        connector = DatabaseConnector()
+        result = connector.connect(
+            "databricks", "my-workspace.databricks.com", 443, "",
+            username="", password="",
+            http_path="/sql/1.0/warehouses/abc"
+        )
+
+        assert result is True
+        mock_path.unlink.assert_not_called()


### PR DESCRIPTION
## Problema

Ao conectar no Databricks via OAuth, quando o refresh token cacheado expira o SDK lanca `KeyError: 'access_token'` e a conexao falha sem possibilidade de recuperacao.

## Solucao

- O `connect()` agora captura `KeyError('access_token')` para conexoes Databricks
- Deleta o arquivo de cache OAuth obsoleto (`~/.datapyn/oauth_cache/databricks_*.json`)
- Dispose do engine antigo e recria um novo
- Retry automatico que forca novo fluxo OAuth via browser

Tambem inclui os commits anteriores desta branch:
- Suporte a separador `GO` em scripts SQL (batch splitting)
- Continue-on-error ao executar batches (comportamento SSMS)

## Testes

- 3 novos testes em `TestDatabricksOAuthRetry`
- 40 testes de database connector passando