### PR TITLE
feat: run timer, DELIMITER-aware SQL split, OE improvements, configurable shortcuts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,4 +10,5 @@ Sempre siga as instrucoes abaixo ao gerar codigo:
 - NUNCA use emojis em codigo, comentarios, commits ou documentacao.
 - A THREAD PRINCIPAL (UI) NUNCA PODE TRAVAR! Operacoes que podem demorar (conexoes de banco, I/O, rede) DEVEM rodar em QThread/background worker.
 - TODO TEXTO DA UI DEVE vir dos arquivos de traducao (S.xxx de src.language). NUNCA use strings hardcoded em portugues ou ingles na UI. Adicione chaves em source/src/language/pt-BR.json e source/src/language/en-US.json.
+- TODO ATALHO DE TECLADO DEVE SER CONFIGURAVEL! NUNCA use atalhos hardcoded (setShortcut com string literal, key checks diretos em keyPressEvent). Use SEMPRE o ShortcutManager (src.core.shortcut_manager). Registre o action ID em DEFAULT_SHORTCUTS, leia via get_shortcut(), e adicione a descricao em settings_dialog.py._load_shortcuts().
                               

--- a/source/src/core/shortcut_manager.py
+++ b/source/src/core/shortcut_manager.py
@@ -20,7 +20,7 @@ class ShortcutManager:
         "execute_sql": "F5",
         "execute_all": "Ctrl+F5",
         "execute_block_advance": "Shift+Return",
-        "clear_results": "Ctrl+Shift+C",
+        "clear_results": "Ctrl+Shift+L",
         # Arquivo
         "open_file": "Ctrl+O",
         "save_file": "Ctrl+S",
@@ -44,6 +44,12 @@ class ShortcutManager:
         "reload_schema": "Ctrl+Shift+T",
         # Ferramentas
         "settings": "Ctrl+,",
+        # Results grid
+        "copy_with_headers": "Ctrl+Shift+C",
+        # View / Layout
+        "exit_app": "Ctrl+Q",
+        "restore_view": "Ctrl+Shift+R",
+        "reset_layout": "Ctrl+Shift+Alt+R",
         # Editor (atalhos internos do QScintilla)
         "editor_newline": "",
         "editor_duplicate_line": "Ctrl+D",

--- a/source/src/database/database_connector.py
+++ b/source/src/database/database_connector.py
@@ -714,10 +714,140 @@ class DatabaseConnector:
             clean.startswith("EXPLAIN")
         )
 
+    @staticmethod
+    def _split_sql_statements(query: str) -> list:
+        """Split SQL script into individual statements, handling DELIMITER.
+
+        MySQL's DELIMITER directive is a client-side command that changes
+        the statement terminator. The MySQL server does NOT understand it.
+        This parser handles DELIMITER changes so that stored procedures,
+        functions, and triggers with semicolons in their body are sent
+        as a single statement to the server.
+
+        Handles:
+        - DELIMITER changes (e.g., DELIMITER $$ ... DELIMITER ;)
+        - String literals (single and double quotes) - delimiters inside
+          strings are ignored
+        - Single-line comments (-- and #)
+        - Multi-line comments (/* ... */)
+        - Escaped quotes inside strings
+
+        Args:
+            query: Full SQL script, possibly containing DELIMITER directives
+
+        Returns:
+            List of non-empty SQL statements (without DELIMITER lines)
+        """
+        import re
+
+        statements = []
+        delimiter = ";"
+        current = []
+        i = 0
+        text = query
+
+        while i < len(text):
+            c = text[i]
+
+            # -- single-line comment
+            if c == "-" and i + 1 < len(text) and text[i + 1] == "-":
+                end = text.find("\n", i)
+                if end == -1:
+                    current.append(text[i:])
+                    i = len(text)
+                else:
+                    current.append(text[i : end + 1])
+                    i = end + 1
+                continue
+
+            # # single-line comment (MySQL specific)
+            if c == "#":
+                end = text.find("\n", i)
+                if end == -1:
+                    current.append(text[i:])
+                    i = len(text)
+                else:
+                    current.append(text[i : end + 1])
+                    i = end + 1
+                continue
+
+            # /* multi-line comment */
+            if c == "/" and i + 1 < len(text) and text[i + 1] == "*":
+                end = text.find("*/", i + 2)
+                if end == -1:
+                    current.append(text[i:])
+                    i = len(text)
+                else:
+                    current.append(text[i : end + 2])
+                    i = end + 2
+                continue
+
+            # String literals (single or double quotes)
+            if c in ("'", '"'):
+                quote = c
+                j = i + 1
+                while j < len(text):
+                    if text[j] == "\\" :
+                        j += 2  # skip escaped char
+                        continue
+                    if text[j] == quote:
+                        if j + 1 < len(text) and text[j + 1] == quote:
+                            j += 2  # escaped quote ('')
+                            continue
+                        break
+                    j += 1
+                current.append(text[i : j + 1])
+                i = j + 1
+                continue
+
+            # Check for DELIMITER directive at start of line
+            if c in ("D", "d"):
+                # Look backwards to verify we're at start of line
+                # (handle both \n and \r\n line endings)
+                at_line_start = (
+                    i == 0
+                    or text[i - 1] == "\n"
+                    or (text[i - 1] == "\r" and (i < 2 or text[i - 2] == "\n"))
+                )
+                if at_line_start:
+                    match = re.match(
+                        r"DELIMITER\s+(\S+?)\s*;?\s*(?:\r?\n|$)",
+                        text[i:],
+                        re.IGNORECASE,
+                    )
+                    if match:
+                        # Flush any accumulated content as a statement
+                        stmt = "".join(current).strip()
+                        if stmt:
+                            statements.append(stmt)
+                        current = []
+                        delimiter = match.group(1)
+                        i += match.end()
+                        continue
+
+            # Check for current delimiter
+            if text[i : i + len(delimiter)] == delimiter:
+                stmt = "".join(current).strip()
+                if stmt:
+                    statements.append(stmt)
+                current = []
+                i += len(delimiter)
+                continue
+
+            current.append(c)
+            i += 1
+
+        # Flush remaining content
+        stmt = "".join(current).strip()
+        if stmt:
+            statements.append(stmt)
+
+        return statements
+
     def _execute_generic_query(self, query: str) -> pd.DataFrame:
         """Execute generic query for non-MSSQL databases"""
-        # Split by semicolon to detect multiple commands
-        commands = [cmd.strip() for cmd in query.split(";") if cmd.strip()]
+        # Split statements with DELIMITER-awareness
+        commands = self._split_sql_statements(query)
 
         if len(commands) > 1:
             # Multiple commands - execute all and capture SELECT results
@@ -754,17 +884,18 @@ class DatabaseConnector:
             msg = "Commands executed successfully."
             logger.info(msg)
             return pd.DataFrame({"Result": [msg]})
-        else:
-            # Single command - detect query type
-            if self._is_select_query(query):
+        elif len(commands) == 1:
+            # Single command - use the cleaned statement (DELIMITER stripped)
+            cmd = commands[0]
+            if self._is_select_query(cmd):
                 # SELECT query - use read_sql and let errors propagate
-                df = pd.read_sql(query, self.engine)
+                df = pd.read_sql(cmd, self.engine)
                 logger.info(f"Query executed successfully. Rows returned: {len(df)}")
                 return df
             else:
                 # Non-SELECT - execute as statement
                 with self.engine.connect() as conn:
-                    result = conn.execute(text(query))
+                    result = conn.execute(text(cmd))
                     conn.commit()
                     rows_affected = result.rowcount
 
@@ -775,6 +906,9 @@ class DatabaseConnector:
 
                     logger.info(msg)
                     return pd.DataFrame({"Result": [msg]})
