### PR TITLE
feat: notification config + settings dialog refactor

### DIFF
--- a/source/src/language/en-US.json
+++ b/source/src/language/en-US.json
@@ -564,7 +564,22 @@
     "workspace_switch_new_instance": "Open New Instance",
     "workspace_switch_new_instance_tooltip": "Keeps current open and opens another DataPyn with the new workspace",
     "workspace_restart_title": "Restart Required",
-    "workspace_restart_message": "The application needs to restart to switch workspaces. Restart now?"
+    "workspace_restart_message": "The application needs to restart to switch workspaces. Restart now?",
+    "tab_notifications": "Notifications",
+    "section_notifications": "NOTIFICATIONS",
+    "label_notifications_enabled": "Show notifications after execution",
+    "label_notifications_sound": "Play notification sound",
+    "section_notification_template": "MESSAGE TEMPLATE",
+    "label_success_title": "Success title:",
+    "label_success_message": "Success message:",
+    "label_error_title": "Error title:",
+    "label_error_message": "Error message:",
+    "notification_variables_hint": "Available variables: {{rows}}, {{blocks}}, {{tab_name}}, {{block_name}}, {{connection}}, {{database}}, {{type}}, {{elapsed}}",
+    "notification_preview_label": "Preview:",
+    "notification_default_success_title": "{{type}}",
+    "notification_default_success_msg": "Complete! {{rows}} rows returned",
+    "notification_default_error_title": "{{type}}",
+    "notification_default_error_msg": "Error: {{error}}"
   },
 
   "connections_manager": {

--- a/source/src/language/pt-BR.json
+++ b/source/src/language/pt-BR.json
@@ -566,7 +566,22 @@
     "workspace_switch_new_instance": "Abrir Nova Instancia",
     "workspace_switch_new_instance_tooltip": "Mantem o atual aberto e abre outro DataPyn com o novo workspace",
     "workspace_restart_title": "Reiniciar Necessario",
-    "workspace_restart_message": "O aplicativo precisa reiniciar para trocar de workspace. Deseja reiniciar agora?"
+    "workspace_restart_message": "O aplicativo precisa reiniciar para trocar de workspace. Deseja reiniciar agora?",
+    "tab_notifications": "Notificacoes",
+    "section_notifications": "NOTIFICACOES",
+    "label_notifications_enabled": "Mostrar notificacoes apos execucao",
+    "label_notifications_sound": "Tocar som de notificacao",
+    "section_notification_template": "TEMPLATE DA MENSAGEM",
+    "label_success_title": "Titulo (sucesso):",
+    "label_success_message": "Mensagem (sucesso):",
+    "label_error_title": "Titulo (erro):",
+    "label_error_message": "Mensagem (erro):",
+    "notification_variables_hint": "Variaveis disponiveis: {{rows}}, {{blocks}}, {{tab_name}}, {{block_name}}, {{connection}}, {{database}}, {{type}}, {{elapsed}}",
+    "notification_preview_label": "Preview:",
+    "notification_default_success_title": "{{type}}",
+    "notification_default_success_msg": "Concluido! {{rows}} linhas retornadas",
+    "notification_default_error_title": "{{type}}",
+    "notification_default_error_msg": "Erro: {{error}}"
   },
 
   "connections_manager": {

--- a/source/src/ui/components/session_widget.py
+++ b/source/src/ui/components/session_widget.py
@@ -198,6 +198,9 @@ class SessionWidget(QWidget):
         self._queue_had_error: bool = False
         self._queue_last_error: str = ""
         self._queue_last_type: str = ""  # "sql", "python", "cross"
+        self._queue_last_block_name: str = ""
+        self._queue_last_connection: str = ""
+        self._queue_last_database: str = ""
 
         # Overlay de loading
         self._loading_overlay: Optional[QLabel] = None
@@ -874,25 +877,47 @@ class SessionWidget(QWidget):
         if self._queue_blocks_done == 0:
             return
 
+        from PyQt6.QtCore import QSettings
+        settings = QSettings("DataPyn", "DataPyn")
+
+        # Resolve type label
+        if self._queue_last_type == "sql":
+            type_label = S.notification.sql_query
+        elif self._queue_last_type == "python":
+            type_label = S.notification.python
+        else:
+            type_label = S.notification.cross_syntax if hasattr(S.notification, 'cross_syntax') else "Cross-Syntax"
+
+        # Build template variables
+        tpl_vars = {
+            "rows": f"{self._queue_last_rows:,}",
+            "blocks": str(self._queue_blocks_done),
+            "tab_name": self.session.title or "",
+            "block_name": self._queue_last_block_name or "",
+            "connection": self._queue_last_connection or "",
+            "database": self._queue_last_database or "",
+            "type": type_label,
+            "error": self._queue_last_error[:80] if self._queue_last_error else "",
+        }
+
+        def _render(template: str) -> str:
+            """Replace {{var}} placeholders in template."""
+            result = template
+            for key, value in tpl_vars.items():
+                result = result.replace("{{" + key + "}}", value)
+            return result
+
         if self._queue_had_error:
-            title = S.notification.sql_query if self._queue_last_type == "sql" else S.notification.python
-            msg = S.notification.error.format(error=self._queue_last_error)
+            default_title = S.settings.notification_default_error_title if hasattr(S.settings, 'notification_default_error_title') else "{{type}}"
+            default_msg = S.settings.notification_default_error_msg if hasattr(S.settings, 'notification_default_error_msg') else "Error: {{error}}"
+            title = _render(settings.value("notifications/error_title", default_title))
+            msg = _render(settings.value("notifications/error_message", default_msg))
             self.execution_finished.emit(title, msg, False)
         else:
-            # Build a meaningful message based on what ran
-            rows_str = f"{self._queue_last_rows:,}"
-            if self._queue_blocks_done > 1:
-                title = S.notification.sql_query if self._queue_last_type == "sql" else S.notification.python
-                msg = S.notification.complete_blocks_rows.format(
-                    blocks=self._queue_blocks_done, rows=rows_str
-                )
-            elif self._queue_last_type == "sql":
-                title = S.notification.sql_query
-                msg = S.notification.complete_rows.format(rows=rows_str)
-            else:
-                title = S.notification.python
-                msg = S.notification.complete_rows.format(rows=rows_str)
-
+            default_title = S.settings.notification_default_success_title if hasattr(S.settings, 'notification_default_success_title') else "{{type}}"
+            default_msg = S.settings.notification_default_success_msg if hasattr(S.settings, 'notification_default_success_msg') else "Complete! {{rows}} rows returned"
+            title = _render(settings.value("notifications/success_title", default_title))
+            msg = _render(settings.value("notifications/success_message", default_msg))
             self.execution_finished.emit(title, msg, True)
 
         # Reset counters
@@ -902,6 +927,9 @@ class SessionWidget(QWidget):
         self._queue_had_error = False
         self._queue_last_error = ""
         self._queue_last_type = ""
+        self._queue_last_block_name = ""
+        self._queue_last_connection = ""
+        self._queue_last_database = ""
 
     # === EXECUTION QUEUE ===
 
@@ -922,6 +950,9 @@ class SessionWidget(QWidget):
         self._queue_had_error = False
         self._queue_last_error = ""
         self._queue_last_type = ""
+        self._queue_last_block_name = ""
+        self._queue_last_connection = ""
+        self._queue_last_database = ""
 
         # Add all to queue
         self._execution_queue.extend(queue)
@@ -1024,6 +1055,16 @@ class SessionWidget(QWidget):
             database_name = None
 
         # Execute according to language
+        # Track context for notification templates
+        if block_name:
+            self._queue_last_block_name = block_name
+        if connection_name:
+            self._queue_last_connection = connection_name
+        elif self.session.connection_name:
+            self._queue_last_connection = self.session.connection_name
+        if database_name:
+            self._queue_last_database = database_name
+
         if language == "sql":
             self._on_execute_sql(code, block_name=block_name, connection_name=connection_name, database_name=database_name)
         elif language == "python":

--- a/source/src/ui/dialogs/settings_dialog.py
+++ b/source/src/ui/dialogs/settings_dialog.py
@@ -21,9 +21,10 @@ from PyQt6.QtWidgets import (
     QCheckBox,
     QListWidget,
     QListWidgetItem,
+    QLineEdit,
 )
 from PyQt6.QtCore import Qt, pyqtSignal, QSettings
-from PyQt6.QtGui import QFont, QKeySequence
+from PyQt6.QtGui import QKeySequence
 from src.core import ShortcutManager
 from src.core.theme_manager import ThemeManager
 from src.language import S, get_available_languages
@@ -114,6 +115,9 @@ class SettingsDialog(QDialog):
         # Copilot tab
         self._setup_copilot_tab()
 
+        # Notifications tab
+        self._setup_notifications_tab()
+
         # Workspace tab
         self._setup_workspace_tab()
 
@@ -121,7 +125,7 @@ class SettingsDialog(QDialog):
 
         # Select initial tab if specified
         if self._initial_tab:
-            tab_map = {"general": 0, "shortcuts": 1, "copilot": 2, "workspace": 3}
+            tab_map = {"general": 0, "shortcuts": 1, "copilot": 2, "notifications": 3, "workspace": 4}
             if self._initial_tab in tab_map:
                 self.tabs.setCurrentIndex(tab_map[self._initial_tab])
 
@@ -185,19 +189,10 @@ class SettingsDialog(QDialog):
 
         layout.addLayout(btn_layout)
 
-    def _setup_general_tab(self):
-        """Sets up the General tab with language selector"""
-        general_widget = QWidget()
-        general_layout = QVBoxLayout(general_widget)
-        general_layout.setSpacing(20)
-        general_layout.setContentsMargins(20, 20, 20, 20)
+    # ==================== SHARED STYLE HELPERS ====================
 
-        # Language section
-        from src.design_system.tokens import get_colors
-        colors = get_colors()
-        
-        lang_group = QGroupBox(S.settings.section_language)
-        lang_group.setStyleSheet(f"""
+    def _get_group_style(self, colors) -> str:
+        return f"""
             QGroupBox {{
                 font-weight: bold;
                 font-size: 11px;
@@ -212,20 +207,28 @@ class SettingsDialog(QDialog):
                 left: 10px;
                 padding: 0 6px;
             }}
-        """)
-        lang_layout = QVBoxLayout(lang_group)
-        lang_layout.setSpacing(10)
+        """
 
-        # Language combo
-        lang_row = QHBoxLayout()
-        lang_label = QLabel(S.settings.label_language)
-        lang_label.setStyleSheet(f"color: {colors.text_secondary}; font-size: 11px; font-weight: normal;")
-        lang_row.addWidget(lang_label)
+    def _get_label_style(self, colors) -> str:
+        return f"color: {colors.text_secondary}; font-size: 11px; font-weight: normal;"
 
-        self.lang_combo = QComboBox()
-        self.lang_combo.setFixedWidth(250)
-        self.lang_combo.setStyleSheet(f"""
-            QComboBox {{
+    def _get_hint_style(self, colors) -> str:
+        return f"color: {colors.text_tertiary}; font-size: 10px; font-style: italic; font-weight: normal;"
+
+    def _get_info_box_style(self, colors) -> str:
+        return f"""
+            background-color: {colors.bg_secondary};
+            color: {colors.text_secondary};
+            padding: 8px 8px 8px 12px;
+            border-radius: 4px;
+            border-left: 3px solid {colors.interactive_primary};
+            font-size: 10px;
+            font-weight: normal;
+        """
+
+    def _get_input_style(self, colors) -> str:
+        return f"""
+            QLineEdit, QSpinBox, QComboBox {{
                 background-color: {colors.bg_secondary};
                 color: {colors.text_secondary};
                 border: 1px solid {colors.border_default};
@@ -233,7 +236,10 @@ class SettingsDialog(QDialog):
                 padding: 6px 10px;
                 font-size: 11px;
             }}
-            QComboBox:hover {{
+            QLineEdit:hover, QSpinBox:hover, QComboBox:hover {{
+                border-color: {colors.interactive_primary};
+            }}
+            QLineEdit:focus, QSpinBox:focus {{
                 border-color: {colors.interactive_primary};
             }}
             QComboBox::drop-down {{
@@ -246,9 +252,84 @@ class SettingsDialog(QDialog):
                 selection-background-color: {colors.interactive_primary};
                 border: 1px solid {colors.border_default};
             }}
-        """)
+        """
 
-        # Load available languages
+    def _get_checkbox_style(self, colors) -> str:
+        return f"""
+            QCheckBox {{
+                color: {colors.text_secondary};
+                font-size: 11px;
+                font-weight: normal;
+                spacing: 8px;
+            }}
+            QCheckBox::indicator {{
+                width: 16px;
+                height: 16px;
+                border: 1px solid {colors.border_default};
+                border-radius: 3px;
+                background-color: {colors.bg_secondary};
+            }}
+            QCheckBox::indicator:checked {{
+                background-color: {colors.interactive_primary};
+                border-color: {colors.interactive_primary};
+            }}
+            QCheckBox::indicator:hover {{
+                border-color: {colors.interactive_primary};
+            }}
+        """
+
+    def _make_group(self, title: str, colors) -> QGroupBox:
+        group = QGroupBox(title)
+        group.setStyleSheet(self._get_group_style(colors))
+        return group
+
+    def _make_label(self, text: str, colors, fixed_width: int = 0) -> QLabel:
+        lbl = QLabel(text)
+        lbl.setStyleSheet(self._get_label_style(colors))
+        if fixed_width:
+            lbl.setFixedWidth(fixed_width)
+        return lbl
+
+    def _make_hint(self, text: str, colors) -> QLabel:
+        lbl = QLabel(text)
+        lbl.setStyleSheet(self._get_hint_style(colors))
+        return lbl
+
+    def _make_info_box(self, text: str, colors) -> QLabel:
+        lbl = QLabel(text)
+        lbl.setWordWrap(True)
+        lbl.setStyleSheet(self._get_info_box_style(colors))
+        return lbl
+
+    def _make_field_row(self, label_text: str, widget, colors, label_width: int = 130) -> QHBoxLayout:
+        row = QHBoxLayout()
+        row.setSpacing(10)
+        lbl = self._make_label(label_text, colors, fixed_width=label_width)
+        row.addWidget(lbl)
+        row.addWidget(widget)
+        return row
+
+    # ==================== TAB SETUP ====================
+
+    def _setup_general_tab(self):
+        """Sets up the General tab with language selector"""
+        general_widget = QWidget()
+        general_layout = QVBoxLayout(general_widget)
+        general_layout.setSpacing(16)
+        general_layout.setContentsMargins(20, 20, 20, 20)
+
+        colors = get_colors()
+        input_style = self._get_input_style(colors)
+
+        # --- Language section ---
+        lang_group = self._make_group(S.settings.section_language, colors)
+        lang_layout = QVBoxLayout(lang_group)
+        lang_layout.setSpacing(8)
+
+        self.lang_combo = QComboBox()
+        self.lang_combo.setFixedWidth(250)
+        self.lang_combo.setStyleSheet(input_style)
+
         languages = get_available_languages()
         current_idx = 0
         for i, lang in enumerate(languages):
@@ -257,48 +338,19 @@ class SettingsDialog(QDialog):
                 current_idx = i
         self.lang_combo.setCurrentIndex(current_idx)
 
-        lang_row.addWidget(self.lang_combo)
-        lang_row.addStretch()
-        lang_layout.addLayout(lang_row)
-
-        # Restart hint
-        hint_label = QLabel(S.settings.language_restart_hint)
-        hint_label.setStyleSheet(f"color: {colors.text_tertiary}; font-size: 10px; font-style: italic; font-weight: normal;")
-        lang_layout.addWidget(hint_label)
-
+        lang_layout.addLayout(
+            self._make_field_row(S.settings.label_language, self.lang_combo, colors, label_width=150)
+        )
+        lang_layout.addWidget(self._make_hint(S.settings.language_restart_hint, colors))
         general_layout.addWidget(lang_group)
 
-        # Display section - Grid row limit
-        display_group = QGroupBox(
-            S.settings.section_display if hasattr(S.settings, 'section_display') else "DISPLAY"
+        # --- Display section ---
+        display_group = self._make_group(
+            S.settings.section_display if hasattr(S.settings, 'section_display') else "DISPLAY",
+            colors,
         )
-        display_group.setStyleSheet(f"""
-            QGroupBox {{
-                font-weight: bold;
-                font-size: 11px;
-                color: {colors.text_secondary};
-                border: 1px solid {colors.border_default};
-                border-radius: 4px;
-                margin-top: 12px;
-                padding-top: 20px;
-            }}
-            QGroupBox::title {{
-                subcontrol-origin: margin;
-                left: 10px;
-                padding: 0 6px;
-            }}
-        """)
         display_layout = QVBoxLayout(display_group)
-        display_layout.setSpacing(10)
-
-        # Row limit
-        row_limit_row = QHBoxLayout()
-        row_limit_label = QLabel(
-            S.settings.label_grid_row_limit if hasattr(S.settings, 'label_grid_row_limit')
-            else "Default grid display limit (rows):"
-        )
-        row_limit_label.setStyleSheet(f"color: {colors.text_secondary}; font-size: 11px; font-weight: normal;")
-        row_limit_row.addWidget(row_limit_label)
+        display_layout.setSpacing(8)
 
         self.grid_row_limit_spin = QSpinBox()
         self.grid_row_limit_spin.setRange(10, 1000000)
@@ -306,113 +358,52 @@ class SettingsDialog(QDialog):
         settings = QSettings("DataPyn", "DataPyn")
         self.grid_row_limit_spin.setValue(int(settings.value("grid/display_row_limit", 100)))
         self.grid_row_limit_spin.setFixedWidth(120)
-        self.grid_row_limit_spin.setStyleSheet(f"""
-            QSpinBox {{
-                background-color: {colors.bg_secondary};
-                color: {colors.text_secondary};
-                border: 1px solid {colors.border_default};
-                border-radius: 4px;
-                padding: 6px 10px;
-                font-size: 11px;
-            }}
-            QSpinBox:hover {{
-                border-color: {colors.interactive_primary};
-            }}
-        """)
-        row_limit_row.addWidget(self.grid_row_limit_spin)
-        row_limit_row.addStretch()
-        display_layout.addLayout(row_limit_row)
+        self.grid_row_limit_spin.setStyleSheet(input_style)
 
-        # Hint
-        display_hint = QLabel(
-            S.settings.grid_row_limit_hint if hasattr(S.settings, 'grid_row_limit_hint')
-            else "Only affects display. Exports always include all data."
+        display_layout.addLayout(
+            self._make_field_row(
+                S.settings.label_grid_row_limit if hasattr(S.settings, 'label_grid_row_limit')
+                else "Default grid display limit (rows):",
+                self.grid_row_limit_spin, colors, label_width=250,
+            )
         )
-        display_hint.setStyleSheet(f"color: {colors.text_tertiary}; font-size: 10px; font-style: italic; font-weight: normal;")
-        display_layout.addWidget(display_hint)
-
+        display_layout.addWidget(self._make_hint(
+            S.settings.grid_row_limit_hint if hasattr(S.settings, 'grid_row_limit_hint')
+            else "Only affects display. Exports always include all data.",
+            colors,
+        ))
         general_layout.addWidget(display_group)
 
-        # Editor section - Monaco Editor info
-        editor_group = QGroupBox(
-            S.settings.section_editor if hasattr(S.settings, 'section_editor') else "CODE EDITOR"
+        # --- Editor section ---
+        editor_group = self._make_group(
+            S.settings.section_editor if hasattr(S.settings, 'section_editor') else "CODE EDITOR",
+            colors,
         )
-        editor_group.setStyleSheet(f"""
-            QGroupBox {{
-                font-weight: bold;
-                font-size: 11px;
-                color: {colors.text_secondary};
-                border: 1px solid {colors.border_default};
-                border-radius: 4px;
-                margin-top: 12px;
-                padding-top: 20px;
-            }}
-            QGroupBox::title {{
-                subcontrol-origin: margin;
-                left: 10px;
-                padding: 0 6px;
-            }}
-        """)
         editor_layout = QVBoxLayout(editor_group)
-        editor_layout.setSpacing(10)
+        editor_layout.setSpacing(8)
 
-        # Monaco Editor info
-        editor_info = QLabel(
+        editor_layout.addWidget(self._make_label(
             S.settings.editor_monaco if hasattr(S.settings, 'editor_monaco')
-            else "Monaco Editor with Copilot inline completions"
-        )
-        editor_info.setStyleSheet(f"color: {colors.text_secondary}; font-size: 11px; font-weight: normal;")
-        editor_layout.addWidget(editor_info)
-
-        # Editor hint
-        editor_hint = QLabel(
-            "Powered by Monaco (VS Code editor engine)"
-        )
-        editor_hint.setStyleSheet(f"color: {colors.text_tertiary}; font-size: 10px; font-style: italic; font-weight: normal;")
-        editor_layout.addWidget(editor_hint)
-
+            else "Monaco Editor with Copilot inline completions",
+            colors,
+        ))
+        editor_layout.addWidget(self._make_hint("Powered by Monaco (VS Code editor engine)", colors))
         general_layout.addWidget(editor_group)
-        general_layout.addStretch()
 
+        general_layout.addStretch()
         self.tabs.addTab(general_widget, S.settings.tab_general)
 
     def _setup_shortcuts_tab(self):
         """Sets up the Shortcuts tab"""
         shortcuts_widget = QWidget()
         shortcuts_layout = QVBoxLayout(shortcuts_widget)
-        shortcuts_layout.setSpacing(15)
+        shortcuts_layout.setSpacing(16)
         shortcuts_layout.setContentsMargins(20, 20, 20, 20)
 
-        # Header
-        header_layout = QVBoxLayout()
-        header_layout.setSpacing(5)
-
-        title = QLabel(S.settings.header_shortcuts)
-        title_font = QFont()
-        title_font.setPointSize(14)
-        title_font.setBold(True)
-        title.setFont(title_font)
-        header_layout.addWidget(title)
-
-        subtitle = QLabel(S.settings.subtitle_shortcuts)
-        from src.design_system.tokens import get_colors
         colors = get_colors()
-        subtitle.setStyleSheet(f"color: {colors.text_tertiary}; font-size: 11px;")
-        header_layout.addWidget(subtitle)
 
-        shortcuts_layout.addLayout(header_layout)
-
-        # Instructions
-        instructions = QLabel(S.settings.tip_shortcuts)
-        instructions.setStyleSheet(f"""
-            background-color: {colors.bg_secondary};
-            color: {colors.text_secondary};
-            padding: 10px;
-            border-radius: 4px;
-            border-left: 3px solid {colors.interactive_primary};
-            font-size: 10px;
-        """)
-        shortcuts_layout.addWidget(instructions)
+        # Info box
+        shortcuts_layout.addWidget(self._make_info_box(S.settings.tip_shortcuts, colors))
 
         # Shortcuts table
         self.table = QTableWidget()
@@ -426,12 +417,12 @@ class SettingsDialog(QDialog):
         self.table.setSelectionMode(QTableWidget.SelectionMode.SingleSelection)
         self.table.setAlternatingRowColors(True)
         self.table.cellDoubleClicked.connect(self._edit_shortcut)
-
-        # Table style
         self.table.setStyleSheet(f"""
             QTableWidget {{
                 gridline-color: {colors.border_default};
                 font-size: 11px;
+                border: 1px solid {colors.border_default};
+                border-radius: 4px;
             }}
             QTableWidget::item {{
                 padding: 8px;
@@ -447,7 +438,6 @@ class SettingsDialog(QDialog):
                 font-weight: bold;
             }}
         """)
-
         shortcuts_layout.addWidget(self.table)
 
         self.tabs.addTab(shortcuts_widget, S.settings.tab_shortcuts)
@@ -456,46 +446,27 @@ class SettingsDialog(QDialog):
         """Sets up the Copilot tab with Chat and Autocomplete settings."""
         copilot_widget = QWidget()
         copilot_layout = QVBoxLayout(copilot_widget)
-        copilot_layout.setSpacing(20)
+        copilot_layout.setSpacing(16)
         copilot_layout.setContentsMargins(20, 20, 20, 20)
 
         colors = get_colors()
         self._copilot_settings = get_copilot_settings()
 
-        # ========================
-        # COPILOT CHAT SECTION
-        # ========================
-        chat_group = QGroupBox(
+        # --- Copilot Chat section ---
+        chat_group = self._make_group(
             S.settings.section_copilot_chat if hasattr(S.settings, 'section_copilot_chat')
-            else "COPILOT CHAT"
+            else "COPILOT CHAT",
+            colors,
         )
-        chat_group.setStyleSheet(f"""
-            QGroupBox {{
-                font-weight: bold;
-                font-size: 11px;
-                color: {colors.text_secondary};
-                border: 1px solid {colors.border_default};
-                border-radius: 4px;
-                margin-top: 12px;
-                padding-top: 20px;
-            }}
-            QGroupBox::title {{
-                subcontrol-origin: margin;
-                left: 10px;
-                padding: 0 6px;
-            }}
-        """)
         chat_layout = QVBoxLayout(chat_group)
-        chat_layout.setSpacing(10)
+        chat_layout.setSpacing(8)
 
-        # Chat status row
         chat_status_row = QHBoxLayout()
-        chat_status_label = QLabel(
-            S.settings.copilot_status if hasattr(S.settings, 'copilot_status')
-            else "Status:"
-        )
-        chat_status_label.setStyleSheet(f"color: {colors.text_secondary}; font-size: 11px; font-weight: normal;")
-        chat_status_row.addWidget(chat_status_label)
+        chat_status_row.setSpacing(8)
+        chat_status_row.addWidget(self._make_label(
+            S.settings.copilot_status if hasattr(S.settings, 'copilot_status') else "Status:",
+            colors,
+        ))
 
         self._chat_status_value = QLabel()
         self._chat_status_value.setStyleSheet(f"color: {colors.text_primary}; font-size: 11px; font-weight: normal;")
@@ -503,58 +474,35 @@ class SettingsDialog(QDialog):
         chat_status_row.addWidget(self._chat_status_value)
         chat_status_row.addStretch()
 
-        # Chat login/logout button
         self._chat_auth_btn = QPushButton()
         self._chat_auth_btn.setFixedHeight(28)
         self._chat_auth_btn.setFixedWidth(100)
         self._update_chat_button_state()
         self._chat_auth_btn.clicked.connect(self._on_chat_auth_clicked)
         chat_status_row.addWidget(self._chat_auth_btn)
-
         chat_layout.addLayout(chat_status_row)
 
-        # Chat auto-connect hint
         chat_hint = QLabel(self._get_chat_auth_hint())
-        chat_hint.setStyleSheet(f"color: {colors.text_tertiary}; font-size: 10px; font-style: italic; font-weight: normal;")
+        chat_hint.setStyleSheet(self._get_hint_style(colors))
         chat_layout.addWidget(chat_hint)
         self._chat_hint_label = chat_hint
-
         copilot_layout.addWidget(chat_group)
 
-        # ========================
-        # AUTOCOMPLETE SECTION
-        # ========================
-        lsp_group = QGroupBox(
+        # --- Autocomplete section ---
+        lsp_group = self._make_group(
             S.settings.section_copilot_autocomplete if hasattr(S.settings, 'section_copilot_autocomplete')
-            else "AUTOCOMPLETE"
+            else "AUTOCOMPLETE",
+            colors,
         )
-        lsp_group.setStyleSheet(f"""
-            QGroupBox {{
-                font-weight: bold;
-                font-size: 11px;
-                color: {colors.text_secondary};
-                border: 1px solid {colors.border_default};
-                border-radius: 4px;
-                margin-top: 12px;
-                padding-top: 20px;
-            }}
-            QGroupBox::title {{
-                subcontrol-origin: margin;
-                left: 10px;
-                padding: 0 6px;
-            }}
-        """)
         lsp_layout = QVBoxLayout(lsp_group)
-        lsp_layout.setSpacing(10)
+        lsp_layout.setSpacing(8)
 
-        # LSP status row
         lsp_status_row = QHBoxLayout()
-        lsp_status_label = QLabel(
-            S.settings.copilot_status if hasattr(S.settings, 'copilot_status')
-            else "Status:"
-        )
-        lsp_status_label.setStyleSheet(f"color: {colors.text_secondary}; font-size: 11px; font-weight: normal;")
-        lsp_status_row.addWidget(lsp_status_label)
+        lsp_status_row.setSpacing(8)
+        lsp_status_row.addWidget(self._make_label(
+            S.settings.copilot_status if hasattr(S.settings, 'copilot_status') else "Status:",
+            colors,
+        ))
 
         self._lsp_status_value = QLabel()
         self._lsp_status_value.setStyleSheet(f"color: {colors.text_primary}; font-size: 11px; font-weight: normal;")
@@ -562,23 +510,20 @@ class SettingsDialog(QDialog):
         lsp_status_row.addWidget(self._lsp_status_value)
         lsp_status_row.addStretch()
 
-        # LSP login/logout button
         self._lsp_auth_btn = QPushButton()
         self._lsp_auth_btn.setFixedHeight(28)
         self._lsp_auth_btn.setFixedWidth(100)
         self._update_lsp_button_state()
         self._lsp_auth_btn.clicked.connect(self._on_lsp_auth_clicked)
         lsp_status_row.addWidget(self._lsp_auth_btn)
-
         lsp_layout.addLayout(lsp_status_row)
 
-        # LSP auto-connect hint
         lsp_hint = QLabel(self._get_lsp_auth_hint())
-        lsp_hint.setStyleSheet(f"color: {colors.text_tertiary}; font-size: 10px; font-style: italic; font-weight: normal;")
+        lsp_hint.setStyleSheet(self._get_hint_style(colors))
         lsp_layout.addWidget(lsp_hint)
         self._lsp_hint_label = lsp_hint
-
         copilot_layout.addWidget(lsp_group)
+
         copilot_layout.addStretch()
 
         tab_title = S.settings.tab_copilot if hasattr(S.settings, 'tab_copilot') else "Copilot"
@@ -762,114 +707,157 @@ class SettingsDialog(QDialog):
         self._update_lsp_button_state()
         self._lsp_hint_label.setText(self._get_lsp_auth_hint())
 
+    def _setup_notifications_tab(self):
+        """Sets up the Notifications tab with toggle and template config."""
+        colors = get_colors()
+        settings = QSettings("DataPyn", "DataPyn")
+        input_style = self._get_input_style(colors)
+        checkbox_style = self._get_checkbox_style(colors)
+
+        notif_widget = QWidget()
+        notif_layout = QVBoxLayout(notif_widget)
+        notif_layout.setSpacing(16)
+        notif_layout.setContentsMargins(20, 20, 20, 20)
+
+        # --- General notification settings ---
+        general_group = self._make_group(S.settings.section_notifications, colors)
+        general_layout = QVBoxLayout(general_group)
+        general_layout.setSpacing(8)
+
+        self.notif_enabled_cb = QCheckBox(S.settings.label_notifications_enabled)
+        self.notif_enabled_cb.setChecked(
+            settings.value("notifications/enabled", True, type=bool)
+        )
+        self.notif_enabled_cb.setStyleSheet(checkbox_style)
+        general_layout.addWidget(self.notif_enabled_cb)
+
+        self.notif_sound_cb = QCheckBox(S.settings.label_notifications_sound)
+        self.notif_sound_cb.setChecked(
+            settings.value("notifications/sound", True, type=bool)
+        )
+        self.notif_sound_cb.setStyleSheet(checkbox_style)
+        general_layout.addWidget(self.notif_sound_cb)
+
+        notif_layout.addWidget(general_group)
+
+        # --- Template settings ---
+        template_group = self._make_group(S.settings.section_notification_template, colors)
+        template_layout = QVBoxLayout(template_group)
+        template_layout.setSpacing(10)
+
+        # Available variables hint
+        template_layout.addWidget(self._make_info_box(
+            S.settings.notification_variables_hint, colors,
+        ))
+
+        # Default templates from translations
+        default_success_title = S.settings.notification_default_success_title
+        default_success_msg = S.settings.notification_default_success_msg
+        default_error_title = S.settings.notification_default_error_title
+        default_error_msg = S.settings.notification_default_error_msg
+
+        # Success title
+        self.notif_success_title = QLineEdit()
+        self.notif_success_title.setText(
+            settings.value("notifications/success_title", default_success_title)
+        )
+        self.notif_success_title.setStyleSheet(input_style)
+        template_layout.addLayout(
+            self._make_field_row(S.settings.label_success_title, self.notif_success_title, colors)
+        )
+
+        # Success message
+        self.notif_success_msg = QLineEdit()
+        self.notif_success_msg.setText(
+            settings.value("notifications/success_message", default_success_msg)
+        )
+        self.notif_success_msg.setStyleSheet(input_style)
+        template_layout.addLayout(
+            self._make_field_row(S.settings.label_success_message, self.notif_success_msg, colors)
+        )
+
+        # Error title
+        self.notif_error_title = QLineEdit()
+        self.notif_error_title.setText(
+            settings.value("notifications/error_title", default_error_title)
+        )
+        self.notif_error_title.setStyleSheet(input_style)
+        template_layout.addLayout(
+            self._make_field_row(S.settings.label_error_title, self.notif_error_title, colors)
+        )
+
+        # Error message
+        self.notif_error_msg = QLineEdit()
+        self.notif_error_msg.setText(
+            settings.value("notifications/error_message", default_error_msg)
+        )
+        self.notif_error_msg.setStyleSheet(input_style)
+        template_layout.addLayout(
+            self._make_field_row(S.settings.label_error_message, self.notif_error_msg, colors)
+        )
+
+        notif_layout.addWidget(template_group)
+        notif_layout.addStretch()
+
+        tab_title = S.settings.tab_notifications if hasattr(S.settings, 'tab_notifications') else "Notifications"
+        self.tabs.addTab(notif_widget, tab_title)
+
     def _setup_workspace_tab(self):
         """Setup Workspace tab for workspace/profile management."""
         from src.core.workspace_service import get_workspace_service
         colors = get_colors()
-        
+
         workspace_widget = QWidget()
         workspace_layout = QVBoxLayout(workspace_widget)
-        workspace_layout.setSpacing(15)
-        workspace_layout.setContentsMargins(15, 15, 15, 15)
-        
-        # Store workspace service reference
+        workspace_layout.setSpacing(16)
+        workspace_layout.setContentsMargins(20, 20, 20, 20)
+
         self._workspace_service = get_workspace_service()
-        
-        # ========================
-        # CURRENT WORKSPACE SECTION
-        # ========================
-        current_group = QGroupBox(
+
+        # --- Current workspace section ---
+        current_group = self._make_group(
             S.settings.section_workspace_current if hasattr(S.settings, 'section_workspace_current')
-            else "CURRENT WORKSPACE"
+            else "CURRENT WORKSPACE",
+            colors,
         )
-        current_group.setStyleSheet(f"""
-            QGroupBox {{
-                font-weight: bold;
-                font-size: 11px;
-                color: {colors.text_secondary};
-                border: 1px solid {colors.border_default};
-                border-radius: 4px;
-                margin-top: 12px;
-                padding-top: 20px;
-            }}
-            QGroupBox::title {{
-                subcontrol-origin: margin;
-                left: 10px;
-                padding: 0 6px;
-            }}
-        """)
         current_layout = QVBoxLayout(current_group)
         current_layout.setSpacing(8)
-        
-        # Workspace name
-        name_row = QHBoxLayout()
-        name_label = QLabel(
-            S.settings.workspace_name if hasattr(S.settings, 'workspace_name')
-            else "Name:"
-        )
-        name_label.setStyleSheet(f"color: {colors.text_secondary}; font-size: 11px; font-weight: normal;")
-        name_label.setFixedWidth(60)
-        name_row.addWidget(name_label)
-        
+
         self._workspace_name_label = QLabel(self._workspace_service.current_workspace_name)
         self._workspace_name_label.setStyleSheet(f"color: {colors.text_primary}; font-size: 12px; font-weight: bold;")
-        name_row.addWidget(self._workspace_name_label)
-        name_row.addStretch()
-        current_layout.addLayout(name_row)
-        
-        # Workspace path
-        path_row = QHBoxLayout()
-        path_label = QLabel(
-            S.settings.workspace_path if hasattr(S.settings, 'workspace_path')
-            else "Folder:"
+        current_layout.addLayout(
+            self._make_field_row(
+                S.settings.workspace_name if hasattr(S.settings, 'workspace_name') else "Name:",
+                self._workspace_name_label, colors, label_width=60,
+            )
         )
-        path_label.setStyleSheet(f"color: {colors.text_secondary}; font-size: 11px; font-weight: normal;")
-        path_label.setFixedWidth(60)
-        path_row.addWidget(path_label)
-        
+
         self._workspace_path_label = QLabel(str(self._workspace_service.current_workspace))
         self._workspace_path_label.setStyleSheet(f"color: {colors.text_tertiary}; font-size: 10px; font-weight: normal;")
         self._workspace_path_label.setWordWrap(True)
-        path_row.addWidget(self._workspace_path_label, 1)
-        current_layout.addLayout(path_row)
-        
-        # Hint
-        hint_label = QLabel(
+        current_layout.addLayout(
+            self._make_field_row(
+                S.settings.workspace_path if hasattr(S.settings, 'workspace_path') else "Folder:",
+                self._workspace_path_label, colors, label_width=60,
+            )
+        )
+
+        current_layout.addWidget(self._make_hint(
             S.settings.workspace_hint if hasattr(S.settings, 'workspace_hint')
-            else "All configurations are stored in this folder"
-        )
-        hint_label.setStyleSheet(f"color: {colors.text_tertiary}; font-size: 10px; font-style: italic; font-weight: normal;")
-        current_layout.addWidget(hint_label)
-        
+            else "All configurations are stored in this folder",
+            colors,
+        ))
         workspace_layout.addWidget(current_group)
-        
-        # ========================
-        # SAVED WORKSPACES SECTION
-        # ========================
-        saved_group = QGroupBox(
+
+        # --- Saved workspaces section ---
+        saved_group = self._make_group(
             S.settings.section_workspaces if hasattr(S.settings, 'section_workspaces')
-            else "SAVED WORKSPACES"
+            else "SAVED WORKSPACES",
+            colors,
         )
-        saved_group.setStyleSheet(f"""
-            QGroupBox {{
-                font-weight: bold;
-                font-size: 11px;
-                color: {colors.text_secondary};
-                border: 1px solid {colors.border_default};
-                border-radius: 4px;
-                margin-top: 12px;
-                padding-top: 20px;
-            }}
-            QGroupBox::title {{
-                subcontrol-origin: margin;
-                left: 10px;
-                padding: 0 6px;
-            }}
-        """)
         saved_layout = QVBoxLayout(saved_group)
         saved_layout.setSpacing(10)
-        
-        # Workspace list
+
         self._workspace_list = QListWidget()
         self._workspace_list.setFixedHeight(120)
         self._workspace_list.setStyleSheet(f"""
@@ -891,20 +879,17 @@ class SettingsDialog(QDialog):
                 background-color: {colors.bg_elevated};
             }}
         """)
-        
-        # Store colors for button state updates (must be before _refresh_workspace_list)
+
         self._workspace_colors = colors
-        
         self._refresh_workspace_list()
         saved_layout.addWidget(self._workspace_list)
-        
+
         # Buttons row
         btn_row = QHBoxLayout()
         btn_row.setSpacing(8)
-        
+
         add_btn = QPushButton(
-            S.settings.workspace_add if hasattr(S.settings, 'workspace_add')
-            else "Add..."
+            S.settings.workspace_add if hasattr(S.settings, 'workspace_add') else "Add..."
         )
         add_btn.setFixedHeight(28)
         add_btn.setStyleSheet(f"""
@@ -922,10 +907,9 @@ class SettingsDialog(QDialog):
         """)
         add_btn.clicked.connect(self._on_add_workspace)
         btn_row.addWidget(add_btn)
-        
+
         duplicate_btn = QPushButton(
-            S.settings.workspace_duplicate if hasattr(S.settings, 'workspace_duplicate')
-            else "Duplicate..."
+            S.settings.workspace_duplicate if hasattr(S.settings, 'workspace_duplicate') else "Duplicate..."
         )
         duplicate_btn.setFixedHeight(28)
         duplicate_btn.setStyleSheet(f"""
@@ -944,33 +928,28 @@ class SettingsDialog(QDialog):
         """)
         duplicate_btn.clicked.connect(self._on_duplicate_workspace)
         btn_row.addWidget(duplicate_btn)
-        
+
         self._remove_btn = QPushButton(
-            S.settings.workspace_remove if hasattr(S.settings, 'workspace_remove')
-            else "Remove"
+            S.settings.workspace_remove if hasattr(S.settings, 'workspace_remove') else "Remove"
         )
         self._remove_btn.setFixedHeight(28)
         self._remove_btn.clicked.connect(self._on_remove_workspace)
         btn_row.addWidget(self._remove_btn)
-        
-        # Connect list selection to update button state
+
         self._workspace_list.currentItemChanged.connect(self._update_remove_button_state)
-        
+
         btn_row.addStretch()
         saved_layout.addLayout(btn_row)
-        
-        # Switch hint
-        switch_hint = QLabel(
+
+        saved_layout.addWidget(self._make_hint(
             S.settings.workspace_switch_hint if hasattr(S.settings, 'workspace_switch_hint')
-            else "Switching workspace requires restarting the app"
-        )
-        switch_hint.setStyleSheet(f"color: {colors.text_tertiary}; font-size: 10px; font-style: italic; font-weight: normal;")
-        saved_layout.addWidget(switch_hint)
-        
+            else "Switching workspace requires restarting the app",
+            colors,
+        ))
+
         workspace_layout.addWidget(saved_group)
         workspace_layout.addStretch()
-        
-        # Add tab
+
         tab_title = S.settings.tab_workspace if hasattr(S.settings, 'tab_workspace') else "Workspace"
         self.tabs.addTab(workspace_widget, tab_title)
     
@@ -1389,6 +1368,14 @@ class SettingsDialog(QDialog):
 
         # Save grid display row limit
         settings.setValue("grid/display_row_limit", self.grid_row_limit_spin.value())
+
+        # Save notification settings
+        settings.setValue("notifications/enabled", self.notif_enabled_cb.isChecked())
+        settings.setValue("notifications/sound", self.notif_sound_cb.isChecked())
+        settings.setValue("notifications/success_title", self.notif_success_title.text())
+        settings.setValue("notifications/success_message", self.notif_success_msg.text())
+        settings.setValue("notifications/error_title", self.notif_error_title.text())
+        settings.setValue("notifications/error_message", self.notif_error_msg.text())
 
         # Save shortcuts
         for row in range(self.table.rowCount()):

--- a/source/src/ui/main_window/_execution.py
+++ b/source/src/ui/main_window/_execution.py
@@ -692,6 +692,13 @@ class ExecutionMixin:
             tab_index: Indice da aba que originou (foca nela ao clicar)
         """
         try:
+            from PyQt6.QtCore import QSettings
+            settings = QSettings("DataPyn", "DataPyn")
+            if not settings.value("notifications/enabled", True, type=bool):
+                return
+
+            sound = settings.value("notifications/sound", True, type=bool)
+
             on_click = None
             if tab_index is not None:
                 on_click = lambda idx=tab_index: self._focus_window_and_tab(idx)
@@ -701,6 +708,7 @@ class ExecutionMixin:
                 message=message,
                 success=success,
                 on_click=on_click,
+                sound=sound,
             )
         except Exception as e:
             logger.error(f"Error sending toast notification: {e}")

--- a/source/src/ui/main_window/_execution.py
+++ b/source/src/ui/main_window/_execution.py
@@ -14,6 +14,7 @@ from PyQt6.QtCore import Qt, QThread, QTimer, QElapsedTimer
 from PyQt6.QtWidgets import QMessageBox
 
 from src.ui.main_window._workers import SqlWorker, PythonWorker
+from src.ui.components.toast_notification import ToastManager
 from src.language import S
 
 logger = logging.getLogger(__name__)

--- a/source/src/ui/main_window/_execution.py
+++ b/source/src/ui/main_window/_execution.py
@@ -675,21 +675,9 @@ class ExecutionMixin:
 
     def _on_execution_finished_notification(self, title: str, message: str, success: bool, widget):
         """
-        Decide se deve enviar notificacao apos execucao terminar.
-
-        Regras:
-        - Nao notifica se o usuario esta focado na aba que executou
-          (janela ativa + aba visivel)
-        - Notifica se a janela esta minimizada ou se outra aba esta selecionada
+        Envia notificacao apos execucao terminar.
         """
         tab_index = self.session_tabs.indexOf(widget)
-        current_tab = self.session_tabs.currentIndex()
-        is_active_window = self.isActiveWindow() and not self.isMinimized()
-
-        # Skip notification if user is looking at the executing tab
-        if is_active_window and current_tab == tab_index:
-            return
-
         self._send_notification(title, message, success, tab_index)
 
     def _send_notification(self, title: str, message: str, success: bool = True, tab_index: int = None):

--- a/tests/test_notification_config.py
+++ b/tests/test_notification_config.py
@@ -1,0 +1,291 @@
+"""
+Tests for notification configuration system:
+- Settings dialog UI (toggle, sound, templates)
+- Template rendering with variables
+- Notification enabled/disabled via QSettings
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch, PropertyMock
+from PyQt6.QtCore import QSettings
+
+
+# ==================== TEMPLATE RENDERING TESTS ====================
+
+
+class TestNotificationTemplateRendering:
+    """Test the template variable replacement logic used in notifications."""
+
+    def _render(self, template: str, variables: dict) -> str:
+        """Reproduce the same rendering logic from session_widget."""
+        result = template
+        for key, value in variables.items():
+            result = result.replace("{{" + key + "}}", value)
+        return result
+
+    def test_render_basic_rows(self):
+        """Template with {{rows}} is replaced correctly."""
+        tpl = "Complete! {{rows}} rows returned"
+        result = self._render(tpl, {"rows": "1,234"})
+        assert result == "Complete! 1,234 rows returned"
+
+    def test_render_multiple_variables(self):
+        """Template with multiple variables is rendered correctly."""
+        tpl = "{{type}} - {{rows}} rows from {{connection}}"
+        result = self._render(tpl, {
+            "type": "SQL Query",
+            "rows": "500",
+            "connection": "my_db",
+        })
+        assert result == "SQL Query - 500 rows from my_db"
+
+    def test_render_all_variables(self):
+        """All supported variables are replaced."""
+        tpl = "{{type}} | {{rows}} | {{blocks}} | {{tab_name}} | {{block_name}} | {{connection}} | {{database}} | {{error}}"
+        variables = {
+            "type": "SQL Query",
+            "rows": "100",
+            "blocks": "3",
+            "tab_name": "My Tab",
+            "block_name": "query1",
+            "connection": "prod_db",
+            "database": "analytics",
+            "error": "",
+        }
+        result = self._render(tpl, variables)
+        assert result == "SQL Query | 100 | 3 | My Tab | query1 | prod_db | analytics | "
+
+    def test_render_empty_variables(self):
+        """Empty variables are replaced with empty string."""
+        tpl = "{{type}}: {{block_name}}"
+        result = self._render(tpl, {"type": "Python", "block_name": ""})
+        assert result == "Python: "
+
+    def test_render_no_variables(self):
+        """Template without variables is returned as-is."""
+        tpl = "Execution complete!"
+        result = self._render(tpl, {"rows": "100"})
+        assert result == "Execution complete!"
+
+    def test_render_error_template(self):
+        """Error template with {{error}} is rendered."""
+        tpl = "Error: {{error}}"
+        result = self._render(tpl, {"error": "connection timeout", "type": "SQL Query"})
+        assert result == "Error: connection timeout"
+
+    def test_render_custom_format(self):
+        """User-defined custom template works."""
+        tpl = "[{{tab_name}}] {{block_name}} -> {{rows}} rows ({{connection}}/{{database}})"
+        result = self._render(tpl, {
+            "tab_name": "Analysis",
+            "block_name": "sales_query",
+            "rows": "5,000",
+            "connection": "warehouse",
+            "database": "sales_db",
+        })
+        assert result == "[Analysis] sales_query -> 5,000 rows (warehouse/sales_db)"
+
+    def test_render_preserves_unknown_placeholders(self):
+        """Unknown {{variables}} are left as-is."""
+        tpl = "{{type}} - {{unknown_var}}"
+        result = self._render(tpl, {"type": "SQL Query"})
+        assert result == "SQL Query - {{unknown_var}}"
+
+
+# ==================== SETTINGS PERSISTENCE TESTS ====================
+
+
+class TestNotificationSettings:
+    """Test that notification settings are read/written correctly via QSettings."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_settings(self):
+        """Clean notification settings before and after each test."""
+        settings = QSettings("DataPyn", "DataPyn")
+        keys = [
+            "notifications/enabled",
+            "notifications/sound",
+            "notifications/success_title",
+            "notifications/success_message",
+            "notifications/error_title",
+            "notifications/error_message",
+        ]
+        originals = {k: settings.value(k) for k in keys}
+        for k in keys:
+            settings.remove(k)
+        yield
+        for k in keys:
+            settings.remove(k)
+            if originals[k] is not None:
+                settings.setValue(k, originals[k])
+
+    def test_default_enabled_is_true(self):
+        """Notifications are enabled by default when no setting is saved."""
+        settings = QSettings("DataPyn", "DataPyn")
+        assert settings.value("notifications/enabled", True, type=bool) is True
+
+    def test_default_sound_is_true(self):
+        """Sound is enabled by default when no setting is saved."""
+        settings = QSettings("DataPyn", "DataPyn")
+        assert settings.value("notifications/sound", True, type=bool) is True
+
+    def test_save_and_read_enabled_false(self):
+        """Can save enabled=False and read it back."""
+        settings = QSettings("DataPyn", "DataPyn")
+        settings.setValue("notifications/enabled", False)
+        assert settings.value("notifications/enabled", True, type=bool) is False
+
+    def test_save_and_read_sound_false(self):
+        """Can save sound=False and read it back."""
+        settings = QSettings("DataPyn", "DataPyn")
+        settings.setValue("notifications/sound", False)
+        assert settings.value("notifications/sound", True, type=bool) is False
+
+    def test_save_and_read_custom_templates(self):
+        """Can save custom templates and read them back."""
+        settings = QSettings("DataPyn", "DataPyn")
+        settings.setValue("notifications/success_title", "Done!")
+        settings.setValue("notifications/success_message", "{{rows}} rows from {{connection}}")
+        settings.setValue("notifications/error_title", "Failed")
+        settings.setValue("notifications/error_message", "{{error}} on {{database}}")
+
+        assert settings.value("notifications/success_title") == "Done!"
+        assert settings.value("notifications/success_message") == "{{rows}} rows from {{connection}}"
+        assert settings.value("notifications/error_title") == "Failed"
+        assert settings.value("notifications/error_message") == "{{error}} on {{database}}"
+
+
+# ==================== SETTINGS DIALOG UI TESTS ====================
+
+
+class TestNotificationSettingsDialog:
+    """Test the notifications tab in the settings dialog."""
+
+    @pytest.fixture
+    def dialog(self, qtbot):
+        """Create a SettingsDialog for testing."""
+        from src.ui.dialogs.settings_dialog import SettingsDialog
+        from src.core import ShortcutManager
+
+        sm = ShortcutManager()
+        dlg = SettingsDialog(shortcut_manager=sm)
+        qtbot.addWidget(dlg)
+        return dlg
+
+    def test_notifications_tab_exists(self, dialog):
+        """The Notifications tab is present in the dialog."""
+        tab_texts = [dialog.tabs.tabText(i) for i in range(dialog.tabs.count())]
+        # Check that at least one tab contains notification-related text
+        assert any("notif" in t.lower() or "Notif" in t for t in tab_texts), f"No notifications tab found in: {tab_texts}"
+
+    def test_notifications_tab_index(self, dialog):
+        """The Notifications tab is at index 3 (after General, Shortcuts, Copilot)."""
+        assert dialog.tabs.count() >= 5, f"Expected at least 5 tabs, got {dialog.tabs.count()}"
+
+    def test_enabled_checkbox_exists(self, dialog):
+        """The enabled checkbox is present and defaults to checked."""
+        assert hasattr(dialog, 'notif_enabled_cb')
+        assert dialog.notif_enabled_cb.isChecked()
+
+    def test_sound_checkbox_exists(self, dialog):
+        """The sound checkbox is present and defaults to checked."""
+        assert hasattr(dialog, 'notif_sound_cb')
+        assert dialog.notif_sound_cb.isChecked()
+
+    def test_template_fields_exist(self, dialog):
+        """All 4 template input fields exist."""
+        assert hasattr(dialog, 'notif_success_title')
+        assert hasattr(dialog, 'notif_success_msg')
+        assert hasattr(dialog, 'notif_error_title')
+        assert hasattr(dialog, 'notif_error_msg')
+
+    def test_template_fields_have_defaults(self, dialog):
+        """Template fields have non-empty default values."""
+        assert dialog.notif_success_title.text() != ""
+        assert dialog.notif_success_msg.text() != ""
+        assert dialog.notif_error_title.text() != ""
+        assert dialog.notif_error_msg.text() != ""
+
+    def test_save_notification_settings(self, dialog, qtbot):
+        """Saving settings persists notification config to QSettings."""
+        # Modify values
+        dialog.notif_enabled_cb.setChecked(False)
+        dialog.notif_sound_cb.setChecked(False)
+        dialog.notif_success_title.setText("Custom Title")
+        dialog.notif_success_msg.setText("{{rows}} rows done")
+        dialog.notif_error_title.setText("Oops")
+        dialog.notif_error_msg.setText("Failed: {{error}}")
+
+        # Save
+        dialog._save_all()
+
+        # Verify
+        settings = QSettings("DataPyn", "DataPyn")
+        assert settings.value("notifications/enabled", True, type=bool) is False
+        assert settings.value("notifications/sound", True, type=bool) is False
+        assert settings.value("notifications/success_title") == "Custom Title"
+        assert settings.value("notifications/success_message") == "{{rows}} rows done"
+        assert settings.value("notifications/error_title") == "Oops"
+        assert settings.value("notifications/error_message") == "Failed: {{error}}"
+
+        # Cleanup
+        for key in ["notifications/enabled", "notifications/sound",
+                     "notifications/success_title", "notifications/success_message",
+                     "notifications/error_title", "notifications/error_message"]:
+            settings.remove(key)
+
+
+# ==================== NOTIFICATION DISABLED TEST ====================
+
+
+class TestNotificationDisabled:
+    """Test that notifications are skipped when disabled."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_settings(self):
+        settings = QSettings("DataPyn", "DataPyn")
+        original = settings.value("notifications/enabled")
+        yield
+        if original is not None:
+            settings.setValue("notifications/enabled", original)
+        else:
+            settings.remove("notifications/enabled")
+
+    def test_send_notification_skipped_when_disabled(self):
+        """_send_notification does NOT call ToastManager when notifications are disabled."""
+        settings = QSettings("DataPyn", "DataPyn")
+        settings.setValue("notifications/enabled", False)
+
+        with patch("src.ui.main_window._execution.ToastManager") as mock_tm:
+            # Create a minimal mock that has the method
+            mixin = MagicMock()
+            from src.ui.main_window._execution import ExecutionMixin
+            ExecutionMixin._send_notification(mixin, "Title", "Message", True, 0)
+            mock_tm.notify.assert_not_called()
+
+    def test_send_notification_called_when_enabled(self):
+        """_send_notification calls ToastManager when notifications are enabled."""
+        settings = QSettings("DataPyn", "DataPyn")
+        settings.setValue("notifications/enabled", True)
+
+        with patch("src.ui.main_window._execution.ToastManager") as mock_tm:
+            mixin = MagicMock()
+            ExecutionMixin = __import__("src.ui.main_window._execution", fromlist=["ExecutionMixin"]).ExecutionMixin
+            ExecutionMixin._send_notification(mixin, "Title", "Message", True, 0)
+            mock_tm.notify.assert_called_once()
+
+    def test_send_notification_passes_sound_setting(self):
+        """_send_notification reads sound setting and passes it to ToastManager."""
+        settings = QSettings("DataPyn", "DataPyn")
+        settings.setValue("notifications/enabled", True)
+        settings.setValue("notifications/sound", False)
+
+        with patch("src.ui.main_window._execution.ToastManager") as mock_tm:
+            from src.ui.main_window._execution import ExecutionMixin
+            mixin = MagicMock()
+            ExecutionMixin._send_notification(mixin, "Title", "Message", True, 0)
+            call_kwargs = mock_tm.notify.call_args
+            assert call_kwargs[1].get("sound") is False or call_kwargs.kwargs.get("sound") is False
+
+        # Cleanup
+        settings.remove("notifications/sound")


### PR DESCRIPTION
## Changes

### Configurable Notifications
- Toggle enable/sound per user preference
- Custom notification templates with `{{variable}}` rendering (block name, connection, database, duration, rows)
- Template fields in Settings > Notifications tab

### Settings Dialog Full Refactor
- Created 8 shared style helpers + 5 widget factories for consistent styling
- Standardized margins (20px) and spacing (16px between groups, 8-10px inner) across all 5 tabs
- Eliminated ~8 duplicate QGroupBox stylesheet blocks and ~15 duplicate label style strings
- Fixed hint label overlap bug in Notifications tab
- Removed oversized Shortcuts tab header for visual consistency

### Tests
- 23 new tests in `test_notification_config.py`
- Full suite: 170+ tests passing