### PR TITLE
feat: per-tab custom notifications with result access and color picker

### DIFF
--- a/source/src/language/en-US.json
+++ b/source/src/language/en-US.json
@@ -434,6 +434,7 @@
     "ctx_close_all_others": "Close All Others",
     "ctx_rename": "Rename",
     "ctx_duplicate": "Duplicate",
+    "ctx_customize_notification": "Customize Notification",
     "ctx_close": "Close"
   },
 
@@ -580,6 +581,23 @@
     "notification_default_success_msg": "Complete! {{rows}} rows returned",
     "notification_default_error_title": "{{type}}",
     "notification_default_error_msg": "Error: {{error}}"
+  },
+
+  "tab_notification": {
+    "dialog_title": "Tab Notification",
+    "section_config": "NOTIFICATION CONFIG",
+    "enable_custom": "Enable custom notification for this tab",
+    "section_template": "MESSAGE TEMPLATE",
+    "variables_hint": "Variables: {{rows}}, {{blocks}}, {{tab_name}}, {{block_name}}, {{connection}}, {{database}}, {{type}}. Use {{result[row][col]}} to access query result values (e.g. {{result[0][1]}}).",
+    "label_title": "Title:",
+    "label_message": "Message:",
+    "label_color": "Color:",
+    "color_picker_title": "Notification Color",
+    "default_title": "{{tab_name}}",
+    "default_message": "{{rows}} rows - {{result[0][0]}}",
+    "btn_save": "Save",
+    "btn_cancel": "Cancel",
+    "badge_active": "Custom notification active"
   },
 
   "connections_manager": {

--- a/source/src/language/pt-BR.json
+++ b/source/src/language/pt-BR.json
@@ -436,6 +436,7 @@
     "ctx_close_all_others": "Fechar Todas as Outras",
     "ctx_rename": "Renomear",
     "ctx_duplicate": "Duplicar",
+    "ctx_customize_notification": "Personalizar Notificacao",
     "ctx_close": "Fechar"
   },
 
@@ -582,6 +583,23 @@
     "notification_default_success_msg": "Concluido! {{rows}} linhas retornadas",
     "notification_default_error_title": "{{type}}",
     "notification_default_error_msg": "Erro: {{error}}"