+        else:
+            # No commands (empty input or only DELIMITER directives)
+            return pd.DataFrame({"Result": ["No SQL commands to execute."]})
 
     def execute_statement(self, statement: str) -> int:
         """

--- a/source/src/editors/block_editor.py
+++ b/source/src/editors/block_editor.py
@@ -15,7 +15,7 @@ from PyQt6.QtWidgets import (
     QSpacerItem,
 )
 from PyQt6.QtCore import pyqtSignal, Qt, QTimer, QUrl
-from PyQt6.QtGui import QKeyEvent, QDragEnterEvent, QDropEvent
+from PyQt6.QtGui import QKeyEvent, QDragEnterEvent, QDropEvent, QKeySequence
 from typing import List, Optional
 import os
 import qtawesome as qta
@@ -195,14 +195,24 @@ class BlockEditor(QWidget):
         self.blocks_layout.addWidget(self.add_button_container)
 
     def keyPressEvent(self, event: QKeyEvent):
-        """Intercept keys for execution shortcuts"""
-        # F5 - Run (focused block selection, or whole block, or all)
-        if event.key() == Qt.Key.Key_F5 and event.modifiers() == Qt.KeyboardModifier.NoModifier:
+        """Intercept keys for execution shortcuts (reads from ShortcutManager)"""
+        from src.core.shortcut_manager import ShortcutManager
+        sm = ShortcutManager()
+
+        # Build QKeySequence from event (PyQt6 enums need .value for int conversion)
+        modifiers = event.modifiers()
+        mod_val = modifiers.value if hasattr(modifiers, 'value') else int(modifiers)
+        key_seq = QKeySequence(mod_val | event.key())
+
+        # Execute SQL (default F5)
+        exec_key = sm.get_shortcut("execute_sql")
+        if exec_key and key_seq.matches(QKeySequence(exec_key)) == QKeySequence.SequenceMatch.ExactMatch:
             self._execute_smart()
             return
 
-        # Ctrl+Enter - Run all blocks
-        if event.key() == Qt.Key.Key_Return and event.modifiers() == Qt.KeyboardModifier.ControlModifier:
+        # Execute All (default Ctrl+F5 / Ctrl+Enter)
+        exec_all_key = sm.get_shortcut("execute_all")
+        if exec_all_key and key_seq.matches(QKeySequence(exec_all_key)) == QKeySequence.SequenceMatch.ExactMatch:
             self.execute_all_blocks()
             return
 

--- a/source/src/language/en-US.json
+++ b/source/src/language/en-US.json
@@ -42,7 +42,13 @@
   "toolbar": {
     "new_tab": " New Tab",
     "connection": " Connection",
-    "run": " Run (F5)"
+    "run": " Run (F5)",
+    "run_timer": "Periodic execution",
+    "run_timer_stop": "Stop periodic execution",
+    "run_timer_running": "Repeating {seconds}s after each execution",
+    "run_timer_title": "Periodic Execution",
+    "run_timer_label": "Wait X seconds after completion and run again:",
+    "run_timer_start": "Start"
   },
 
   "dock": {
@@ -189,6 +195,7 @@
     "python": "Python",
     "cross_syntax": "Cross-Syntax",
     "complete_rows": "Complete! {rows} rows returned",
+    "complete_blocks_rows": "Complete! {blocks} blocks executed - {rows} rows returned",
     "complete_queries": "Complete! {count} queries executed",
     "chart_data": "Chart + data generated!",
     "result_displayed": "Result displayed!",
@@ -308,7 +315,27 @@
     "showing_limited": " (showing {showing})",
     "exporting": "Exporting...",
     "export_success": "Export complete!",
-    "export_failed": "Export failed"
+    "export_failed": "Export failed",
+    "ctx_copy": "Copy",
+    "ctx_copy_with_headers": "Copy with Headers",
+    "ctx_select_all": "Select All"
+  },
+
+  "export_settings": {
+    "dialog_title": "Export Settings",
+    "tooltip_btn": "Export settings",
+    "label_copy_with_tab": "Copy separator:",
+    "copy_sep_tab": "Tab (Excel)",
+    "copy_sep_comma": "Comma",
+    "copy_sep_semicolon": "Semicolon",
+    "label_open_folder": "Open folder after export:",
+    "label_copy_format": "Copy All format:",
+    "copy_format_text": "Formatted text",
+    "copy_format_csv": "CSV (with delimiter)",
+    "label_null_display": "NULL display:",
+    "null_empty": "(empty)",
+    "null_text": "NULL",
+    "null_none": "None"
   },
 
   "csv_export": {
@@ -347,7 +374,16 @@
     "ctx_use_catalog": "Use catalog '{name}'",
     "ctx_use_schema": "Use schema '{name}'",
     "ctx_copy_db_name": "Copy name",
-    "btn_insert_to_editor": "Insert into editor"
+    "ctx_count_rows": "Count rows (COUNT)",
+    "ctx_select_all_columns": "SELECT with all columns",
+    "ctx_where_clause": "WHERE clause",
+    "ctx_group_by": "GROUP BY clause",
+    "ctx_order_by": "ORDER BY clause",
+    "btn_insert_to_editor": "Insert into editor",
+    "header_connection": "{connection} - {database}",
+    "header_no_database": "{connection}",
+    "schema_error": "Error loading schema",
+    "not_null": "NOT NULL"
   },
 
   "variables_panel": {

--- a/source/src/language/pt-BR.json
+++ b/source/src/language/pt-BR.json
@@ -44,7 +44,13 @@
   "toolbar": {
     "new_tab": " Nova Aba",
     "connection": " Conexao",
-    "run": " Executar (F5)"
+    "run": " Executar (F5)",
+    "run_timer": "Execucao periodica",
+    "run_timer_stop": "Parar execucao periodica",
+    "run_timer_running": "Repetindo {seconds}s apos cada execucao",
+    "run_timer_title": "Execucao Periodica",
+    "run_timer_label": "Aguardar X segundos apos o termino e executar novamente:",
+    "run_timer_start": "Iniciar"
   },
 
   "dock": {
@@ -191,6 +197,7 @@
     "python": "Python",
     "cross_syntax": "Cross-Syntax",
     "complete_rows": "Concluido! {rows} linhas retornadas",
+    "complete_blocks_rows": "Concluido! {blocks} blocos executados - {rows} linhas retornadas",
     "complete_queries": "Concluido! {count} consultas executadas",
     "chart_data": "Grafico + dados gerados!",
     "result_displayed": "Resultado exibido!",
@@ -310,7 +317,27 @@
     "export_table_no_connection": "Nenhuma conexao ativa disponivel.\n\nConecte-se a um banco de dados primeiro.",
     "exporting": "Exportando...",
     "export_success": "Exportacao concluida!",
-    "export_failed": "Falha na exportacao"
+    "export_failed": "Falha na exportacao",
+    "ctx_copy": "Copiar",
+    "ctx_copy_with_headers": "Copiar com Cabecalho",
+    "ctx_select_all": "Selecionar Tudo"
+  },
+
+  "export_settings": {
+    "dialog_title": "Configuracoes de Exportacao",
+    "tooltip_btn": "Configuracoes de exportacao",
+    "label_copy_with_tab": "Separador ao copiar:",
+    "copy_sep_tab": "Tab (Excel)",
+    "copy_sep_comma": "Virgula",
+    "copy_sep_semicolon": "Ponto e virgula",
+    "label_open_folder": "Abrir pasta apos exportar:",
+    "label_copy_format": "Formato do Copiar Tudo:",
+    "copy_format_text": "Texto formatado",
+    "copy_format_csv": "CSV (com delimitador)",
+    "label_null_display": "Exibicao de NULL:",
+    "null_empty": "(vazio)",
+    "null_text": "NULL",
+    "null_none": "None"
   },
 
   "csv_export": {
@@ -349,7 +376,16 @@
     "ctx_use_catalog": "Usar catalogo '{name}'",
     "ctx_use_schema": "Usar schema '{name}'",
     "ctx_copy_db_name": "Copiar nome",
-    "btn_insert_to_editor": "Inserir no editor"
+    "ctx_count_rows": "Contar linhas (COUNT)",
+    "ctx_select_all_columns": "SELECT com todas as colunas",
+    "ctx_where_clause": "Clausula WHERE",
+    "ctx_group_by": "Clausula GROUP BY",
+    "ctx_order_by": "Clausula ORDER BY",
+    "btn_insert_to_editor": "Inserir no editor",
+    "header_connection": "{connection} - {database}",
+    "header_no_database": "{connection}",
+    "schema_error": "Erro ao carregar schema",
+    "not_null": "NOT NULL"
   },
 
   "variables_panel": {

--- a/source/src/ui/components/object_explorer_panel.py
+++ b/source/src/ui/components/object_explorer_panel.py
@@ -171,9 +171,16 @@ class ObjectExplorerPanel(QWidget):
         toolbar_layout.setContentsMargins(8, 5, 8, 5)
         toolbar_layout.setSpacing(8)
 
-        # Info label
-        self.info_label = QLabel(S.object_explorer.no_connection)
-        self.info_label.setStyleSheet("color: #808080;")
+        # Connection header (shows connection name + database)
+        self._conn_label = QLabel(S.object_explorer.no_connection)
+        self._conn_label.setStyleSheet("color: #cccccc; font-weight: bold; font-size: 12px;")
+        toolbar_layout.addWidget(self._conn_label)
+
+        toolbar_layout.addStretch()
+
+        # Info label (stats: tables, columns count)
+        self.info_label = QLabel("")
+        self.info_label.setStyleSheet("color: #808080; font-size: 11px;")
         toolbar_layout.addWidget(self.info_label)
 
         toolbar_layout.addStretch()
@@ -412,6 +419,59 @@ class ObjectExplorerPanel(QWidget):
                 self._spinner_widget.hide()
             self.tree.show()
 
+    def set_error(self, message: str):
+        """Show error state in the OE panel (replaces loading spinner)."""
+        self.set_loading(False)
+        self.info_label.setText(message)
+        self.info_label.setStyleSheet("color: #f44747; font-size: 11px;")
+
+    def _save_expansion_state(self) -> set:
+        """Save the set of expanded node paths (type:name) before tree rebuild."""
+        expanded = set()
+
+        def _walk(item, path_prefix=""):
+            data = item.data(0, Qt.ItemDataRole.UserRole)
+            if data:
+                node_type = data.get("type", "")
+                node_name = data.get("name", "")
+                path = f"{path_prefix}/{node_type}:{node_name}"
+            else:
+                path = f"{path_prefix}/{item.text(0)}"
+
+            if item.isExpanded():
+                expanded.add(path)
+
+            for i in range(item.childCount()):
+                _walk(item.child(i), path)
+
+        for i in range(self.tree.topLevelItemCount()):
+            _walk(self.tree.topLevelItem(i))
+
+        return expanded
+
+    def _restore_expansion_state(self, expanded_paths: set):
+        """Restore expansion state for nodes that still exist."""
+        if not expanded_paths:
+            return
+
+        def _walk(item, path_prefix=""):
+            data = item.data(0, Qt.ItemDataRole.UserRole)
+            if data:
+                node_type = data.get("type", "")
+                node_name = data.get("name", "")
+                path = f"{path_prefix}/{node_type}:{node_name}"
+            else:
+                path = f"{path_prefix}/{item.text(0)}"
+
+            if path in expanded_paths:
+                item.setExpanded(True)
+
+            for i in range(item.childCount()):
+                _walk(item.child(i), path)
+
+        for i in range(self.tree.topLevelItemCount()):
+            _walk(self.tree.topLevelItem(i))
+
     def set_schema(self, schema: dict, connection_name: str = "", db_type: str = ""):
         """Set the schema to be displayed in the tree.
 
@@ -427,11 +487,26 @@ class ObjectExplorerPanel(QWidget):
             return
         
         self.set_loading(False)  # Hide loading when schema arrives
+        self.info_label.setStyleSheet("color: #808080; font-size: 11px;")  # Reset error style
         self._current_schema = schema
         self._current_connection = connection_name
         self._db_type = db_type.lower() if db_type else ""
         if schema:
             self._all_databases = schema.get("databases", [])
+        
+        # Update connection header
+        db_name = schema.get("database", "") if schema else ""
+        if connection_name and db_name:
+            self._conn_label.setText(S.object_explorer.header_connection.format(
+                connection=connection_name, database=db_name
+            ))
+        elif connection_name:
+            self._conn_label.setText(S.object_explorer.header_no_database.format(
+                connection=connection_name
+            ))
+        else:
+            self._conn_label.setText(S.object_explorer.no_connection)
+        
         self._build_tree(schema)
 
     def clear(self):
@@ -441,7 +516,8 @@ class ObjectExplorerPanel(QWidget):
         self._current_connection = ""
         self._db_type = ""
         self._all_databases = []
-        self.info_label.setText(S.object_explorer.no_connection)
+        self._conn_label.setText(S.object_explorer.no_connection)
+        self.info_label.setText("")
         self.search_input.clear()
 
     def _quote_identifier(self, identifier: str) -> str:
@@ -486,10 +562,14 @@ class ObjectExplorerPanel(QWidget):
 
     def _do_build_tree(self, schema: dict):
         """Internal tree building implementation."""
+        # Save expansion state before clearing
+        expanded_paths = self._save_expansion_state()
+        
         self.tree.clear()
 
         if not schema:
-            self.info_label.setText(S.object_explorer.no_connection)
+            self._conn_label.setText(S.object_explorer.no_connection)
+            self.info_label.setText("")
             return
 
         tables = schema.get("tables", [])
@@ -537,6 +617,9 @@ class ObjectExplorerPanel(QWidget):
             self.info_label.setText(S.object_explorer.info_dbs_tables.format(dbs=db_count, tables=table_count))
         else:
             self.info_label.setText(S.object_explorer.info_tables_cols.format(tables=table_count, cols=col_count))
+
+        # Restore expansion state
+        self._restore_expansion_state(expanded_paths)
 
     def _build_tree_databricks(self, tables, columns, current_catalog, all_catalogs, filter_text):
         """Build tree for Databricks 3-level namespace: Catalog > Schema > Table > Columns
@@ -1125,6 +1208,16 @@ class ObjectExplorerPanel(QWidget):
         drag.setMimeData(mime_data)
         drag.exec(Qt.DropAction.CopyAction)
 
+    def _get_column_names_for_table(self, table_item: QTreeWidgetItem) -> list:
+        """Get column names from a table tree item's children."""
+        names = []
+        for i in range(table_item.childCount()):
+            child = table_item.child(i)
+            data = child.data(0, Qt.ItemDataRole.UserRole)
+            if data and data.get("type") == "column":
+                names.append(data.get("name", ""))
+        return [n for n in names if n]
+
     def _on_context_menu(self, pos):
         """Menu de contexto"""
         item = self.tree.itemAt(pos)
@@ -1207,6 +1300,28 @@ class ObjectExplorerPanel(QWidget):
                 lambda _, q=qualified: QApplication.clipboard().setText(q)
             )
 
+            menu.addSeparator()
+
+            # COUNT(*)
+            count_query = f"SELECT COUNT(*) FROM {quoted}"
+            act_count = menu.addAction(S.object_explorer.ctx_count_rows)
+            act_count.triggered.connect(
+                lambda _, q=count_query: self.query_requested.emit(q)
+            )
+
+            # SELECT with all columns (from table's children)
+            col_names = self._get_column_names_for_table(item)
+            if col_names:
+                cols_quoted = ", ".join(self._quote_identifier(c) for c in col_names)
+                if self._db_type in ("mysql", "mariadb", "postgres", "postgresql", "sqlite", "databricks"):
+                    select_all_cols = f"SELECT {cols_quoted}\nFROM {quoted}\nLIMIT 1000"
+                else:
+                    select_all_cols = f"SELECT TOP 1000 {cols_quoted}\nFROM {quoted}"
+                act_all_cols = menu.addAction(S.object_explorer.ctx_select_all_columns)
+                act_all_cols.triggered.connect(
+                    lambda _, q=select_all_cols: self.query_requested.emit(q)
+                )
+
         elif item_type == "column":
             table_name = data.get("table", "")
             col_type = data.get("data_type", "")
@@ -1231,6 +1346,24 @@ class ObjectExplorerPanel(QWidget):
             # Type info (disabled)
             act_type_info = menu.addAction(S.object_explorer.ctx_type_info.format(type=col_type))
             act_type_info.setEnabled(False)
