### PR TITLE
feat: toggle ativo/inativo nos blocos de codigo

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -40,7 +40,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-          cache: 'pip'
 
       - name: Setup | Install uv
         uses: astral-sh/setup-uv@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-          cache: 'pip'
 
       - name: Setup | Install uv
         uses: astral-sh/setup-uv@v3
@@ -138,7 +137,15 @@ jobs:
           Write-Host "MSI version: $version (from $rawVersion)"
           
           $sourceDir = "dist\DataPyn"
-          $wixBin = "${env:WIX}bin\"
+
+          # Find WiX bin directory (env:WIX on older runners, or well-known path)
+          $wixBin = if ($env:WIX) { "${env:WIX}bin\" } else {
+            $found = Get-ChildItem -Path "C:\Program Files (x86)\WiX*" -Directory -ErrorAction SilentlyContinue |
+                     Sort-Object Name -Descending | Select-Object -First 1
+            if ($found) { "$($found.FullName)\bin\" }
+            else { throw "WiX Toolset not found. Set WIX env var or install WiX 3.x." }
+          }
+          Write-Host "WiX bin: $wixBin"
 
           # Harvest all files from PyInstaller output
           # -sreg: suppress SelfReg warnings (not applicable to PyInstaller output)

--- a/source/src/editors/block_editor.py
+++ b/source/src/editors/block_editor.py
@@ -285,7 +285,7 @@ class BlockEditor(QWidget):
 
         for index, block in enumerate(self._blocks):
             code = block.get_code().strip()
-            if code:
+            if code and block.is_active():
                 # Tuple: (language, code, block, block_name, connection_name, database_name)
                 queue.append((block.get_language(), code, block, block.get_block_name(), block.get_connection_name(), block.get_database_name()))
                 self._execution_queue_blocks.append(block)

--- a/source/src/editors/code_block.py
+++ b/source/src/editors/code_block.py
@@ -18,7 +18,7 @@ from PyQt6.QtWidgets import (
     QLineEdit,
     QMenu,
 )
-from PyQt6.QtCore import pyqtSignal, Qt, QMimeData, QPoint, QTimer
+from PyQt6.QtCore import pyqtSignal, Qt, QMimeData, QPoint, QTimer, QSize
 from PyQt6.QtGui import QDrag, QPixmap, QPainter, QColor
 import qtawesome as qta
 
@@ -425,6 +425,7 @@ class CodeBlock(QFrame):
         self._is_copilot_editing = False  # Copilot is editing this block
         self._copilot_editing_timer = None  # Auto-dismiss timer
         self._is_maximized = False  # Block is in maximized/focus mode
+        self._is_active = True  # Block is active (included in execute all)
 
         self._setup_ui()
         self._connect_signals()
@@ -631,6 +632,17 @@ class CodeBlock(QFrame):
         self.db_panel.setMinimumWidth(80)
         self.db_panel.setMaximumWidth(180)
         control_layout.addWidget(self.db_panel)
+
+        # Active toggle switch
+        self.active_toggle = QPushButton()
+        self.active_toggle.setCheckable(True)
+        self.active_toggle.setChecked(True)
+        self.active_toggle.setFixedSize(36, 20)
+        self.active_toggle.setToolTip(S.block.tooltip_active)
+        self.active_toggle.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._update_active_toggle_style()
+        self.active_toggle.toggled.connect(self._on_active_toggled)
+        control_layout.addWidget(self.active_toggle)
 
         # Block name field (becomes dataframe variable name for SQL)
         self.name_input = QLineEdit()
@@ -1036,7 +1048,64 @@ class CodeBlock(QFrame):
                 }
             """)
 
+    def _update_active_toggle_style(self):
+        from src.design_system.tokens import get_colors
+        colors = get_colors()
+        if self._is_active:
+            self.active_toggle.setStyleSheet(f"""
+                QPushButton {{
+                    background: {colors.interactive_primary};
+                    border: none;
+                    border-radius: 10px;
+                }}
+                QPushButton::indicator {{ width: 0; height: 0; }}
+            """)
+            self.active_toggle.setIcon(qta.icon("mdi.circle", color="white", scale_factor=0.6))
+            self.active_toggle.setIconSize(QSize(16, 16))
+            self.active_toggle.setLayoutDirection(Qt.LayoutDirection.RightToLeft)
+        else:
+            self.active_toggle.setStyleSheet(f"""
+                QPushButton {{
+                    background: {colors.bg_tertiary};
+                    border: 1px solid {colors.border_default};
+                    border-radius: 10px;
+                }}
+                QPushButton::indicator {{ width: 0; height: 0; }}
+            """)
+            self.active_toggle.setIcon(qta.icon("mdi.circle", color=colors.text_tertiary, scale_factor=0.6))
+            self.active_toggle.setIconSize(QSize(16, 16))
+            self.active_toggle.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
+
+    def _on_active_toggled(self, checked: bool):
+        self._is_active = checked
+        self._update_active_toggle_style()
+        self._update_inactive_visual()
+
+    def _update_inactive_visual(self):
+        opacity = 1.0 if self._is_active else 0.45
+        self.editor_container.setEnabled(self._is_active)
+        # Dim the editor when inactive
+        effect = self.editor_container.graphicsEffect()
+        if not self._is_active:
+            from PyQt6.QtWidgets import QGraphicsOpacityEffect
+            opacity_effect = QGraphicsOpacityEffect(self.editor_container)
+            opacity_effect.setOpacity(0.45)
+            self.editor_container.setGraphicsEffect(opacity_effect)
+        else:
+            self.editor_container.setGraphicsEffect(None)
+
     # === Public API ===
+
+    def is_active(self) -> bool:
+        """Return whether this block is active (included in execute all)"""
+        return self._is_active
+
+    def set_active(self, active: bool):
+        """Set active state"""
+        self._is_active = active
+        self.active_toggle.setChecked(active)
+        self._update_active_toggle_style()
+        self._update_inactive_visual()
 
     def get_language(self) -> str:
         return self.lang_combo.currentData()
@@ -1307,6 +1376,7 @@ class CodeBlock(QFrame):
             "code": self.get_code(),
             "height": self.editor_container.height(),
             "block_name": self.get_block_name(),
+            "is_active": self._is_active,
         }
         if self._connection_name:
             data["connection_name"] = self._connection_name
@@ -1338,6 +1408,9 @@ class CodeBlock(QFrame):
         # Restore custom database
         if "database_name" in data and data["database_name"]:
             block.set_database_name(data["database_name"])
+        # Restore active state
+        if "is_active" in data:
+            block.set_active(data["is_active"])
         return block
 
     # === Drag ===

--- a/source/src/language/en-US.json
+++ b/source/src/language/en-US.json
@@ -426,7 +426,8 @@
     "status_cancelled": "Cancelled",
     "status_error": "Error",
     "drag_label": "[{lang}] Block",
-    "copilot_editing": "Copilot editing..."
+    "copilot_editing": "Copilot editing...",
+    "tooltip_active": "Enable/disable block (inactive blocks are skipped on execute all)"
   },
 
   "find_replace": {

--- a/source/src/language/pt-BR.json
+++ b/source/src/language/pt-BR.json
@@ -428,7 +428,8 @@
     "status_cancelled": "Cancelado",
     "status_error": "Erro",
     "drag_label": "[{lang}] Bloco",
-    "copilot_editing": "Copilot editando..."
+    "copilot_editing": "Copilot editando...",
+    "tooltip_active": "Ativar/desativar bloco (blocos inativos sao pulados ao executar todos)"
   },
 
   "find_replace": {

--- a/tests/test_block_editor.py
+++ b/tests/test_block_editor.py
@@ -1194,3 +1194,126 @@ class TestBlockMaximize:
         blocks = editor.get_blocks()
         for i, original_code in enumerate(initial_blocks):
             assert blocks[i].get_code() == original_code
+
+
+class TestBlockActiveToggle:
+    """Testes do toggle ativo/inativo nos blocos"""
+
+    @pytest.fixture
+    def theme_manager(self):
+        return ThemeManager()
+
+    @pytest.fixture
+    def block(self, theme_manager, qtbot):
+        block = CodeBlock(theme_manager=theme_manager)
+        qtbot.addWidget(block)
+        return block
+
+    def test_block_active_by_default(self, block):
+        """Bloco deve ser ativo por padrao"""
+        assert block.is_active() is True
+        assert block.active_toggle.isChecked() is True
+
+    def test_set_active_false(self, block):
+        """Deve desativar o bloco"""
+        block.set_active(False)
+        assert block.is_active() is False
+        assert block.active_toggle.isChecked() is False
+
+    def test_set_active_true(self, block):
+        """Deve reativar o bloco"""
+        block.set_active(False)
+        block.set_active(True)
+        assert block.is_active() is True
+        assert block.active_toggle.isChecked() is True
+
+    def test_toggle_click_changes_state(self, block):
+        """Clicar no toggle deve mudar o estado"""
+        block.active_toggle.setChecked(False)
+        assert block.is_active() is False
+        block.active_toggle.setChecked(True)
+        assert block.is_active() is True
+
+    def test_inactive_block_editor_disabled(self, block):
+        """Editor deve ficar desabilitado quando bloco inativo"""
+        block.set_active(False)
+        assert block.editor_container.isEnabled() is False
+        block.set_active(True)
+        assert block.editor_container.isEnabled() is True
+
+    def test_to_dict_saves_active_state(self, block):
+        """to_dict deve salvar estado ativo"""
+        block.set_active(False)
+        data = block.to_dict()
+        assert data["is_active"] is False
+
+        block.set_active(True)
+        data = block.to_dict()
+        assert data["is_active"] is True
+
+    def test_from_dict_restores_active_state(self, theme_manager, qtbot):
+        """from_dict deve restaurar estado inativo"""
+        data = {"language": "sql", "code": "SELECT 1", "is_active": False}
+        block = CodeBlock.from_dict(data, theme_manager)
+        qtbot.addWidget(block)
+        assert block.is_active() is False
+
+    def test_from_dict_defaults_active_true(self, theme_manager, qtbot):
+        """from_dict sem is_active deve manter bloco ativo (compatibilidade)"""
+        data = {"language": "sql", "code": "SELECT 1"}
+        block = CodeBlock.from_dict(data, theme_manager)
+        qtbot.addWidget(block)
+        assert block.is_active() is True
+
+    @pytest.fixture
+    def _no_focus_editor(self, monkeypatch):
+        """Prevent QScintilla from grabbing focus (avoids test hang)"""
+        monkeypatch.setattr(CodeBlock, "focus_editor", lambda self: None)
+
+    @pytest.fixture
+    def editor(self, qtbot, _no_focus_editor):
+        theme = ThemeManager()
+        editor = BlockEditor(theme_manager=theme)
+        qtbot.addWidget(editor)
+        return editor
+
+    def test_execute_all_skips_inactive(self, editor, qtbot):
+        """Execute all deve pular blocos inativos"""
+        editor.add_block("sql")
+        editor.add_block("sql")
+        editor.add_block("sql")
+
+        blocks = editor.get_blocks()
+        blocks[0].set_code("SELECT 1")
+        blocks[1].set_code("SELECT 2")
+        blocks[2].set_code("SELECT 3")
+
+        # Desativar o bloco do meio
+        blocks[1].set_active(False)
+
+        # Capturar a queue emitida
+        emitted_queue = []
+        editor.execute_queue.connect(lambda q: emitted_queue.extend(q))
+        editor.execute_all_blocks()
+
+        # Deve ter apenas 2 blocos na queue (0 e 2)
+        assert len(emitted_queue) == 2
+        assert emitted_queue[0][1] == "SELECT 1"  # code of first block
+        assert emitted_queue[1][1] == "SELECT 3"  # code of third block
+
+    def test_execute_all_skips_all_inactive(self, editor, qtbot):
+        """Se todos os blocos estao inativos, nada deve ser executado"""
+        editor.add_block("sql")
+        editor.add_block("sql")
+
+        blocks = editor.get_blocks()
+        blocks[0].set_code("SELECT 1")
+        blocks[1].set_code("SELECT 2")
+        blocks[0].set_active(False)
+        blocks[1].set_active(False)
+
+        emitted_queue = []
+        editor.execute_queue.connect(lambda q: emitted_queue.extend(q))
+        editor.execute_all_blocks()
+
+        assert len(emitted_queue) == 0


### PR DESCRIPTION
## Funcionalidade

Adiciona um switch (toggle) no header de cada bloco de codigo para ativar/desativar o bloco.

### Comportamento

- **Bloco ativo** (padrao): toggle azul, editor funciona normalmente
- **Bloco inativo**: toggle cinza, editor com opacidade reduzida (45%) e desabilitado
- **Executar todos**: blocos inativos sao automaticamente pulados

### Persistencia

O estado ativo/inativo e salvo e restaurado ao abrir/fechar sessoes. Compativel com arquivos antigos (blocos sem o campo `is_active` sao tratados como ativos).

### Arquivos alterados

- `source/src/editors/code_block.py` — toggle switch, visual feedback, getter/setter, serialization
- `source/src/editors/block_editor.py` — `execute_all_blocks()` pula blocos inativos
- `source/src/language/pt-BR.json` / `en-US.json` — chave `tooltip_active`
- `tests/test_block_editor.py` — 10 novos testes em `TestBlockActiveToggle`

### Testes

194 testes de bloco passando