+  },
+
+  "tab_notification": {
+    "dialog_title": "Notificacao da Aba",
+    "section_config": "CONFIGURACAO DE NOTIFICACAO",
+    "enable_custom": "Ativar notificacao personalizada para esta aba",
+    "section_template": "TEMPLATE DA MENSAGEM",
+    "variables_hint": "Variaveis: {{rows}}, {{blocks}}, {{tab_name}}, {{block_name}}, {{connection}}, {{database}}, {{type}}. Use {{result[linha][coluna]}} para acessar valores do resultado (ex: {{result[0][1]}}).",
+    "label_title": "Titulo:",
+    "label_message": "Mensagem:",
+    "label_color": "Cor:",
+    "color_picker_title": "Cor da Notificacao",
+    "default_title": "{{tab_name}}",
+    "default_message": "{{rows}} linhas - {{result[0][0]}}",
+    "btn_save": "Salvar",
+    "btn_cancel": "Cancelar",
+    "badge_active": "Notificacao personalizada ativa"
   },
 
   "connections_manager": {

--- a/source/src/ui/components/session_tabs.py
+++ b/source/src/ui/components/session_tabs.py
@@ -111,7 +111,19 @@ class SessionTabBar(QTabBar):
 
         menu.addSeparator()
 
-        # 6. Close
+        # 6. Customize notification
+        notif_label = (
+            S.session_tabs.ctx_customize_notification
+            if hasattr(S.session_tabs, 'ctx_customize_notification')
+            else "Customize Notification"
+        )
+        notif_action = QAction(qta.icon("mdi.bell-ring-outline"), notif_label, self)
+        notif_action.triggered.connect(lambda: self._customize_notification(index))
+        menu.addAction(notif_action)
+
+        menu.addSeparator()
+
+        # 7. Close
         close_action = QAction(qta.icon("mdi.close"), S.session_tabs.ctx_close, self)
         close_action.triggered.connect(lambda: self._close_tab(index))
         menu.addAction(close_action)
@@ -192,6 +204,23 @@ class SessionTabBar(QTabBar):
         tab_widget = self.parent()
         if tab_widget and hasattr(tab_widget, "duplicate_session"):
             tab_widget.duplicate_session.emit(index)
+
+    def _customize_notification(self, index):
+        """Open per-tab notification config dialog"""
+        tab_widget = self.parent()
+        if not tab_widget:
+            return
+        widget = tab_widget.widget(index)
+        if not widget or not hasattr(widget, 'get_tab_notification_config'):
+            return
+
+        from src.ui.dialogs.tab_notification_dialog import TabNotificationDialog
+        current_config = widget.get_tab_notification_config()
+        dialog = TabNotificationDialog(current_config, parent=self)
+        if dialog.exec() == TabNotificationDialog.DialogCode.Accepted:
+            config = dialog.get_config()
+            if config is not None:
+                widget.set_tab_notification_config(config)
 
     def _close_tab(self, index):
         """Close a tab"""

--- a/source/src/ui/components/session_widget.py
+++ b/source/src/ui/components/session_widget.py
@@ -209,6 +209,9 @@ class SessionWidget(QWidget):
         self.file_path: Optional[str] = None
         self._original_file_type: Optional[str] = None
 
+        # Per-tab custom notification config (lives in memory, persisted via DPW)
+        self._tab_notification_config: Optional[Dict[str, Any]] = None
+
         # Per-tab periodic execution
         self._periodic_timer: Optional[QTimer] = None
         self._periodic_interval: int = 0  # seconds
@@ -225,6 +228,16 @@ class SessionWidget(QWidget):
             self.editor.setText(session.code)
 
         # Connections are selected per block via clickable panel (no need to populate list)
+
+    # --- Per-tab notification config ---
+
+    def get_tab_notification_config(self) -> Optional[Dict[str, Any]]:
+        """Return the per-tab notification config dict, or None."""
+        return self._tab_notification_config
+
+    def set_tab_notification_config(self, config: Optional[Dict[str, Any]]):
+        """Set per-tab notification config (or None to clear)."""
+        self._tab_notification_config = config
 
     def _setup_ui(self):
         """Configure widget UI"""
@@ -872,6 +885,33 @@ class SessionWidget(QWidget):
 
     # === EXECUTION NOTIFICATION ===
 
+    @staticmethod
+    def _resolve_result_refs(template: str, last_result) -> str:
+        """Replace {{result[row][col]}} references with actual values from last_result DataFrame."""
+        import re
+        if last_result is None:
+            return template
+
+        def _replace_match(m):
+            try:
+                row = int(m.group(1))
+                col = int(m.group(2))
+                if hasattr(last_result, 'iloc'):
+                    val = last_result.iloc[row, col]
+                elif isinstance(last_result, list) and row < len(last_result):
+                    row_data = last_result[row]
+                    if isinstance(row_data, (list, tuple)) and col < len(row_data):
+                        val = row_data[col]
+                    else:
+                        return m.group(0)
+                else:
+                    return m.group(0)
+                return str(val)
+            except (IndexError, KeyError, TypeError, ValueError):
+                return m.group(0)
+
+        return re.sub(r'\{\{result\[(\d+)\]\[(\d+)\]\}\}', _replace_match, template)
+
     def _emit_queue_notification(self):
         """Emit a single notification summarizing the entire queue execution."""
         if self._queue_blocks_done == 0:
@@ -900,14 +940,25 @@ class SessionWidget(QWidget):
             "error": self._queue_last_error[:80] if self._queue_last_error else "",
         }
 
+        # Get _last_result for result[N][M] references
+        last_result = self.session.get_variable("_last_result") if hasattr(self.session, 'get_variable') else None
+
         def _render(template: str) -> str:
-            """Replace {{var}} placeholders in template."""
+            """Replace {{var}} placeholders and result[N][M] in template."""
             result = template
             for key, value in tpl_vars.items():
                 result = result.replace("{{" + key + "}}", value)
+            result = self._resolve_result_refs(result, last_result)
             return result
 
-        if self._queue_had_error:
+        # Check for per-tab custom notification config
+        tab_config = self._tab_notification_config
+        if tab_config and tab_config.get("enabled"):
+            title = _render(tab_config.get("title", "{{tab_name}}"))
+            msg = _render(tab_config.get("message", "{{rows}} rows"))
+            success = not self._queue_had_error
+            self.execution_finished.emit(title, msg, success)
+        elif self._queue_had_error:
             default_title = S.settings.notification_default_error_title if hasattr(S.settings, 'notification_default_error_title') else "{{type}}"
             default_msg = S.settings.notification_default_error_msg if hasattr(S.settings, 'notification_default_error_msg') else "Error: {{error}}"
             title = _render(settings.value("notifications/error_title", default_title))

--- a/source/src/ui/components/toast_notification.py
+++ b/source/src/ui/components/toast_notification.py
@@ -74,6 +74,7 @@ class ToastNotification(QWidget):
         duration: int = 0,
         parent: QWidget = None,
         on_click=None,
+        color: str = None,
     ):
         # Top-level window (no parent) so it shows above everything,
         # even when the main window is minimized or unfocused.