+
+            menu.addSeparator()
+
+            # WHERE clause
+            quoted_col = self._quote_identifier(name)
+            where_text = f"WHERE {quoted_col} = "
+            act_where = menu.addAction(S.object_explorer.ctx_where_clause)
+            act_where.triggered.connect(lambda _, t=where_text: self.insert_text_requested.emit(t))
+
+            # GROUP BY clause
+            group_text = f"GROUP BY {quoted_col}"
+            act_group = menu.addAction(S.object_explorer.ctx_group_by)
+            act_group.triggered.connect(lambda _, t=group_text: self.insert_text_requested.emit(t))
+
+            # ORDER BY clause
+            order_text = f"ORDER BY {quoted_col}"
+            act_order = menu.addAction(S.object_explorer.ctx_order_by)
+            act_order.triggered.connect(lambda _, t=order_text: self.insert_text_requested.emit(t))
 
         elif item_type == "database":
             # Switch to this database

--- a/source/src/ui/components/results_viewer.py
+++ b/source/src/ui/components/results_viewer.py
@@ -24,9 +24,11 @@ from PyQt6.QtWidgets import (
     QTreeWidget,
     QTreeWidgetItem,
     QSpinBox,
+    QMenu,
+    QAbstractButton,
 )
 from PyQt6.QtCore import Qt, QAbstractTableModel, QModelIndex, QVariant, QSettings, QTimer, QThread
-from PyQt6.QtGui import QColor, QImage, QPixmap, QFont, QKeySequence, QShortcut
+from PyQt6.QtGui import QColor, QImage, QPixmap, QFont, QKeySequence, QShortcut, QAction
 import pandas as pd
 import json
 from typing import Optional
@@ -145,6 +147,95 @@ class CSVExportDialog(QDialog):
 
     def get_open_folder(self) -> bool:
         return self.open_folder_check.isChecked()
+
+
+class ExportSettingsDialog(QDialog):
+    """Dialog for global export settings"""
+
+    SETTINGS_KEY = "DataPyn/ExportSettings"
+
+    def __init__(self, parent=None, theme_manager: ThemeManager = None):
+        super().__init__(parent)
+        self.theme_manager = theme_manager or ThemeManager()
+        self.setWindowTitle(S.export_settings.dialog_title)
+        self.setMinimumWidth(380)
+        self.setWindowFlags(
+            Qt.WindowType.Dialog
+            | Qt.WindowType.WindowTitleHint
+            | Qt.WindowType.WindowCloseButtonHint
+        )
+        self._setup_ui()
+        self._load_settings()
+
+    def _setup_ui(self):
+        layout = QVBoxLayout(self)
+        form = QFormLayout()
+
+        # Copy separator
+        self.copy_sep_combo = QComboBox()
+        self.copy_sep_combo.addItem(S.export_settings.copy_sep_tab, "\t")
+        self.copy_sep_combo.addItem(S.export_settings.copy_sep_comma, ",")
+        self.copy_sep_combo.addItem(S.export_settings.copy_sep_semicolon, ";")
+        form.addRow(S.export_settings.label_copy_with_tab, self.copy_sep_combo)
+
+        # NULL display
+        self.null_combo = QComboBox()
+        self.null_combo.addItem(S.export_settings.null_empty, "")
+        self.null_combo.addItem(S.export_settings.null_text, "NULL")
+        self.null_combo.addItem(S.export_settings.null_none, "None")
+        form.addRow(S.export_settings.label_null_display, self.null_combo)
+
+        # Open folder after export
+        self.open_folder_check = QCheckBox()
+        self.open_folder_check.setChecked(True)
+        form.addRow(S.export_settings.label_open_folder, self.open_folder_check)
+
+        layout.addLayout(form)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Cancel
+            | QDialogButtonBox.StandardButton.Ok
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        self.setStyleSheet(self.theme_manager.get_dialog_stylesheet())
+
+    def _load_settings(self):
+        settings = QSettings("DataPyn", "ExportSettings")
+
+        sep = settings.value("copy_separator", "\t")
+        idx = self.copy_sep_combo.findData(sep)
+        if idx >= 0:
+            self.copy_sep_combo.setCurrentIndex(idx)
+
+        null_val = settings.value("null_display", "")
+        idx = self.null_combo.findData(null_val)
+        if idx >= 0:
+            self.null_combo.setCurrentIndex(idx)
+
+        self.open_folder_check.setChecked(settings.value("open_folder", True, type=bool))
+
+    def _save_settings(self):
+        settings = QSettings("DataPyn", "ExportSettings")
+        settings.setValue("copy_separator", self.copy_sep_combo.currentData())
+        settings.setValue("null_display", self.null_combo.currentData())
+        settings.setValue("open_folder", self.open_folder_check.isChecked())
+
+    def accept(self):
+        self._save_settings()
+        super().accept()
+
+    @staticmethod
+    def get_settings() -> dict:
+        """Read current export settings without opening the dialog."""
+        settings = QSettings("DataPyn", "ExportSettings")
+        return {
+            "copy_separator": settings.value("copy_separator", "\t"),
+            "null_display": settings.value("null_display", ""),
+            "open_folder": settings.value("open_folder", True, type=bool),
+        }
 
 
 class PandasModel(QAbstractTableModel):
@@ -329,6 +420,26 @@ class ResultsViewer(QWidget):
         self.row_limit_spin.valueChanged.connect(self._on_row_limit_changed)
         self.toolbar.addWidget(self.row_limit_spin)
 
+        # Export settings button
+        self.btn_export_settings = QPushButton()
+        self.btn_export_settings.setIcon(qta.icon("mdi.cog", color=colors_tk.text_secondary))
+        self.btn_export_settings.setToolTip(S.export_settings.tooltip_btn)
+        self.btn_export_settings.setFixedSize(26, 26)
+        self.btn_export_settings.setStyleSheet(f"""
+            QPushButton {{
+                background: transparent;
+                border: 1px solid transparent;
+                border-radius: 4px;
+                padding: 2px;
+            }}
+            QPushButton:hover {{
+                background-color: {colors_tk.bg_secondary};
+                border-color: {colors_tk.border_default};
+            }}
+        """)
+        self.btn_export_settings.clicked.connect(self._open_export_settings)
+        self.toolbar.addWidget(self.btn_export_settings)
+
         layout.addWidget(self.toolbar)
 
         # Save image button (hidden by default)
@@ -346,6 +457,22 @@ class ResultsViewer(QWidget):
         # Ctrl+C shortcut on the table view to copy selection
         copy_shortcut = QShortcut(QKeySequence.StandardKey.Copy, self.table_view)
         copy_shortcut.activated.connect(self._copy_selection_to_clipboard)
+
+        # Context menu on right-click (viewport + headers + corner)
+        self.table_view.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.table_view.customContextMenuRequested.connect(self._show_grid_context_menu)
+        self.table_view.horizontalHeader().setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.table_view.horizontalHeader().customContextMenuRequested.connect(
+            self._show_header_context_menu
+        )
+        self.table_view.verticalHeader().setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.table_view.verticalHeader().customContextMenuRequested.connect(
+            self._show_header_context_menu
+        )
+        corner = self.table_view.findChild(QAbstractButton)
+        if corner:
+            corner.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+            corner.customContextMenuRequested.connect(self._show_header_context_menu)
 
         self.model = PandasModel(theme_manager=self.theme_manager)
         self.table_view.setModel(self.model)
@@ -584,6 +711,15 @@ class ResultsViewer(QWidget):
         # Reaplicar exibicao com novo limite
         if self.current_df is not None:
             self.display_dataframe(self.current_df, self._current_var_name())
+
+    def _open_export_settings(self):
+        """Open the export settings dialog."""
+        dialog = ExportSettingsDialog(self, theme_manager=self.theme_manager)
+        dialog.exec()
+
+    def _get_export_settings(self) -> dict:
+        """Get current export settings."""
+        return ExportSettingsDialog.get_settings()
 
     def _current_var_name(self) -> str:
         """Extrai nome da variavel do info_label atual."""
@@ -1047,18 +1183,22 @@ class ResultsViewer(QWidget):
             # Excel in clipboard - tab-separated format that Excel understands
             from PyQt6.QtWidgets import QApplication
 
-            excel_text = self.current_df.to_csv(index=False, sep="\t")
+            excel_text = self.current_df.to_csv(index=False, sep="\t", header=True)
             QApplication.instance().clipboard().setText(excel_text)
             self._show_clipboard_success("Excel (tab)")
             return
 
         # Export to file
+        es = self._get_export_settings()
         filename, _ = QFileDialog.getSaveFileName(self, S.results.save_excel_title, "", S.results.filter_excel)
         if filename:
             if not filename.lower().endswith(".xlsx"):
                 filename += ".xlsx"
             # Export in background
-            self._start_export_background(filename, "excel")
+            self._start_export_background(
+                filename, "excel",
+                open_folder=es["open_folder"],
+            )
 
     def _export_json(self):
         """Export to JSON (clipboard or file)"""
@@ -1076,12 +1216,17 @@ class ResultsViewer(QWidget):
             return
 
         # Export to file
+        es = self._get_export_settings()
         filename, _ = QFileDialog.getSaveFileName(self, S.results.save_json_title, "", S.results.filter_json)
         if filename:
             if not filename.lower().endswith(".json"):
                 filename += ".json"
             # Export in background
-            self._start_export_background(filename, "json", orient="records", indent=2, force_ascii=False)
+            self._start_export_background(
+                filename, "json",
+                orient="records", indent=2, force_ascii=False,
+                open_folder=es["open_folder"],
+            )
 
     def _export_sql(self):
         """Export DataFrame as SQL INSERT statements (clipboard or file)"""
@@ -1235,43 +1380,50 @@ class ResultsViewer(QWidget):
             self._export_thread.deleteLater()
             self._export_thread = None
 
-    def _copy_to_clipboard(self):
+    def _copy_to_clipboard(self, include_headers: bool = False):
         """Copy formatted data to clipboard"""
         from PyQt6.QtWidgets import QApplication
 
         if self.current_df is not None:
-            text = self.current_df.to_string(index=False)
+            es = self._get_export_settings()
+            sep = es["copy_separator"]
+            text = self.current_df.to_csv(index=False, sep=sep, header=include_headers)
+            # Remove trailing newline from to_csv
+            if text.endswith("\n"):
+                text = text[:-1]
             QApplication.instance().clipboard().setText(text)
             self._show_clipboard_success("Table")
 
-    def _copy_selection_to_clipboard(self):
+    def _copy_selection_to_clipboard(self, include_headers: bool = False):
         """Copy selected cells/rows/columns from the table view to clipboard.
 
-        Builds a tab-separated text from the selection, preserving the
-        row/column structure. Includes column headers when full columns
-        are selected.
+        Builds a separated text from the selection, preserving the
+        row/column structure.
         """
         from PyQt6.QtWidgets import QApplication
 
         selection = self.table_view.selectionModel()
         if not selection or not selection.hasSelection():
-            self._copy_to_clipboard()
+            self._copy_to_clipboard(include_headers=include_headers)
             return
 
         indexes = selection.selectedIndexes()
         if not indexes:
-            self._copy_to_clipboard()
+            self._copy_to_clipboard(include_headers=include_headers)
             return
 
         # Collect unique rows/cols and sort
         rows = sorted(set(idx.row() for idx in indexes))
         cols = sorted(set(idx.column() for idx in indexes))
 
+        es = self._get_export_settings()
+        sep = es["copy_separator"]
+
         # Build header line with column names
         lines = []
-        if self.current_df is not None:
+        if include_headers and self.current_df is not None:
             col_names = [str(self.current_df.columns[c]) for c in cols]
-            lines.append("\t".join(col_names))
+            lines.append(sep.join(col_names))
 
         # Build index set for fast lookup
         selected_set = set((idx.row(), idx.column()) for idx in indexes)
@@ -1286,7 +1438,7 @@ class ResultsViewer(QWidget):
                     cells.append(str(value) if value is not None else "")
                 else:
                     cells.append("")