@@ -81,6 +82,7 @@ class ToastNotification(QWidget):
         self._on_click = on_click
         self._duration = duration or (self.DURATION_DEFAULT if success else self.DURATION_ERROR)
         self._success = success
+        self._custom_color = color
 
         self.setFixedWidth(self.WIDTH)
         self.setMinimumHeight(self.MIN_HEIGHT)
@@ -98,11 +100,18 @@ class ToastNotification(QWidget):
 
     def _build_ui(self, title: str, message: str, success: bool):
         """Build the toast UI."""
-        # Colors
-        bg = "#1e8a3e" if success else "#c0392b"
-        bg_hover = "#22a347" if success else "#d44637"
-        border_color = "#27ae60" if success else "#e74c3c"
-        icon_char = "\u2713" if success else "\u2717"  # checkmark / cross
+        # Colors - custom color overrides default
+        if self._custom_color:
+            bg = self._custom_color
+            # Derive hover/border from custom color
+            bg_hover = self._custom_color + "dd"
+            border_color = self._custom_color
+            icon_char = "\u2713" if success else "\u2717"
+        else:
+            bg = "#1e8a3e" if success else "#c0392b"
+            bg_hover = "#22a347" if success else "#d44637"
+            border_color = "#27ae60" if success else "#e74c3c"
+            icon_char = "\u2713" if success else "\u2717"  # checkmark / cross
 
         self.setStyleSheet(f"""
             ToastNotification {{
@@ -270,6 +279,7 @@ class ToastManager:
         success: bool = True,
         on_click=None,
         sound: bool = True,
+        color: str = None,
     ):
         """
         Show a toast notification.
@@ -280,12 +290,13 @@ class ToastManager:
             success: True for green/success, False for red/error.
             on_click: Optional callback when user clicks the toast.
             sound: Whether to play a notification sound.
+            color: Optional custom background color (hex string).
         """
         if _manager is None:
             logger.debug("ToastManager not initialized - skipping notification")
             return
 
-        _manager._show(title, message, success, on_click, sound)
+        _manager._show(title, message, success, on_click, sound, color)
 
     def _show(
         self,
@@ -294,6 +305,7 @@ class ToastManager:
         success: bool,
         on_click,
         sound: bool,
+        color: str = None,
     ):
         """Internal: create and show a toast."""
         toast = ToastNotification(
@@ -302,6 +314,7 @@ class ToastManager:
             success=success,
             parent=self._parent,
             on_click=on_click,
+            color=color,
         )
         toast.closed.connect(self._on_toast_closed)
 

--- a/source/src/ui/dialogs/tab_notification_dialog.py
+++ b/source/src/ui/dialogs/tab_notification_dialog.py
@@ -1,0 +1,269 @@
+"""
+Per-tab notification configuration dialog.
+
+Allows users to set custom notification templates for a specific tab.
+The config lives in memory and is persisted only via DPW save/load.
+"""
+
+from PyQt6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit,
+    QCheckBox, QPushButton, QGroupBox, QWidget, QColorDialog,
+)
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QColor
+from typing import Optional, Dict, Any
+
+from src.design_system.tokens import get_colors, RADIUS
+from src.language import S
+
+
+class TabNotificationDialog(QDialog):
+    """Dialog for configuring per-tab notification templates."""
+
+    def __init__(self, current_config: Optional[Dict[str, Any]] = None, parent=None):
+        super().__init__(parent)
+        self._config = current_config or {}
+        self._result_config: Optional[Dict[str, Any]] = None
+        self._setup_ui()
+
+    def _setup_ui(self):
+        colors = get_colors()
+        title = S.tab_notification.dialog_title if hasattr(S, 'tab_notification') else "Tab Notification"
+        self.setWindowTitle(title)
+        self.setMinimumWidth(420)
+        self.setMaximumWidth(520)
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowType.WindowContextHelpButtonHint)
+
+        self.setStyleSheet(f"""
+            QDialog {{
+                background-color: {colors.bg_primary};
+            }}
+        """)
+
+        layout = QVBoxLayout(self)
+        layout.setSpacing(16)
+        layout.setContentsMargins(20, 20, 20, 20)
+
+        group_style = f"""
+            QGroupBox {{
+                font-weight: bold;
+                font-size: 11px;
+                color: {colors.text_secondary};
+                border: 1px solid {colors.border_default};
+                border-radius: 4px;
+                margin-top: 12px;
+                padding-top: 20px;
+            }}
+            QGroupBox::title {{
+                subcontrol-origin: margin;
+                left: 10px;
+                padding: 0 6px;
+            }}
+        """
+        input_style = f"""
+            QLineEdit {{
+                background-color: {colors.bg_secondary};
+                color: {colors.text_primary};
+                border: 1px solid {colors.border_default};
+                border-radius: 4px;
+                padding: 6px 10px;
+                font-size: 12px;
+            }}
+            QLineEdit:focus {{
+                border-color: {colors.interactive_primary};
+            }}
+        """
+        checkbox_style = f"""
+            QCheckBox {{
+                color: {colors.text_primary};
+                font-size: 12px;
+                spacing: 8px;
+                font-weight: normal;
+            }}
+        """
+
+        # --- Enable section ---
+        config_group = QGroupBox(
+            S.tab_notification.section_config if hasattr(S, 'tab_notification') else "NOTIFICATION CONFIG"
+        )
+        config_group.setStyleSheet(group_style)
+        config_layout = QVBoxLayout(config_group)
+        config_layout.setSpacing(8)
+
+        self._enable_cb = QCheckBox(
+            S.tab_notification.enable_custom if hasattr(S, 'tab_notification') else "Enable custom notification for this tab"
+        )
+        self._enable_cb.setStyleSheet(checkbox_style)
+        self._enable_cb.setChecked(self._config.get("enabled", False))
+        self._enable_cb.toggled.connect(self._on_enable_toggled)
+        config_layout.addWidget(self._enable_cb)
+        layout.addWidget(config_group)
+
+        # --- Template section ---
+        template_group = QGroupBox(
+            S.tab_notification.section_template if hasattr(S, 'tab_notification') else "MESSAGE TEMPLATE"
+        )
+        template_group.setStyleSheet(group_style)
+        template_layout = QVBoxLayout(template_group)
+        template_layout.setSpacing(10)
+
+        # Variables hint
+        hint_text = (
+            S.tab_notification.variables_hint if hasattr(S, 'tab_notification')
+            else "Variables: {{rows}}, {{blocks}}, {{tab_name}}, {{block_name}}, {{connection}}, {{database}}, {{type}}. Use {{result[row][col]}} to access query result values (e.g. {{result[0][1]}})."
+        )
+        hint_label = QLabel(hint_text)
+        hint_label.setWordWrap(True)
+        hint_label.setStyleSheet(f"""
+            QLabel {{
+                background-color: {colors.bg_elevated};
+                color: {colors.text_secondary};
+                font-size: 11px;
+                padding: 8px 8px 8px 12px;
+                border-left: 3px solid {colors.interactive_primary};
+                border-radius: 4px;
+                font-weight: normal;
+            }}
+        """)
+        template_layout.addWidget(hint_label)
+
+        label_style = f"color: {colors.text_secondary}; font-size: 11px; font-weight: normal;"
+        default_title = (
+            S.tab_notification.default_title if hasattr(S, 'tab_notification') else "{{tab_name}}"
+        )
+        default_message = (
+            S.tab_notification.default_message if hasattr(S, 'tab_notification') else "{{rows}} rows - {{result[0][0]}}"
+        )
+
+        # Title field
+        title_row = QHBoxLayout()
+        title_label = QLabel(S.tab_notification.label_title if hasattr(S, 'tab_notification') else "Title:")
+        title_label.setStyleSheet(label_style)
+        title_label.setFixedWidth(80)
+        title_row.addWidget(title_label)
+        self._title_input = QLineEdit()
+        self._title_input.setText(self._config.get("title", default_title))
+        self._title_input.setStyleSheet(input_style)
+        title_row.addWidget(self._title_input)
+        template_layout.addLayout(title_row)
+
+        # Message field
+        msg_row = QHBoxLayout()
+        msg_label = QLabel(S.tab_notification.label_message if hasattr(S, 'tab_notification') else "Message:")
+        msg_label.setStyleSheet(label_style)
+        msg_label.setFixedWidth(80)
+        msg_row.addWidget(msg_label)
+        self._message_input = QLineEdit()
+        self._message_input.setText(self._config.get("message", default_message))
+        self._message_input.setStyleSheet(input_style)
+        msg_row.addWidget(self._message_input)
+        template_layout.addLayout(msg_row)
+
+        # Color picker row
+        color_row = QHBoxLayout()
+        color_label = QLabel(
+            S.tab_notification.label_color if hasattr(S, 'tab_notification') else "Color:"
+        )
+        color_label.setStyleSheet(label_style)
+        color_label.setFixedWidth(80)
+        color_row.addWidget(color_label)
+
+        self._color_value = self._config.get("color", "#1e8a3e")
+        self._color_btn = QPushButton()
+        self._color_btn.setFixedSize(32, 28)
+        self._color_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._update_color_btn()
+        self._color_btn.clicked.connect(self._pick_color)
+        color_row.addWidget(self._color_btn)
+
+        self._color_hex_label = QLabel(self._color_value)
+        self._color_hex_label.setStyleSheet(f"color: {colors.text_tertiary}; font-size: 11px; font-weight: normal;")
+        color_row.addWidget(self._color_hex_label)
+        color_row.addStretch()
+        template_layout.addLayout(color_row)
+
+        self._template_group = template_group
+        layout.addWidget(template_group)
+
+        # --- Buttons ---
+        btn_row = QHBoxLayout()
+        btn_row.addStretch()
+
+        cancel_btn = QPushButton(S.tab_notification.btn_cancel if hasattr(S, 'tab_notification') else "Cancel")
+        cancel_btn.setFixedHeight(30)
+        cancel_btn.setStyleSheet(f"""
+            QPushButton {{
+                background-color: {colors.bg_elevated};
+                color: {colors.text_primary};
+                border: 1px solid {colors.border_default};
+                border-radius: 4px;
+                font-size: 11px;
+                padding: 0 16px;
+            }}
+            QPushButton:hover {{
+                background-color: {colors.bg_tertiary};
+            }}
+        """)
+        cancel_btn.clicked.connect(self.reject)
+        btn_row.addWidget(cancel_btn)
+
+        save_btn = QPushButton(S.tab_notification.btn_save if hasattr(S, 'tab_notification') else "Save")
+        save_btn.setFixedHeight(30)
+        save_btn.setStyleSheet(f"""
+            QPushButton {{
+                background-color: {colors.interactive_primary};
+                color: white;
+                border: none;
+                border-radius: 4px;
+                font-size: 11px;
+                padding: 0 16px;
+            }}
+            QPushButton:hover {{
+                background-color: {colors.interactive_primary}dd;
+            }}
+        """)
+        save_btn.clicked.connect(self._on_save)
+        btn_row.addWidget(save_btn)
+
+        layout.addLayout(btn_row)
+
+        # Initial state
+        self._on_enable_toggled(self._enable_cb.isChecked())
+
+    def _on_enable_toggled(self, checked: bool):
+        self._template_group.setEnabled(checked)
+
+    def _update_color_btn(self):
+        self._color_btn.setStyleSheet(f"""
+            QPushButton {{
+                background-color: {self._color_value};
+                border: 1px solid rgba(255,255,255,0.3);
+                border-radius: 4px;
+            }}
+            QPushButton:hover {{
+                border: 1px solid rgba(255,255,255,0.6);
+            }}
+        """)
+
+    def _pick_color(self):
+        color = QColorDialog.getColor(
+            QColor(self._color_value), self,
+            S.tab_notification.color_picker_title if hasattr(S, 'tab_notification') else "Notification Color",
+        )
+        if color.isValid():
+            self._color_value = color.name()
+            self._update_color_btn()
+            self._color_hex_label.setText(self._color_value)
+
+    def _on_save(self):
+        self._result_config = {
+            "enabled": self._enable_cb.isChecked(),
+            "title": self._title_input.text(),
+            "message": self._message_input.text(),
+            "color": self._color_value,
+        }
+        self.accept()
+
+    def get_config(self) -> Optional[Dict[str, Any]]:
+        """Returns the config dict if saved, or None if cancelled."""
+        return self._result_config

--- a/source/src/ui/main_window/_execution.py
+++ b/source/src/ui/main_window/_execution.py
@@ -677,11 +677,24 @@ class ExecutionMixin:
     def _on_execution_finished_notification(self, title: str, message: str, success: bool, widget):
         """
         Envia notificacao apos execucao terminar.
+        Suppresses notification if the user is focused on the originating tab.
         """
         tab_index = self.session_tabs.indexOf(widget)
-        self._send_notification(title, message, success, tab_index)
 
-    def _send_notification(self, title: str, message: str, success: bool = True, tab_index: int = None):
+        # Skip notification if user is focused on this tab and window is active
+        if (self.isActiveWindow()
+                and tab_index >= 0
+                and tab_index == self.session_tabs.currentIndex()):
+            return
+
+        # Check per-tab custom notification color
+        color = None
+        tab_config = getattr(widget, '_tab_notification_config', None)
+        if tab_config and tab_config.get("enabled") and tab_config.get("color"):
+            color = tab_config["color"]
+        self._send_notification(title, message, success, tab_index, color=color)
+
+    def _send_notification(self, title: str, message: str, success: bool = True, tab_index: int = None, color: str = None):
         """
         Envia notificacao in-app (toast) no canto inferior direito.
 
@@ -709,6 +722,7 @@ class ExecutionMixin:
                 success=success,
                 on_click=on_click,
                 sound=sound,
+                color=color,
             )
         except Exception as e:
             logger.error(f"Error sending toast notification: {e}")

--- a/source/src/ui/main_window/_file_io.py
+++ b/source/src/ui/main_window/_file_io.py
@@ -174,6 +174,10 @@ class FileIOMixin:
                     blocks_data = dpw_data.get("blocks", [])
                     if blocks_data:
                         widget.editor.from_list(blocks_data)
+                    # Restore per-tab notification config
+                    notif_config = dpw_data.get("notification_config")
+                    if notif_config:
+                        widget.set_tab_notification_config(notif_config)
                 except json.JSONDecodeError:
                     # Fallback: treat as single SQL block
                     blocks = widget.editor.get_blocks()
@@ -546,6 +550,11 @@ class FileIOMixin:
                 "version": "1.0",
                 "blocks": blocks_data
             }
+
+            # Persist per-tab notification config if set
+            tab_notif = current_widget.get_tab_notification_config()
+            if tab_notif and tab_notif.get("enabled"):
+                dpw_content["notification_config"] = tab_notif
 
             with open(file_path, "w", encoding="utf-8") as f:
                 json.dump(dpw_content, f, indent=2, ensure_ascii=False)

--- a/tests/test_tab_notification.py
+++ b/tests/test_tab_notification.py
@@ -1,0 +1,296 @@
+"""
+Tests for per-tab notification feature:
+- TabNotificationDialog UI
+- result[row][col] template rendering
+- Per-tab config in SessionWidget
+- DPW persistence of notification config
+"""
+
+import pytest
+import json
+import pandas as pd
+from unittest.mock import MagicMock, patch
+from PyQt6.QtCore import Qt
+
+
+# ==================== RESULT REFERENCE RENDERING ====================
+
+
+class TestResultRefRendering:
+    """Test the result[N][M] reference resolution in templates."""
+
+    def _resolve(self, template, last_result):
+        from src.ui.components.session_widget import SessionWidget
+        return SessionWidget._resolve_result_refs(template, last_result)
+
+    def test_basic_result_ref(self):
+        """{{result[0][0]}} resolves to first cell of DataFrame."""
+        df = pd.DataFrame({"a": [42], "b": [99]})
+        result = self._resolve("Value: {{result[0][0]}}", df)
+        assert result == "Value: 42"
+
+    def test_result_ref_second_column(self):
+        """{{result[0][1]}} resolves to second column."""
+        df = pd.DataFrame({"a": [42], "b": [99]})
+        result = self._resolve("{{result[0][1]}}", df)
+        assert result == "99"
+
+    def test_result_ref_second_row(self):
+        """{{result[1][0]}} resolves to second row."""
+        df = pd.DataFrame({"x": [10, 20, 30]})
+        result = self._resolve("{{result[1][0]}}", df)
+        assert result == "20"
+
+    def test_multiple_result_refs(self):
+        """Multiple result refs in one template."""
+        df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+        result = self._resolve("{{result[0][0]}} / {{result[1][1]}}", df)
+        assert result == "1 / 4"
+
+    def test_result_ref_out_of_bounds(self):
+        """Out-of-bounds ref is left as-is."""
+        df = pd.DataFrame({"a": [42]})
+        result = self._resolve("{{result[5][0]}}", df)
+        assert result == "{{result[5][0]}}"
+
+    def test_result_ref_none_dataframe(self):
+        """None last_result leaves refs as-is."""
+        result = self._resolve("{{result[0][0]}}", None)
+        assert result == "{{result[0][0]}}"
+
+    def test_result_ref_mixed_with_vars(self):
+        """result refs mixed with {{var}} placeholders (vars not resolved here)."""
+        df = pd.DataFrame({"val": [123]})
+        result = self._resolve("{{tab_name}}: {{result[0][0]}}", df)
+        assert result == "{{tab_name}}: 123"
+
+    def test_result_ref_string_value(self):
+        """String values are resolved correctly."""
+        df = pd.DataFrame({"name": ["Alice"]})
+        result = self._resolve("{{result[0][0]}}", df)
+        assert result == "Alice"
+
+    def test_result_ref_no_refs_in_template(self):
+        """Template without result refs is returned unchanged."""
+        df = pd.DataFrame({"a": [1]})
+        result = self._resolve("No refs here", df)
+        assert result == "No refs here"
+
+    def test_result_ref_empty_dataframe(self):
+        """Empty DataFrame leaves refs as-is."""
+        df = pd.DataFrame()
+        result = self._resolve("{{result[0][0]}}", df)
+        assert result == "{{result[0][0]}}"
+
+
+# ==================== TAB NOTIFICATION DIALOG ====================
+
+
+class TestTabNotificationDialog:
+    """Test the TabNotificationDialog UI."""
+
+    @pytest.fixture
+    def dialog(self, qtbot):
+        from src.ui.dialogs.tab_notification_dialog import TabNotificationDialog
+        dlg = TabNotificationDialog(parent=None)
+        qtbot.addWidget(dlg)
+        return dlg
+
+    @pytest.fixture
+    def dialog_with_config(self, qtbot):
+        from src.ui.dialogs.tab_notification_dialog import TabNotificationDialog
+        config = {
+            "enabled": True,
+            "title": "My Tab",
+            "message": "Got {{result[0][0]}}",
+        }
+        dlg = TabNotificationDialog(current_config=config, parent=None)
+        qtbot.addWidget(dlg)
+        return dlg
+
+    def test_dialog_creates(self, dialog):
+        """Dialog is created without errors."""
+        assert dialog is not None
+
+    def test_default_enable_unchecked(self, dialog):
+        """Enable checkbox is unchecked by default (no config)."""
+        assert not dialog._enable_cb.isChecked()
+
+    def test_config_restores_enabled(self, dialog_with_config):
+        """Config with enabled=True restores checkbox."""
+        assert dialog_with_config._enable_cb.isChecked()
+
+    def test_config_restores_title(self, dialog_with_config):
+        """Config restores title input."""
+        assert dialog_with_config._title_input.text() == "My Tab"
+
+    def test_config_restores_message(self, dialog_with_config):
+        """Config restores message input."""
+        assert dialog_with_config._message_input.text() == "Got {{result[0][0]}}"
+
+    def test_save_returns_config(self, dialog, qtbot):
+        """Clicking save returns config dict."""
+        dialog._enable_cb.setChecked(True)
+        dialog._title_input.setText("Test Title")
+        dialog._message_input.setText("Test Msg")
+        dialog._on_save()
+        config = dialog.get_config()
+        assert config is not None
+        assert config["enabled"] is True
+        assert config["title"] == "Test Title"
+        assert config["message"] == "Test Msg"
+        assert "color" in config
+
+    def test_cancel_returns_none(self, dialog):
+        """get_config returns None if dialog not saved."""
+        config = dialog.get_config()
+        assert config is None
+
+    def test_template_group_disabled_when_unchecked(self, dialog):
+        """Template group is disabled when enable is unchecked."""
+        dialog._enable_cb.setChecked(False)
+        assert not dialog._template_group.isEnabled()
+
+    def test_template_group_enabled_when_checked(self, dialog):
+        """Template group is enabled when enable is checked."""
+        dialog._enable_cb.setChecked(True)
+        assert dialog._template_group.isEnabled()
+
+    def test_color_picker_exists(self, dialog):
+        """Color picker button exists."""
+        assert hasattr(dialog, '_color_btn')
+        assert hasattr(dialog, '_color_value')
+
+    def test_color_default_is_green(self, dialog):
+        """Default color is success green."""
+        assert dialog._color_value == "#1e8a3e"
+
+    def test_color_saved_in_config(self, dialog):
+        """Color is included in saved config."""
+        dialog._enable_cb.setChecked(True)
+        dialog._color_value = "#ff5500"
+        dialog._on_save()
+        config = dialog.get_config()
+        assert config["color"] == "#ff5500"
+
+    def test_color_restored_from_config(self, qtbot):
+        """Color is restored from existing config."""
+        from src.ui.dialogs.tab_notification_dialog import TabNotificationDialog
+        dlg = TabNotificationDialog(current_config={"enabled": True, "color": "#abc123"}, parent=None)
+        qtbot.addWidget(dlg)
+        assert dlg._color_value == "#abc123"
+
+
+# ==================== PER-TAB CONFIG ON SESSION WIDGET ====================
+
+
+class TestSessionWidgetTabNotification:
+    """Test the per-tab notification config on SessionWidget."""
+
+    @pytest.fixture
+    def widget(self, qtbot):
+        from src.ui.components.session_widget import SessionWidget
+        from src.core.session import Session
+        from src.core.theme_manager import ThemeManager
+
+        session = Session(session_id="test-1", title="TestTab")
+        tm = ThemeManager()
+        w = SessionWidget(session=session, theme_manager=tm)
+        qtbot.addWidget(w)
+        return w
+
+    def test_default_config_is_none(self, widget):
+        """Default tab notification config is None."""
+        assert widget.get_tab_notification_config() is None
+
+    def test_set_and_get_config(self, widget):
+        """Can set and retrieve tab notification config."""
+        config = {"enabled": True, "title": "T", "message": "M"}
+        widget.set_tab_notification_config(config)
+        assert widget.get_tab_notification_config() == config
+
+    def test_clear_config(self, widget):
+        """Can clear config by setting None."""
+        widget.set_tab_notification_config({"enabled": True, "title": "T", "message": "M"})
+        widget.set_tab_notification_config(None)
+        assert widget.get_tab_notification_config() is None
+
+
+# ==================== DPW PERSISTENCE ====================
+
+
+class TestDPWNotificationPersistence:
+    """Test that notification config is saved/loaded from DPW files."""
+
+    def test_save_includes_notification_config(self, tmp_path):
+        """DPW save includes notification_config when set."""
+        dpw_file = tmp_path / "test.dpw"
+        blocks_data = [{"language": "sql", "code": "SELECT 1", "height": 400, "block_name": "", "is_active": True}]
+        notif_config = {"enabled": True, "title": "My Tab", "message": "{{result[0][0]}}"}
+
+        dpw_content = {
+            "version": "1.0",
+            "blocks": blocks_data,
+        }
+        if notif_config and notif_config.get("enabled"):
+            dpw_content["notification_config"] = notif_config
+
+        dpw_file.write_text(json.dumps(dpw_content, indent=2), encoding="utf-8")
+
+        loaded = json.loads(dpw_file.read_text(encoding="utf-8"))
+        assert "notification_config" in loaded
+        assert loaded["notification_config"]["enabled"] is True
+        assert loaded["notification_config"]["title"] == "My Tab"
+        assert loaded["notification_config"]["message"] == "{{result[0][0]}}"
+
+    def test_save_excludes_disabled_config(self, tmp_path):
+        """DPW save does NOT include notification_config when disabled."""
+        dpw_file = tmp_path / "test.dpw"
+        blocks_data = [{"language": "sql", "code": "SELECT 1", "height": 400, "block_name": "", "is_active": True}]
+        notif_config = {"enabled": False, "title": "X", "message": "Y"}
+
+        dpw_content = {
+            "version": "1.0",
+            "blocks": blocks_data,
+        }
+        if notif_config and notif_config.get("enabled"):
+            dpw_content["notification_config"] = notif_config
+
+        dpw_file.write_text(json.dumps(dpw_content, indent=2), encoding="utf-8")
+
+        loaded = json.loads(dpw_file.read_text(encoding="utf-8"))
+        assert "notification_config" not in loaded
+
+    def test_load_restores_notification_config(self, tmp_path):
+        """Loading DPW with notification_config restores it."""
+        dpw_content = {
+            "version": "1.0",
+            "blocks": [],
+            "notification_config": {
+                "enabled": True,
+                "title": "Loaded Title",
+                "message": "Loaded Msg with {{result[0][1]}}",
+            },
+        }
+        dpw_file = tmp_path / "test.dpw"
+        dpw_file.write_text(json.dumps(dpw_content, indent=2), encoding="utf-8")
+
+        loaded = json.loads(dpw_file.read_text(encoding="utf-8"))
+        config = loaded.get("notification_config")
+        assert config is not None
+        assert config["enabled"] is True
+        assert config["title"] == "Loaded Title"
+        assert "{{result[0][1]}}" in config["message"]
+
+    def test_load_without_notification_config(self, tmp_path):
+        """Loading DPW without notification_config gives None."""
+        dpw_content = {
+            "version": "1.0",
+            "blocks": [],
+        }
+        dpw_file = tmp_path / "test.dpw"
+        dpw_file.write_text(json.dumps(dpw_content, indent=2), encoding="utf-8")
+
+        loaded = json.loads(dpw_file.read_text(encoding="utf-8"))
+        config = loaded.get("notification_config")
+        assert config is None