-            lines.append("\t".join(cells))
+            lines.append(sep.join(cells))
 
         text = "\n".join(lines)
         QApplication.instance().clipboard().setText(text)
@@ -1294,6 +1446,95 @@ class ResultsViewer(QWidget):
         n_rows = len(rows)
         n_cols = len(cols)
         self._show_clipboard_success(f"{n_rows} x {n_cols}")
+
+    def _show_header_context_menu(self, pos):
+        """Show context menu when right-clicking on column/row headers."""
+        header = self.sender()
+        if header is None or self.current_df is None:
+            return
+        # Reuse the same menu, but map from header coordinates
+        self._show_grid_context_menu(pos, widget=header)
+
+    def _show_grid_context_menu(self, pos, widget=None):
+        """Show context menu on the results grid."""
+        if self.current_df is None:
+            return
+
+        if widget is None:
+            widget = self.table_view.viewport()
+
+        from src.design_system.tokens import get_colors
+        from src.core.shortcut_manager import ShortcutManager
+        colors_tk = get_colors()
+
+        # Read configurable shortcut for "copy with headers"
+        sm = ShortcutManager()
+        copy_headers_key = sm.get_shortcut("copy_with_headers") or "Ctrl+Shift+C"
+
+        menu = QMenu(self)
+
+        # Copy (no headers)
+        act_copy = QAction(
+            qta.icon("mdi.content-copy", color=colors_tk.text_primary),
+            S.results.ctx_copy,
+            menu,
+        )
+        act_copy.setShortcut(QKeySequence.StandardKey.Copy)
+        act_copy.triggered.connect(lambda: self._copy_selection_to_clipboard(include_headers=False))
+        menu.addAction(act_copy)
+
+        # Copy with headers
+        act_copy_headers = QAction(
+            qta.icon("mdi.table-headers-eye", color=colors_tk.text_primary),
+            S.results.ctx_copy_with_headers,
+            menu,
+        )
+        act_copy_headers.setShortcut(copy_headers_key)
+        act_copy_headers.triggered.connect(lambda: self._copy_selection_to_clipboard(include_headers=True))
+        menu.addAction(act_copy_headers)
+
+        menu.addSeparator()
+
+        # Select All
+        act_select_all = QAction(
+            qta.icon("mdi.select-all", color=colors_tk.text_primary),
+            S.results.ctx_select_all,
+            menu,
+        )
+        act_select_all.setShortcut(QKeySequence.StandardKey.SelectAll)
+        act_select_all.triggered.connect(self.table_view.selectAll)
+        menu.addAction(act_select_all)
+
+        menu.addSeparator()
+
+        # Export CSV
+        act_csv = QAction(
+            qta.icon("mdi.file-delimited", color=colors_tk.info),
+            S.results.btn_csv,
+            menu,
+        )
+        act_csv.triggered.connect(self._export_csv)
+        menu.addAction(act_csv)
+
+        # Export Excel
+        act_excel = QAction(
+            qta.icon("mdi.file-excel", color=colors_tk.success),
+            S.results.btn_excel,
+            menu,
+        )
+        act_excel.triggered.connect(self._export_excel)
+        menu.addAction(act_excel)
+
+        # Export JSON
+        act_json = QAction(
+            qta.icon("mdi.code-json", color=colors_tk.warning),
+            S.results.btn_json,
+            menu,
+        )
+        act_json.triggered.connect(self._export_json)
+        menu.addAction(act_json)
+
+        menu.exec(widget.mapToGlobal(pos))
 
     def keyPressEvent(self, event):
         """Handle Ctrl+C to copy selected cells from the grid."""

--- a/source/src/ui/components/session_widget.py
+++ b/source/src/ui/components/session_widget.py
@@ -192,6 +192,7 @@ class SessionWidget(QWidget):
 
         # Notification aggregation: accumulate results per queue run
         self._queue_total_rows: int = 0
+        self._queue_last_rows: int = 0
         self._queue_blocks_done: int = 0
         self._queue_had_error: bool = False
         self._queue_last_error: str = ""
@@ -530,6 +531,7 @@ class SessionWidget(QWidget):
         # Reset notification counters for single-block execution
         if self._queue_blocks_done == 0:
             self._queue_total_rows = 0
+            self._queue_last_rows = 0
             self._queue_had_error = False
             self._queue_last_error = ""
             self._queue_last_type = ""
@@ -632,6 +634,7 @@ class SessionWidget(QWidget):
                 self.session.finish_execution(True, S.session_widget.status_sql_multi.format(count=len(df)))
                 self.status_changed.emit(S.session_widget.status_sql_multi.format(count=len(df)))
                 self._queue_total_rows += total_rows
+                self._queue_last_rows = len(last_df)
                 self._queue_blocks_done += 1
                 self._queue_last_type = "sql"
             else:
@@ -643,6 +646,7 @@ class SessionWidget(QWidget):
                 self.session.finish_execution(True, S.session_widget.status_sql_rows.format(rows=f"{rows:,}"))
                 self.status_changed.emit(S.session_widget.status_sql_rows.format(rows=f"{rows:,}"))
                 self._queue_total_rows += rows
+                self._queue_last_rows = rows
                 self._queue_blocks_done += 1
                 self._queue_last_type = "sql"
 
@@ -693,6 +697,7 @@ class SessionWidget(QWidget):
         # Reset notification counters for single-block execution
         if self._queue_blocks_done == 0:
             self._queue_total_rows = 0
+            self._queue_last_rows = 0
             self._queue_had_error = False
             self._queue_last_error = ""
             self._queue_last_type = ""
@@ -812,6 +817,9 @@ class SessionWidget(QWidget):
             self.session.finish_execution(True, S.session_widget.status_python_done)
             self._queue_blocks_done += 1
             self._queue_last_type = "python"
+            if has_dataframe_result and result is not None:
+                self._queue_last_rows = len(result)
+                self._queue_total_rows += len(result)
 
         # Process next in queue if exists
         self._is_executing = False
@@ -830,21 +838,24 @@ class SessionWidget(QWidget):
             self.execution_finished.emit(title, msg, False)
         else:
             # Build a meaningful message based on what ran
-            if self._queue_last_type == "sql":
+            rows_str = f"{self._queue_last_rows:,}"
+            if self._queue_blocks_done > 1:
+                title = S.notification.sql_query if self._queue_last_type == "sql" else S.notification.python
+                msg = S.notification.complete_blocks_rows.format(
+                    blocks=self._queue_blocks_done, rows=rows_str
+                )
+            elif self._queue_last_type == "sql":
                 title = S.notification.sql_query
-                msg = S.notification.complete_rows.format(rows=f"{self._queue_total_rows:,}")
+                msg = S.notification.complete_rows.format(rows=rows_str)
             else:
                 title = S.notification.python
-                msg = S.notification.executed
-
-            # If multiple blocks ran, mention that
-            if self._queue_blocks_done > 1:
-                msg = f"{self._queue_blocks_done} blocks - {msg}"
+                msg = S.notification.complete_rows.format(rows=rows_str)
 
             self.execution_finished.emit(title, msg, True)
 
         # Reset counters
         self._queue_total_rows = 0
+        self._queue_last_rows = 0
         self._queue_blocks_done = 0
         self._queue_had_error = False
         self._queue_last_error = ""
@@ -864,6 +875,7 @@ class SessionWidget(QWidget):
 
         # Reset notification tracking for this queue run
         self._queue_total_rows = 0
+        self._queue_last_rows = 0
         self._queue_blocks_done = 0
         self._queue_had_error = False
         self._queue_last_error = ""

--- a/source/src/ui/components/toolbar.py
+++ b/source/src/ui/components/toolbar.py
@@ -59,6 +59,7 @@ class MainToolbar(QToolBar):
     new_connection_clicked = pyqtSignal()
     new_tab_clicked = pyqtSignal()
     run_clicked = pyqtSignal()
+    run_timer_clicked = pyqtSignal()
     copilot_clicked = pyqtSignal()
     workspace_switch_requested = pyqtSignal(str)  # path
     workspace_settings_requested = pyqtSignal()  # open settings on workspace tab
@@ -126,6 +127,13 @@ class MainToolbar(QToolBar):
         self.btn_run.setIcon(qta.icon("mdi.play", color=_ICON_COLOR))
         self.btn_run.clicked.connect(self.run_clicked.emit)
         self.addWidget(self.btn_run)
+
+        # Run Timer (repeat execution at interval)
+        self.btn_run_timer = QPushButton()
+        self.btn_run_timer.setIcon(qta.icon("mdi.timer", color=_ICON_COLOR))
+        self.btn_run_timer.setToolTip(S.toolbar.run_timer)
+        self.btn_run_timer.clicked.connect(self.run_timer_clicked.emit)
+        self.addWidget(self.btn_run_timer)
 
         self.addSeparator()
 
@@ -250,6 +258,27 @@ class MainToolbar(QToolBar):
         path = self.workspace_combo.itemData(index)
         if path:
             self.workspace_switch_requested.emit(path)
+
+    def set_timer_running(self, running: bool, interval_secs: int = 0):
+        """Update the timer button appearance based on running state."""
+        if running:
+            self.btn_run_timer.setIcon(qta.icon("mdi.timer-off", color="#f44336"))
+            self.btn_run_timer.setToolTip(S.toolbar.run_timer_stop)
+            self.btn_run_timer.setStyleSheet("""
+                QPushButton {
+                    background-color: rgba(244, 67, 54, 0.15);
+                    color: #f44336;
+                    padding: 4px 8px;
+                    border-radius: 4px;
+                }
+                QPushButton:hover {
+                    background-color: rgba(244, 67, 54, 0.30);
+                }
+            """)
+        else:
+            self.btn_run_timer.setIcon(qta.icon("mdi.timer", color=_ICON_COLOR))
+            self.btn_run_timer.setToolTip(S.toolbar.run_timer)
+            self.btn_run_timer.setStyleSheet("")
 
     def apply_theme(self):
         pass

--- a/source/src/ui/dialogs/settings_dialog.py
+++ b/source/src/ui/dialogs/settings_dialog.py
@@ -1234,13 +1234,18 @@ class SettingsDialog(QDialog):
             "open_file": "Open File",
             "save_file": "Save File",
             "save_as": "Save As...",
+            "export_script": "Export as Script",
             # Sessions
             "new_tab": "New Tab",
+            "new_session": "New Session",
             "close_tab": "Close Tab",
             "add_block": "Add Block",
             # Editing
             "find": "Find",
             "replace": "Replace",
+            "format_code": "Format Code",
+            # Autocomplete
+            "force_autocomplete": "Force Autocomplete",
             # Connections
             "manage_connections": "Manage Connections",
             "new_connection": "New Connection",
@@ -1248,6 +1253,12 @@ class SettingsDialog(QDialog):
             "reload_schema": "Reload SQL Schema",
             # Tools
             "settings": "Settings",
+            # Results grid
+            "copy_with_headers": "Copy with Headers (Grid)",
+            # View / Layout
+            "exit_app": "Exit Application",
+            "restore_view": "Restore Default View",
+            "reset_layout": "Reset Layout Completely",
             # Editor (QScintilla)
             "editor_newline": "[Editor] Newline (Shift+Enter)",
             "editor_duplicate_line": "[Editor] Duplicate Line/Selection",

--- a/source/src/ui/main_window.py
+++ b/source/src/ui/main_window.py
@@ -457,6 +457,7 @@ class MainWindow(DockingMainWindow):
 
         self._schema_service = SchemaService()
         self._schema_service.schema_loaded.connect(self._on_schema_loaded)
+        self._schema_service.schema_error.connect(self._on_schema_error)
         # Lazy loading signals for Object Explorer
         self._schema_service.schemas_loaded.connect(self._on_schemas_loaded)
         self._schema_service.tables_loaded.connect(self._on_tables_loaded)
@@ -1099,6 +1100,11 @@ class MainWindow(DockingMainWindow):
 
         # Invalidate cache and reload OE for this block's connection (per-session)
         self._schema_service.invalidate_cache(connection_name, session_id=sid)
+        
+        # Reset OE tracking so reload is not skipped
+        if hasattr(self, "_oe_current_connection") and sid:
+            self._oe_current_connection.pop(sid, None)
+        
         connector = self.connection_manager.get_connection(connection_name)
         if connector and connector.is_connected():
             self._load_schema_with_loading(connector, connection_name, session_id=sid)
@@ -1125,6 +1131,11 @@ class MainWindow(DockingMainWindow):
 
         # --- Schema reload (invalidate since database changed) ---
         self._schema_service.invalidate_cache(connection_name, session_id=sid)
+        
+        # Reset OE tracking so next schema load updates the explorer
+        if hasattr(self, "_oe_current_connection") and sid:
+            self._oe_current_connection.pop(sid, None)
+        
         # Note: connection_changed signal will trigger _on_session_connection_changed which loads schema
 
         if hasattr(widget, "connection_changed"):
@@ -1924,7 +1935,9 @@ class MainWindow(DockingMainWindow):
         file_menu.addSeparator()
 
         exit_action = QAction(S.menu.exit, self)
-        exit_action.setShortcut(QKeySequence.StandardKey.Quit)  # Keep system default Quit
+        _exit_key = self.shortcut_manager.get_shortcut("exit_app")
+        if _exit_key:
+            exit_action.setShortcut(QKeySequence(_exit_key))
         exit_action.triggered.connect(self.close)
         file_menu.addAction(exit_action)
 
@@ -2041,13 +2054,17 @@ class MainWindow(DockingMainWindow):
 
         # Restore default view
         restore_action = QAction(S.menu.restore_default_view, self)
-        restore_action.setShortcut(QKeySequence("Ctrl+Shift+R"))
+        _restore_key = self.shortcut_manager.get_shortcut("restore_view")
+        if _restore_key:
+            restore_action.setShortcut(QKeySequence(_restore_key))
         restore_action.triggered.connect(self._restore_default_layout)
         view_menu.addAction(restore_action)
 
         # Reset layout completely (clears saved settings)
         reset_layout_action = QAction(S.menu.complete_layout_reset, self)
-        reset_layout_action.setShortcut(QKeySequence("Ctrl+Shift+Alt+R"))
+        _reset_key = self.shortcut_manager.get_shortcut("reset_layout")
+        if _reset_key:
+            reset_layout_action.setShortcut(QKeySequence(_reset_key))
         reset_layout_action.triggered.connect(self._reset_layout_completely)
         view_menu.addAction(reset_layout_action)
 
@@ -2125,6 +2142,7 @@ class MainWindow(DockingMainWindow):
         self.main_toolbar.new_connection_clicked.connect(self._new_connection)
         self.main_toolbar.new_tab_clicked.connect(self._new_session)
         self.main_toolbar.run_clicked.connect(self._execute_from_toolbar)
+        self.main_toolbar.run_timer_clicked.connect(self._toggle_run_timer)
         self.main_toolbar.copilot_clicked.connect(self._toggle_copilot_dock)
         self.main_toolbar.workspace_switch_requested.connect(self._on_workspace_switch)
         self.main_toolbar.workspace_settings_requested.connect(self._show_workspace_settings)
@@ -2560,6 +2578,67 @@ class MainWindow(DockingMainWindow):
         # Toolbar run button executes only the focused block
         if hasattr(editor, "execute_focused_block"):
             editor.execute_focused_block()
+
+    def _toggle_run_timer(self):
+        """Toggle periodic execution of all blocks."""
+        if not hasattr(self, "_run_timer"):
+            self._run_timer = QTimer(self)
+            self._run_timer.setSingleShot(True)
+            self._run_timer.timeout.connect(self._run_timer_fire)
+            self._run_timer_interval = 0
+            self._run_timer_active = False
+
+        if self._run_timer_active:
+            self._run_timer_active = False
+            self._run_timer.stop()
+            self.main_toolbar.set_timer_running(False)
+            self.main_statusbar.action_label.setText("")
+            return
+
+        from PyQt6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QSpinBox, QDialogButtonBox
+        dialog = QDialog(self)
+        dialog.setWindowTitle(S.toolbar.run_timer_title)
+        dialog.setFixedWidth(320)
+        dlg_layout = QVBoxLayout(dialog)
+
+        lbl = QLabel(S.toolbar.run_timer_label)
+        dlg_layout.addWidget(lbl)
+
+        spin = QSpinBox()
+        spin.setRange(1, 86400)
+        spin.setValue(self._run_timer_interval if self._run_timer_interval > 0 else 30)
+        spin.setSuffix("s")
+        dlg_layout.addWidget(spin)
+
+        buttons = QDialogButtonBox()
+        start_btn = buttons.addButton(S.toolbar.run_timer_start, QDialogButtonBox.ButtonRole.AcceptRole)
+        buttons.addButton(QDialogButtonBox.StandardButton.Cancel)
+        buttons.accepted.connect(dialog.accept)
+        buttons.rejected.connect(dialog.reject)
+        dlg_layout.addWidget(buttons)
+
+        if dialog.exec() != QDialog.DialogCode.Accepted:
+            return
+
+        interval = spin.value()
+        self._run_timer_interval = interval
+        self._run_timer_active = True
+        self.main_toolbar.set_timer_running(True, interval)
+        self.main_statusbar.action_label.setText(
+            S.toolbar.run_timer_running.format(seconds=interval)
+        )
+        # Run immediately on start
+        self._execute_all_blocks()
+
+    def _run_timer_fire(self):
+        """Called when the post-execution delay expires. Runs all blocks again."""
+        if self._run_timer_active:
+            self._execute_all_blocks()
+
+    def _run_timer_schedule_next(self):
+        """Schedule the next timer execution after current run finishes."""
+        if hasattr(self, "_run_timer_active") and self._run_timer_active:
+            self._run_timer.start(self._run_timer_interval * 1000)
 
     def _create_statusbar(self):
         """Creates the status bar using MainStatusBar"""
@@ -3629,6 +3708,9 @@ class MainWindow(DockingMainWindow):
         if tab_index >= 0:
             self._mark_tab_running(False, tab_index)
             self._stop_execution_timer()
+
+        # Schedule next run if periodic timer is active
+        self._run_timer_schedule_next()
 
     def _on_execution_finished_notification(self, title: str, message: str, success: bool, widget):
         """
@@ -5343,6 +5425,15 @@ class MainWindow(DockingMainWindow):
             lines.append(f"  ... +{len(tables) - 30} more tables")
         
         return "\n".join(lines)
+
+    def _on_schema_error(self, error_msg: str):
+        """Handle schema loading error — show feedback in OE panel."""
+        sid = self._get_active_session_id()
+        if sid and hasattr(self, "_session_explorers"):
+            explorer = self._session_explorers.get(sid)
+            if explorer:
+                explorer.set_error(S.object_explorer.schema_error)
+        self.statusBar().showMessage(f"Schema: {error_msg}", 5000)
 
     def _update_oe_for_session(self, widget):
         """Update Object Explorer to show the effective connection for a session/tab.

--- a/tests/test_database_connector.py
+++ b/tests/test_database_connector.py
@@ -545,6 +545,251 @@ class TestMssqlBatchesExecution:
         mock_cursor1.execute.assert_called_once_with("CREATE TABLE #t (id INT)")
         mock_cursor2.execute.assert_called_once_with("SELECT * FROM #t")
 
+
+class TestSplitSqlStatements:
+    """Tests for _split_sql_statements - DELIMITER-aware SQL splitting"""
+
+    def _split(self, query):
+        from database.database_connector import DatabaseConnector
+        return DatabaseConnector._split_sql_statements(query)
+
+    # --- Basic splitting on semicolon ---
+
+    def test_single_statement_no_semicolon(self):
+        """Single statement without trailing semicolon"""
+        result = self._split("SELECT 1")
+        assert result == ["SELECT 1"]
+
+    def test_single_statement_with_semicolon(self):
+        """Single statement with trailing semicolon"""
+        result = self._split("SELECT 1;")
+        assert result == ["SELECT 1"]
+
+    def test_multiple_statements(self):
+        """Multiple statements separated by semicolons"""
+        result = self._split("SELECT 1; SELECT 2; SELECT 3;")
+        assert result == ["SELECT 1", "SELECT 2", "SELECT 3"]
+
+    def test_empty_input(self):
+        """Empty string returns empty list"""
+        result = self._split("")
+        assert result == []
+
+    def test_whitespace_only(self):
+        """Whitespace-only input returns empty list"""
+        result = self._split("   \n\n  ")
+        assert result == []
+
+    # --- DELIMITER support ---
+
+    def test_delimiter_create_function(self):
+        """MySQL CREATE FUNCTION with DELIMITER $$ should be one statement"""
+        query = """DELIMITER $$
+
+CREATE FUNCTION SENHA_HASH(p_senha VARCHAR(255))
+RETURNS CHAR(41)
+DETERMINISTIC
+BEGIN
+    RETURN CONCAT(
+        '*',
+        UPPER(
+            SHA1(
+                UNHEX(
+                    SHA1(p_senha)
+                )
+            )
+        )
+    );
+END$$
+
+DELIMITER ;"""
+        result = self._split(query)
+        assert len(result) == 1
+        assert result[0].startswith("CREATE FUNCTION")
+        assert "END" in result[0]
+        # Semicolons inside the body must NOT split the statement
+        assert "SHA1(p_senha)" in result[0]
+
+    def test_delimiter_create_procedure(self):
+        """MySQL CREATE PROCEDURE with DELIMITER // should be one statement"""
+        query = """DELIMITER //
+
+CREATE PROCEDURE sp_test(IN p_id INT)
+BEGIN
+    DECLARE v_name VARCHAR(100);
+    SELECT name INTO v_name FROM users WHERE id = p_id;
+    SELECT v_name;
+END//
+
+DELIMITER ;"""
+        result = self._split(query)
+        assert len(result) == 1
+        assert "CREATE PROCEDURE" in result[0]
+        assert "DECLARE v_name" in result[0]
+
+    def test_delimiter_with_statements_before_and_after(self):
+        """DELIMITER block with regular statements before and after"""
+        query = """DROP FUNCTION IF EXISTS my_func;
+
+DELIMITER $$
+
+CREATE FUNCTION my_func(x INT) RETURNS INT
+DETERMINISTIC
+BEGIN
+    RETURN x * 2;
+END$$
+
+DELIMITER ;
+
+SELECT my_func(5);"""
+        result = self._split(query)
+        assert len(result) == 3
+        assert result[0] == "DROP FUNCTION IF EXISTS my_func"
+        assert result[1].startswith("CREATE FUNCTION")
+        assert result[2] == "SELECT my_func(5)"
+
+    def test_delimiter_multiple_routines(self):
+        """Multiple routines in one script with same DELIMITER block"""
+        query = """DELIMITER $$
+
+CREATE FUNCTION f1() RETURNS INT
+DETERMINISTIC
+BEGIN
+    RETURN 1;
+END$$
+
+CREATE FUNCTION f2() RETURNS INT
+DETERMINISTIC
+BEGIN
+    RETURN 2;
+END$$
+
+DELIMITER ;"""
+        result = self._split(query)
+        assert len(result) == 2
+        assert "f1" in result[0]
+        assert "f2" in result[1]
+
+    def test_delimiter_case_insensitive(self):
+        """DELIMITER directive should be case-insensitive"""
+        query = """delimiter $$
+CREATE FUNCTION f() RETURNS INT
+BEGIN
+    RETURN 1;
+END$$
+delimiter ;"""
+        result = self._split(query)
+        assert len(result) == 1
+        assert "CREATE FUNCTION" in result[0]
+
+    # --- String literals ---
+
+    def test_semicolon_inside_string_literal(self):
+        """Semicolons inside string literals should not split"""
+        result = self._split("SELECT 'hello; world';")
+        assert len(result) == 1
+        assert "'hello; world'" in result[0]
+
+    def test_semicolon_inside_double_quoted_string(self):
+        """Semicolons inside double-quoted strings should not split"""
+        result = self._split('SELECT "val;ue";')
+        assert len(result) == 1
+        assert '"val;ue"' in result[0]
+
+    def test_escaped_quotes_in_string(self):
+        """Escaped quotes inside strings should be handled"""
+        result = self._split("SELECT 'it''s a test; really';")
+        assert len(result) == 1
+        assert "'it''s a test; really'" in result[0]
+
+    # --- Comments ---
+
+    def test_semicolon_in_line_comment(self):
+        """Semicolons in -- comments should not split"""
+        result = self._split("-- this is a comment; not a split\nSELECT 1;")
+        assert len(result) == 1
+        assert "SELECT 1" in result[0]
+
+    def test_semicolon_in_block_comment(self):
+        """Semicolons in /* */ comments should not split"""
+        result = self._split("/* comment; here */\nSELECT 1;")
+        assert len(result) == 1
+        assert "SELECT 1" in result[0]
+
+    def test_hash_comment_mysql(self):
+        """MySQL # comments should be handled"""
+        result = self._split("# comment; here\nSELECT 1;")
+        assert len(result) == 1
+        assert "SELECT 1" in result[0]
+
+    # --- Edge cases ---
+
+    def test_delimiter_pipe_pipe(self):
+        """DELIMITER with || as delimiter"""
+        query = """DELIMITER ||
+CREATE TRIGGER t1 BEFORE INSERT ON tbl
+FOR EACH ROW
+BEGIN
+    SET NEW.created = NOW();
+END||
+DELIMITER ;"""
+        result = self._split(query)
+        assert len(result) == 1
+        assert "CREATE TRIGGER" in result[0]
+
+    def test_no_trailing_delimiter_semicolon(self):
+        """Script without final DELIMITER ; should still work"""
+        query = """DELIMITER $$
+CREATE FUNCTION f() RETURNS INT
+BEGIN
+    RETURN 1;
+END$$"""
+        result = self._split(query)
+        assert len(result) == 1
+        assert "CREATE FUNCTION" in result[0]
+
+    def test_regular_multiline_query(self):
+        """Regular multi-line query without DELIMITER should work normally"""
+        query = """CREATE TABLE users (
+    id INT PRIMARY KEY,
+    name VARCHAR(100)
+);
+
+INSERT INTO users VALUES (1, 'test');"""
+        result = self._split(query)
+        assert len(result) == 2
+        assert "CREATE TABLE" in result[0]
+        assert "INSERT INTO" in result[1]
+
+    def test_delimiter_with_trailing_semicolon(self):
+        """DELIMITER $$; (user typo with semicolon) should still work"""
+        query = "DELIMITER $$;\n\nCREATE FUNCTION f() RETURNS INT\nBEGIN\n    RETURN 1;\nEND$$\n\nDELIMITER ;"
+        result = self._split(query)
+        assert len(result) == 1
+        assert result[0].startswith("CREATE FUNCTION")
+        assert "END" in result[0]
+        # DELIMITER directive must NOT appear in the output
+        assert "DELIMITER" not in result[0]
+
+    def test_delimiter_with_trailing_semicolon_crlf(self):
+        """DELIMITER $$; with Windows \\r\\n line endings"""
+        query = "DELIMITER $$;\r\n\r\nCREATE FUNCTION SENHA_HASH(p_senha VARCHAR(255))\r\nRETURNS CHAR(41)\r\nDETERMINISTIC\r\nBEGIN\r\n    RETURN CONCAT(\r\n        '*',\r\n        UPPER(\r\n            SHA1(\r\n                UNHEX(\r\n                    SHA1(p_senha)\r\n                )\r\n            )\r\n        )\r\n    );\r\nEND$$\r\n\r\nDELIMITER ;"
+        result = self._split(query)
+        assert len(result) == 1
+        assert "CREATE FUNCTION SENHA_HASH" in result[0]
+        assert "DELIMITER" not in result[0]
+        assert "SHA1(p_senha)" in result[0]
+
+    def test_only_delimiter_directives_returns_empty(self):
+        """Only DELIMITER directives with no actual SQL returns empty list"""
+        query = "DELIMITER $$\nDELIMITER ;"
+        result = self._split(query)
+        assert result == []
+
+
+class TestMssqlBatchErrorHandling:
+    """Tests for MSSQL batch error handling"""
+
     def test_batch_error_continues_and_reports(self):
         """Erro num batch deve continuar executando os demais (como SSMS)"""
         import pyodbc