### PR DESCRIPTION
## Per-Tab Custom Notifications

Right-click any tab -> **Customize Notification** to configure a custom notification for that tab.

### Features

- **Custom templates**: Set title and message per tab with `{{variable}}` placeholders
- **`{{result[N][M]}}` syntax**: Access query result values directly in templates (e.g. `{{result[0][1]}}` gets row 0, column 1)
- **Custom color**: Color picker to choose the toast notification background color
- **Smart suppression**: Notifications are suppressed when the user is focused on the originating tab
- **DPW persistence**: Config is saved/restored with `.dpw` workspace files
- **Ephemeral**: Config lives in memory and dies when the tab is closed

### Files Changed

- `source/src/ui/dialogs/tab_notification_dialog.py` (new) - Dialog UI
- `source/src/ui/components/session_tabs.py` - Context menu action
- `source/src/ui/components/session_widget.py` - Config storage, `{{result[N][M]}}` rendering, per-tab notification emission
- `source/src/ui/components/toast_notification.py` - Custom color support
- `source/src/ui/main_window/_execution.py` - Focus-based suppression, color passthrough
- `source/src/ui/main_window/_file_io.py` - DPW save/load of notification config
- `source/src/language/{en-US,pt-BR}.json` - Translation keys

### Tests

- 30 new tests in `test_tab_notification.py` covering:
  - `{{result[N][M]}}` rendering (bounds, types, edge cases)
  - Dialog UI (create, restore config, save, color picker)
  - SessionWidget config get/set
  - DPW persistence (save with/without config, load/restore)