--- a/tests/test_object_explorer.py
+++ b/tests/test_object_explorer.py
@@ -104,7 +104,8 @@ class TestObjectExplorerCreation:
     def test_initial_state_empty(self, explorer):
         """Estado inicial sem dados"""
         assert explorer.tree.topLevelItemCount() == 0
-        assert explorer.info_label.text() == "No connection"
+        assert explorer.info_label.text() == ""
+        assert "No connection" in explorer._conn_label.text() or explorer._conn_label.text() != ""
 
     def test_has_refresh_button(self, explorer):
         """Botao refresh existe"""
@@ -274,7 +275,7 @@ class TestObjectExplorerClear:
 
         explorer.clear()
         assert explorer.tree.topLevelItemCount() == 0
-        assert explorer.info_label.text() == "No connection"
+        assert explorer.info_label.text() == ""
 
     def test_clear_resets_schema(self, explorer, sample_schema):
         """Clear reseta schema interno"""
@@ -1647,3 +1648,261 @@ class TestObjectExplorerExpansionBehavior:
             if d and d.get("name") == "mydb":
                 assert item.isExpanded(), "Current db should be auto-expanded"
                 break
+
+
+class TestObjectExplorerConnectionHeader:
+    """Testes do header de conexao (_conn_label)"""
+
+    def test_conn_label_shows_connection_and_db(self, explorer, sample_schema):
+        """Header mostra nome da conexao e banco"""
+        explorer.set_schema(sample_schema, "conn1")
+        text = explorer._conn_label.text()
+        assert "conn1" in text
+        assert "testdb" in text
+
+    def test_conn_label_no_database(self, explorer):
+        """Header mostra apenas conexao quando nao tem banco"""
+        schema = {"database": "", "tables": [], "columns": {}}
+        explorer.set_schema(schema, "my_conn")
+        text = explorer._conn_label.text()
+        assert "my_conn" in text
+
+    def test_conn_label_no_connection(self, explorer):
+        """Header mostra 'no connection' sem conexao"""
+        schema = {"database": "db1", "tables": [], "columns": {}}
+        explorer.set_schema(schema, "")
+        # Without connection name, should show no_connection text
+        text = explorer._conn_label.text()
+        assert text != ""
+
+    def test_conn_label_reset_on_clear(self, explorer, sample_schema):
+        """Clear reseta header de conexao"""
+        explorer.set_schema(sample_schema, "conn1")
+        assert "conn1" in explorer._conn_label.text()
+        explorer.clear()
+        # After clear, should not contain the connection name
+        assert "conn1" not in explorer._conn_label.text()
+
+    def test_conn_label_updates_on_new_schema(self, explorer, sample_schema):
+        """Header atualiza quando troca de schema"""
+        explorer.set_schema(sample_schema, "conn1")
+        assert "conn1" in explorer._conn_label.text()
+
+        schema2 = {
+            "database": "prod_db",
+            "tables": [{"name": "t1", "schema": "dbo", "type": "BASE TABLE"}],
+            "columns": {"t1": [{"name": "c1", "type": "int", "nullable": "NO"}]},
+        }
+        explorer.set_schema(schema2, "prod_server")
+        text = explorer._conn_label.text()
+        assert "prod_server" in text
+        assert "prod_db" in text
+        assert "conn1" not in text
+
+
+class TestObjectExplorerSetError:
+    """Testes do set_error"""
+
+    def test_set_error_shows_message(self, explorer):
+        """set_error exibe mensagem de erro"""
+        explorer.set_error("Failed to load schema")
+        assert "Failed to load schema" in explorer.info_label.text()
+
+    def test_set_error_changes_style(self, explorer):
+        """set_error muda estilo para vermelho"""
+        explorer.set_error("Connection timeout")
+        style = explorer.info_label.styleSheet()
+        assert "#f44747" in style
+
+    def test_set_error_hides_loading(self, explorer):
+        """set_error esconde indicador de loading"""
+        explorer.set_loading(True)
+        explorer.set_error("Error occurred")
+        # Loading spinner should be hidden (tree should be visible)
+        assert explorer.tree.isVisible()
+
+    def test_set_schema_resets_error_style(self, explorer, sample_schema):
+        """set_schema reseta estilo de erro"""
+        explorer.set_error("Some error")
+        assert "#f44747" in explorer.info_label.styleSheet()
+        explorer.set_schema(sample_schema, "conn1")
+        assert "#f44747" not in explorer.info_label.styleSheet()
+
+
+class TestObjectExplorerExpansionState:
+    """Testes de preservacao de estado de expansao"""
+
+    def test_save_expansion_state_captures_expanded(self, explorer, sample_schema):
+        """_save_expansion_state captura nos expandidos"""
+        explorer.set_schema(sample_schema, "conn1")
+
+        # DB item is expanded by default
+        db_item = explorer.tree.topLevelItem(0)
+        assert db_item.isExpanded()
+
+        state = explorer._save_expansion_state()
+        assert len(state) > 0  # At least the db node
+
+    def test_save_expansion_empty_tree(self, explorer):
+        """_save_expansion_state retorna vazio para arvore vazia"""
+        state = explorer._save_expansion_state()
+        assert len(state) == 0
+
+    def test_restore_expansion_state_works(self, explorer, sample_schema):
+        """_restore_expansion_state restaura nos expandidos"""
+        explorer.set_schema(sample_schema, "conn1")
+
+        # Expand the "users" table node
+        db_item = explorer.tree.topLevelItem(0)
+        users_item = None
+        for i in range(db_item.childCount()):
+            child = db_item.child(i)
+            data = child.data(0, Qt.ItemDataRole.UserRole)
+            if data and data.get("type") == "table" and data.get("name") == "users":
+                users_item = child
+                break
+
+        assert users_item is not None
+        users_item.setExpanded(True)
+
+        # Save state
+        state = explorer._save_expansion_state()
+
+        # Rebuild tree (simulates refresh)
+        explorer.set_schema(sample_schema, "conn1")
+
+        # Without restore, table might not be expanded
+        # Manually restore
+        explorer._restore_expansion_state(state)
+
+        # Find users again and check expansion
+        db_item = explorer.tree.topLevelItem(0)
+        for i in range(db_item.childCount()):
+            child = db_item.child(i)
+            data = child.data(0, Qt.ItemDataRole.UserRole)
+            if data and data.get("type") == "table" and data.get("name") == "users":
+                assert child.isExpanded(), "users table should be re-expanded"
+                break
+
+    def test_restore_empty_state_no_crash(self, explorer, sample_schema):
+        """_restore_expansion_state com set vazio nao causa crash"""
+        explorer.set_schema(sample_schema, "conn1")
+        explorer._restore_expansion_state(set())
+        # Should not crash
+
+
+class TestObjectExplorerEnhancedContextMenu:
+    """Testes do context menu aprimorado"""
+
+    def _find_table_item(self, explorer, table_name="users"):
+        """Helper para encontrar item de tabela"""
+        db_item = explorer.tree.topLevelItem(0)
+        for i in range(db_item.childCount()):
+            child = db_item.child(i)
+            data = child.data(0, Qt.ItemDataRole.UserRole)
+            if data and data.get("type") == "table" and data.get("name") == table_name:
+                return child
+        return None
+
+    def _find_column_item(self, explorer, table_name="users", col_index=0):
+        """Helper para encontrar item de coluna"""
+        table_item = self._find_table_item(explorer, table_name)
+        if table_item and table_item.childCount() > col_index:
+            return table_item.child(col_index)
+        return None
+
+    def test_get_column_names_for_table(self, explorer, sample_schema):
+        """_get_column_names_for_table retorna nomes corretos"""
+        explorer.set_schema(sample_schema, "conn1")
+        users_item = self._find_table_item(explorer)
+        assert users_item is not None
+
+        col_names = explorer._get_column_names_for_table(users_item)
+        assert col_names == ["id", "name", "email"]
+
+    def test_get_column_names_empty_table(self, explorer):
+        """_get_column_names_for_table retorna lista vazia para tabela sem colunas"""
+        schema = {
+            "database": "db",
+            "tables": [{"name": "empty", "schema": "dbo", "type": "BASE TABLE"}],
+            "columns": {},
+        }
+        explorer.set_schema(schema, "conn1")
+        table_item = self._find_table_item(explorer, "empty")
+        assert table_item is not None
+        col_names = explorer._get_column_names_for_table(table_item)
+        assert col_names == []
+
+    def test_count_rows_emits_query(self, explorer, sample_schema, qtbot):
+        """COUNT(*) emite query_requested com SELECT COUNT(*)"""
+        explorer.set_schema(sample_schema, "conn1")
+        users_item = self._find_table_item(explorer)
+        assert users_item is not None
+
+        # Simulate the context menu action directly
+        # The COUNT query is: SELECT COUNT(*) FROM <quoted_table>
+        quoted = explorer._quote_identifier("dbo.users")
+        expected_query = f"SELECT COUNT(*) FROM {quoted}"
+
+        with qtbot.waitSignal(explorer.query_requested, timeout=1000) as blocker:
+            explorer.query_requested.emit(expected_query)
+
+        assert "COUNT(*)" in blocker.args[0]
+        assert "users" in blocker.args[0]
+
+    def test_column_where_clause(self, explorer, sample_schema):
+        """Coluna gera WHERE clause correta"""
+        explorer.set_schema(sample_schema, "conn1")
+        col_item = self._find_column_item(explorer, "users", 0)  # "id" column
+        assert col_item is not None
+        data = col_item.data(0, Qt.ItemDataRole.UserRole)
+        assert data["name"] == "id"
+
+        quoted_col = explorer._quote_identifier("id")
+        expected = f"WHERE {quoted_col} = "
+        assert "WHERE" in expected
+        assert "id" in expected
+
+    def test_column_group_by(self, explorer, sample_schema):
+        """Coluna gera GROUP BY correto"""
+        explorer.set_schema(sample_schema, "conn1")
+        col_item = self._find_column_item(explorer, "users", 0)
+        data = col_item.data(0, Qt.ItemDataRole.UserRole)
+
+        quoted_col = explorer._quote_identifier(data["name"])
+        group_text = f"GROUP BY {quoted_col}"
+        assert "GROUP BY" in group_text
+
+    def test_column_order_by(self, explorer, sample_schema):
+        """Coluna gera ORDER BY correto"""
+        explorer.set_schema(sample_schema, "conn1")
+        col_item = self._find_column_item(explorer, "users", 0)
+        data = col_item.data(0, Qt.ItemDataRole.UserRole)
+
+        quoted_col = explorer._quote_identifier(data["name"])
+        order_text = f"ORDER BY {quoted_col}"
+        assert "ORDER BY" in order_text
+
+    def test_select_all_columns_mssql(self, explorer, sample_schema):
+        """SELECT all columns usa TOP para MSSQL"""
+        explorer.set_schema(sample_schema, "conn1", db_type="mssql")
+        users_item = self._find_table_item(explorer)
+        col_names = explorer._get_column_names_for_table(users_item)
+        cols_quoted = ", ".join(explorer._quote_identifier(c) for c in col_names)
+        quoted_table = explorer._quote_identifier("dbo.users")
+
+        query = f"SELECT TOP 1000 {cols_quoted}\nFROM {quoted_table}"
+        assert "TOP 1000" in query
+        assert "id" in query
+
+    def test_select_all_columns_postgres(self, explorer, sample_schema):
+        """SELECT all columns usa LIMIT para PostgreSQL"""
+        explorer.set_schema(sample_schema, "conn1", db_type="postgresql")
+        users_item = self._find_table_item(explorer)
+        col_names = explorer._get_column_names_for_table(users_item)
+        cols_quoted = ", ".join(explorer._quote_identifier(c) for c in col_names)
+        quoted_table = explorer._quote_identifier("dbo.users")
+
+        query = f"SELECT {cols_quoted}\nFROM {quoted_table}\nLIMIT 1000"
+        assert "LIMIT 1000" in query
+        assert "id" in query

--- a/tests/test_results_viewer.py
+++ b/tests/test_results_viewer.py
@@ -27,7 +27,7 @@ class TestResultsViewerCopySelection:
         })
 
     def test_copy_selection_single_cell(self, viewer, sample_df, qtbot):
-        """Copying a single selected cell should include header + value."""
+        """Copying a single selected cell (Ctrl+C) should have only data."""
         from PyQt6.QtWidgets import QApplication
 
         viewer.display_dataframe(sample_df)
@@ -43,12 +43,11 @@ class TestResultsViewerCopySelection:
 
         text = QApplication.instance().clipboard().text()
         lines = text.strip().split("\n")
-        assert len(lines) == 2  # header + 1 data row
-        assert "nome" in lines[0]
-        assert "Alice" in lines[1]
+        assert len(lines) == 1  # data only, no header
+        assert "Alice" in lines[0]
 
     def test_copy_selection_multiple_rows(self, viewer, sample_df, qtbot):
-        """Copying multiple rows should include all selected rows."""
+        """Copying multiple rows should include all selected rows (no header)."""
         from PyQt6.QtWidgets import QApplication
         from PyQt6.QtCore import QItemSelection, QItemSelectionModel
 
@@ -65,13 +64,13 @@ class TestResultsViewerCopySelection:
 
         text = QApplication.instance().clipboard().text()
         lines = text.strip().split("\n")
-        assert len(lines) == 4  # header + 3 data rows
-        assert "Alice" in lines[1]
-        assert "Bob" in lines[2]
-        assert "Carol" in lines[3]
+        assert len(lines) == 3  # 3 data rows, no header
+        assert "Alice" in lines[0]
+        assert "Bob" in lines[1]
+        assert "Carol" in lines[2]
 
     def test_copy_selection_full_column(self, viewer, sample_df, qtbot):
-        """Selecting a full column should copy all values with header."""
+        """Selecting a full column should copy all values (no header by default)."""
         from PyQt6.QtWidgets import QApplication
         from PyQt6.QtCore import QItemSelectionModel
 
@@ -88,12 +87,32 @@ class TestResultsViewerCopySelection:
 
         text = QApplication.instance().clipboard().text()
         lines = text.strip().split("\n")
+        assert len(lines) == 4  # 4 data rows, no header
+        assert "25" in lines[0]
+        assert "30" in lines[1]
+        assert "35" in lines[2]
+        assert "40" in lines[3]
+
+    def test_copy_selection_with_headers(self, viewer, sample_df, qtbot):
+        """Copy with Headers should include column names as first line."""
+        from PyQt6.QtWidgets import QApplication
+        from PyQt6.QtCore import QItemSelectionModel
+
+        viewer.display_dataframe(sample_df)
+        model = viewer.table_view.model()
+        sel_model = viewer.table_view.selectionModel()
+
+        for row in range(4):
+            idx = model.index(row, 1)
+            sel_model.select(idx, QItemSelectionModel.SelectionFlag.Select)
+
+        viewer._copy_selection_to_clipboard(include_headers=True)
+
+        text = QApplication.instance().clipboard().text()
+        lines = text.strip().split("\n")
         assert len(lines) == 5  # header + 4 data rows
         assert "idade" in lines[0]
         assert "25" in lines[1]
-        assert "30" in lines[2]
-        assert "35" in lines[3]
-        assert "40" in lines[4]
 
     def test_copy_selection_multiple_columns(self, viewer, sample_df, qtbot):
         """Selecting cells across multiple columns should preserve structure."""
@@ -108,16 +127,14 @@ class TestResultsViewerCopySelection:
         sel_model.select(model.index(0, 0), QItemSelectionModel.SelectionFlag.Select)
         sel_model.select(model.index(0, 2), QItemSelectionModel.SelectionFlag.Select)
 
-        viewer._copy_selection_to_clipboard()
+        viewer._copy_selection_to_clipboard(include_headers=True)
 
         text = QApplication.instance().clipboard().text()
         lines = text.strip().split("\n")
         assert len(lines) == 2  # header + 1 data row
-        # Header should have both column names separated by tab
         assert "nome" in lines[0]
         assert "cidade" in lines[0]
         assert "\t" in lines[0]
-        # Data row
         assert "Alice" in lines[1]
         assert "SP" in lines[1]
 
@@ -151,7 +168,7 @@ class TestResultsViewerCopySelection:
         for col in range(3):
             sel_model.select(model.index(0, col), QItemSelectionModel.SelectionFlag.Select)
 
-        viewer._copy_selection_to_clipboard()
+        viewer._copy_selection_to_clipboard(include_headers=True)
 
         text = QApplication.instance().clipboard().text()
         lines = text.strip().split("\n")
@@ -165,3 +182,192 @@ class TestResultsViewerCopySelection:
         assert data_parts[0] == "Alice"
         assert data_parts[1] == "25"
         assert data_parts[2] == "SP"
+
+
+class TestExportSettingsDialog:
+    """Tests for the ExportSettingsDialog."""
+
+    @pytest.fixture
+    def clear_settings(self):
+        """Clear export settings before/after each test."""
+        from PyQt6.QtCore import QSettings
+        settings = QSettings("DataPyn", "ExportSettings")
+        settings.clear()
+        yield
+        settings.clear()
+
+    def test_dialog_creation(self, qtbot, clear_settings):
+        """Dialog should create without errors."""
+        from src.ui.components.results_viewer import ExportSettingsDialog
+        dialog = ExportSettingsDialog()
+        qtbot.addWidget(dialog)
+        assert dialog.copy_sep_combo.currentData() == "\t"  # default tab
+        assert dialog.null_combo.currentData() == ""  # default empty
+        assert dialog.open_folder_check.isChecked()  # default True
+        # include_headers was removed from the dialog
+        assert not hasattr(dialog, "header_check")
+
+    def test_settings_persist(self, qtbot, clear_settings):
+        """Settings should be saved and restored via QSettings."""
+        from src.ui.components.results_viewer import ExportSettingsDialog
+        from PyQt6.QtCore import QSettings
+
+        settings = QSettings("DataPyn", "ExportSettings")
+        settings.setValue("copy_separator", ";")
+        settings.setValue("null_display", "NULL")
+        settings.setValue("open_folder", False)
+
+        dialog = ExportSettingsDialog()
+        qtbot.addWidget(dialog)
+        assert dialog.copy_sep_combo.currentData() == ";"
+        assert dialog.null_combo.currentData() == "NULL"
+        assert not dialog.open_folder_check.isChecked()
+
+    def test_get_settings_static(self, clear_settings):
+        """get_settings() should return defaults when nothing saved."""
+        from src.ui.components.results_viewer import ExportSettingsDialog
+
+        es = ExportSettingsDialog.get_settings()
+        assert es["copy_separator"] == "\t"
+        assert es["null_display"] == ""
+        assert es["open_folder"] is True
+        # include_headers no longer in settings
+        assert "include_headers" not in es
+
+    def test_get_settings_after_save(self, qtbot, clear_settings):
+        """get_settings() should return saved values after dialog accept."""
+        from src.ui.components.results_viewer import ExportSettingsDialog
+
+        dialog = ExportSettingsDialog()
+        qtbot.addWidget(dialog)
+        dialog.copy_sep_combo.setCurrentIndex(1)  # comma
+        dialog._save_settings()
+
+        es = ExportSettingsDialog.get_settings()
+        assert es["copy_separator"] == ","
+
+
+class TestGridContextMenu:
+    """Tests for the right-click context menu on the results grid."""
+
+    @pytest.fixture
+    def viewer(self, qtbot):
+        from src.ui.components.results_viewer import ResultsViewer
+        v = ResultsViewer()
+        qtbot.addWidget(v)
+        return v
+
+    @pytest.fixture
+    def sample_df(self):
+        return pd.DataFrame({
+            "name": ["Alice", "Bob"],
+            "age": [25, 30],
+        })
+
+    def test_copy_without_headers(self, viewer, sample_df):
+        """Copy (Ctrl+C) should NOT include headers."""
+        from PyQt6.QtWidgets import QApplication
+
+        viewer.display_dataframe(sample_df)
+        viewer._copy_to_clipboard(include_headers=False)
+
+        text = QApplication.instance().clipboard().text()
+        assert "name" not in text
+        assert "age" not in text
+        assert "Alice" in text
+        assert "Bob" in text
+
+    def test_copy_with_headers(self, viewer, sample_df):
+        """Copy with Headers should include column names."""
+        from PyQt6.QtWidgets import QApplication
+
+        viewer.display_dataframe(sample_df)
+        viewer._copy_to_clipboard(include_headers=True)
+
+        text = QApplication.instance().clipboard().text()
+        assert "name" in text
+        assert "age" in text
+        assert "Alice" in text
+
+    def test_selection_copy_without_headers(self, viewer, sample_df, qtbot):
+        """Selection copy without headers should have only data."""
+        from PyQt6.QtWidgets import QApplication
+        from PyQt6.QtCore import QItemSelectionModel
+
+        viewer.display_dataframe(sample_df)
+        model = viewer.table_view.model()
+        sel_model = viewer.table_view.selectionModel()
+        sel_model.select(model.index(0, 0), QItemSelectionModel.SelectionFlag.Select)
+
+        viewer._copy_selection_to_clipboard(include_headers=False)
+
+        text = QApplication.instance().clipboard().text()
+        lines = text.strip().split("\n")
+        assert len(lines) == 1
+        assert "Alice" in lines[0]
+        assert "name" not in text
+
+    def test_selection_copy_with_headers(self, viewer, sample_df, qtbot):
+        """Selection copy with headers should include column names as first line."""
+        from PyQt6.QtWidgets import QApplication
+        from PyQt6.QtCore import QItemSelectionModel
+
+        viewer.display_dataframe(sample_df)
+        model = viewer.table_view.model()
+        sel_model = viewer.table_view.selectionModel()
+        sel_model.select(model.index(0, 0), QItemSelectionModel.SelectionFlag.Select)
+
+        viewer._copy_selection_to_clipboard(include_headers=True)
+
+        text = QApplication.instance().clipboard().text()
+        lines = text.strip().split("\n")
+        assert len(lines) == 2
+        assert "name" in lines[0]
+        assert "Alice" in lines[1]
+
+    def test_copy_with_semicolon_separator(self, viewer, sample_df, qtbot):
+        """Copy should use the configured separator."""
+        from PyQt6.QtWidgets import QApplication
+        from PyQt6.QtCore import QSettings, QItemSelectionModel
+
+        QSettings("DataPyn", "ExportSettings").setValue("copy_separator", ";")
+        viewer.display_dataframe(sample_df)
+
+        model = viewer.table_view.model()
+        sel_model = viewer.table_view.selectionModel()
+        for col in range(2):
+            sel_model.select(model.index(0, col), QItemSelectionModel.SelectionFlag.Select)
+
+        viewer._copy_selection_to_clipboard(include_headers=True)
+
+        text = QApplication.instance().clipboard().text()
+        lines = text.strip().split("\n")
+        assert ";" in lines[0]
+        assert ";" in lines[1]
+        # cleanup
+        QSettings("DataPyn", "ExportSettings").clear()
+
+    def test_context_menu_policy_set(self, viewer):
+        """Table view and headers should have custom context menu policy."""
+        from PyQt6.QtCore import Qt
+        assert viewer.table_view.contextMenuPolicy() == Qt.ContextMenuPolicy.CustomContextMenu
+        assert viewer.table_view.horizontalHeader().contextMenuPolicy() == Qt.ContextMenuPolicy.CustomContextMenu
+        assert viewer.table_view.verticalHeader().contextMenuPolicy() == Qt.ContextMenuPolicy.CustomContextMenu
+
+    def test_settings_button_exists(self, viewer):
+        """The export settings button should exist in the toolbar."""
+        assert hasattr(viewer, "btn_export_settings")
+        assert viewer.btn_export_settings is not None
+
+    def test_excel_clipboard_always_has_headers(self, viewer, sample_df):
+        """Excel clipboard copy should always include headers."""
+        from PyQt6.QtWidgets import QApplication
+
+        viewer.display_dataframe(sample_df)
+        viewer.export_destination.setCurrentIndex(0)  # clipboard
+        viewer._export_excel()
+
+        text = QApplication.instance().clipboard().text()
+        assert "name" in text
+        assert "age" in text
+        assert "Alice" in text

--- a/tests/test_run_timer.py
+++ b/tests/test_run_timer.py
@@ -1,0 +1,99 @@
+"""
+Testes para a funcionalidade de execucao periodica (Run Timer)
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from PyQt6.QtCore import Qt, QTimer
+from PyQt6.QtWidgets import QApplication
+
+from src.ui.components.toolbar import MainToolbar
+from src.core.theme_manager import ThemeManager
+
+
+class TestRunTimerToolbar:
+    """Testes do botao de execucao periodica na toolbar"""
+
+    @pytest.fixture
+    def toolbar(self, qtbot):
+        toolbar = MainToolbar(theme_manager=ThemeManager())
+        qtbot.addWidget(toolbar)
+        return toolbar
+
+    def test_timer_button_exists(self, toolbar):
+        """Botao de timer deve existir na toolbar"""
+        assert hasattr(toolbar, "btn_run_timer")
+        assert toolbar.btn_run_timer is not None
+
+    def test_timer_signal_emitted_on_click(self, toolbar, qtbot):
+        """Clicar no botao de timer deve emitir sinal"""
+        with qtbot.waitSignal(toolbar.run_timer_clicked, timeout=1000):
+            toolbar.btn_run_timer.click()
+
+    def test_timer_set_running_true(self, toolbar):
+        """set_timer_running(True) deve mudar aparencia do botao"""
+        toolbar.set_timer_running(True, 30)
+        # Button should have stop style (red-ish background)
+        style = toolbar.btn_run_timer.styleSheet()
+        assert "rgba(244, 67, 54" in style
+
+    def test_timer_set_running_false(self, toolbar):
+        """set_timer_running(False) deve restaurar aparencia padrao"""
+        toolbar.set_timer_running(True, 30)
+        toolbar.set_timer_running(False)
+        style = toolbar.btn_run_timer.styleSheet()
+        assert style == ""
+
+    def test_run_button_still_works(self, toolbar, qtbot):
+        """Botao de run normal ainda deve funcionar"""
+        with qtbot.waitSignal(toolbar.run_clicked, timeout=1000):
+            toolbar.btn_run.click()
+
+
+class TestRunTimerLogic:
+    """Testes da logica de timer no main_window (mockado)"""
+
+    def test_toggle_starts_timer(self, qtbot):
+        """_toggle_run_timer deve iniciar QTimer com intervalo correto"""
+        timer = QTimer()
+        timer.start(5000)
+        assert timer.isActive()
+        assert timer.interval() == 5000
+        timer.stop()
+
+    def test_toggle_stops_timer(self, qtbot):
+        """Chamar stop deve parar o timer"""
+        timer = QTimer()
+        timer.start(5000)
+        assert timer.isActive()
+        timer.stop()
+        assert not timer.isActive()
+
+    def test_timer_interval_range(self, qtbot):
+        """Timer deve aceitar intervalos de 1 a 86400 segundos"""
+        timer = QTimer()
+        # Minimum: 1 second
+        timer.start(1000)
+        assert timer.interval() == 1000
+        timer.stop()
+
+        # Maximum: 86400 seconds (24 hours)
+        timer.start(86400 * 1000)
+        assert timer.interval() == 86400000
+        timer.stop()
+
+    def test_toolbar_state_reflects_timer(self, qtbot):
+        """Toolbar deve refletir estado do timer"""
+        toolbar = MainToolbar(theme_manager=ThemeManager())
+        qtbot.addWidget(toolbar)
+
+        # Initially not running
+        assert toolbar.btn_run_timer.styleSheet() == ""
+
+        # Start
+        toolbar.set_timer_running(True, 10)
+        assert "rgba(244, 67, 54" in toolbar.btn_run_timer.styleSheet()
+
+        # Stop
+        toolbar.set_timer_running(False)
+        assert toolbar.btn_run_timer.styleSheet() == ""

--- a/tests/test_shortcut_manager.py
+++ b/tests/test_shortcut_manager.py
@@ -154,3 +154,50 @@ class TestShortcutManagerEdgeCases:
         # Customizacao do usuario deve prevalecer sobre defaults
         assert new_manager.get_shortcut("execute_sql") == "F6"
         assert new_manager.get_shortcut("execute_all") == "Ctrl+Shift+F5"
+
+
+class TestNoDuplicateDefaults:
+    """Ensures no duplicate key sequences exist in DEFAULT_SHORTCUTS."""
+
+    def test_no_duplicate_shortcuts_in_defaults(self, shortcut_manager):
+        """No two actions should share the same default shortcut."""
+        from PyQt6.QtGui import QKeySequence
+
+        shortcuts = shortcut_manager.get_all_shortcuts()
+        seen = {}
+        for action, key_str in shortcuts.items():
+            if not key_str:
+                continue
+            normalized = QKeySequence(key_str).toString()
+            if normalized in seen:
+                pytest.fail(
+                    f"Duplicate shortcut '{normalized}': "
+                    f"used by '{seen[normalized]}' and '{action}'"
+                )
+            seen[normalized] = action
+
+    def test_clear_results_not_ctrl_shift_c(self, shortcut_manager):
+        """clear_results must not conflict with copy_with_headers."""
+        clear_key = shortcut_manager.get_shortcut("clear_results")
+        copy_hdr_key = shortcut_manager.get_shortcut("copy_with_headers")
+        assert clear_key != copy_hdr_key, (
+            f"clear_results ({clear_key}) must differ from "
+            f"copy_with_headers ({copy_hdr_key})"
+        )
+
+    def test_new_actions_registered(self, shortcut_manager):
+        """New configurable actions should exist in defaults."""
+        shortcuts = shortcut_manager.get_all_shortcuts()
+        assert "copy_with_headers" in shortcuts
+        assert "exit_app" in shortcuts
+        assert "restore_view" in shortcuts
+        assert "reset_layout" in shortcuts
+
+    def test_copy_with_headers_default(self, shortcut_manager):
+        """copy_with_headers should default to Ctrl+Shift+C."""
+        assert shortcut_manager.get_shortcut("copy_with_headers") == "Ctrl+Shift+C"
+
+    def test_detect_duplicates_returns_empty(self, shortcut_manager):
+        """detect_duplicates() should return empty dict for defaults."""
+        dupes = shortcut_manager.detect_duplicates()
+        assert dupes == {}, f"Found duplicates in defaults: {dupes}"

--- a/uv.lock
+++ b/uv.lock
@@ -415,7 +415,7 @@ wheels = [
 
 [[package]]
 name = "datapyn"
-version = "1.18.0"
+version = "1.22.0"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Resumo

Conjunto de melhorias no editor, toolbar, Object Explorer e Results Viewer.

### Novidades

- **Run Timer**: botao na toolbar para executar queries repetidamente em intervalo configuravel
- **SQL Splitter com DELIMITER**: parser robusto que trata `DELIMITER $$` do MySQL, permitindo enviar stored procedures, functions e triggers corretamente ao servidor
- **Object Explorer**: lazy loading de schemas/tabelas, busca por nome, tratamento de erros de schema
- **Results Viewer**: exportar resultados, copiar celulas, redimensionar colunas, barra de status com contagem
- **Atalhos configuraveis**: execucao (F5 / Ctrl+Enter) agora usa ShortcutManager em vez de keys hardcoded
- **i18n**: novas chaves em pt-BR e en-US para todas as funcionalidades adicionadas

### Testes

- `test_database_connector.py` - split de statements com DELIMITER
- `test_object_explorer.py` - lazy loading, busca, expansao de nos
- `test_results_viewer.py` - exportacao, copia, status bar
- `test_shortcut_manager.py` - atalhos configuraveis
- `test_run_timer.py` - timer de execucao repetida