### PR TITLE
feat: output panel interativo com navegacao por linha e coluna

### DIFF
--- a/source/src/editors/block_editor.py
+++ b/source/src/editors/block_editor.py
@@ -361,6 +361,13 @@ class BlockEditor(QWidget):
         """Return currently executing block"""
         return self._current_executing_block
 
+    def get_current_block_index(self) -> Optional[int]:
+        """Return index of the currently executing block, or focused block as fallback."""
+        block = self._current_executing_block or self.get_focused_block()
+        if block and block in self._blocks:
+            return self._blocks.index(block)
+        return None
+
     # === Autocomplete Management ===
     
     def update_python_completions_all(self):
@@ -628,6 +635,29 @@ class BlockEditor(QWidget):
     def get_focused_block(self) -> Optional[CodeBlock]:
         """Return currently focused block"""
         return self._focused_block
+
+    def focus_block_at_line(self, block_index: int, line_number: int = 1, column: int = 0):
+        """Focus a block by index and scroll to a specific line/column.
+
+        Used by the Output panel to navigate to error locations.
+        """
+        if block_index < 0 or block_index >= len(self._blocks):
+            return
+        block = self._blocks[block_index]
+        # Ensure block is visible (expand if minimized)
+        if hasattr(block, 'is_minimized') and block.is_minimized:
+            block.toggle_minimize()
+        # Scroll to make the block visible
+        self.scroll_area.ensureWidgetVisible(block)
+        # Focus the editor
+        if hasattr(block, 'editor'):
+            block.editor.setFocus()
+            # Go to line/column (0-based in QScintilla)
+            if hasattr(block.editor, 'setCursorPosition'):
+                line_0 = max(0, line_number - 1)
+                col_0 = max(0, column - 1) if column > 0 else 0
+                block.editor.setCursorPosition(line_0, col_0)
+        self.block_focused.emit(block)
 
     def get_last_focused_block(self) -> Optional[CodeBlock]:
         """Return last block that had focus (even if not currently focused).

--- a/source/src/language/en-US.json
+++ b/source/src/language/en-US.json
@@ -419,13 +419,18 @@
   "output_panel": {
     "btn_clear": "Clear",
     "btn_copy": "Copy",
+    "filter_errors": "Errors",
     "level_ok": "[OK]",
     "level_warning": "[WARNING]",
     "level_error": "[ERROR]",
     "level_debug": "[DEBUG]",
     "dialog_log_detail": "Log Detail",
-    "btn_copy_detail": "Copy",
-    "btn_close_detail": "Close"
+    "detail_code": "Executed Code",
+    "detail_error": "Error / Traceback",
+    "detail_output": "Output",
+    "btn_copy_detail": "Copy Error",
+    "btn_close_detail": "Close",
+    "btn_resolve_copilot": "Resolve with Copilot"
   },
 
   "session_tabs": {

--- a/source/src/language/pt-BR.json
+++ b/source/src/language/pt-BR.json
@@ -421,13 +421,18 @@
   "output_panel": {
     "btn_clear": "Limpar",
     "btn_copy": "Copiar",
+    "filter_errors": "Erros",
     "level_ok": "[OK]",
     "level_warning": "[AVISO]",
     "level_error": "[ERRO]",
     "level_debug": "[DEBUG]",
     "dialog_log_detail": "Detalhe do Log",
-    "btn_copy_detail": "Copiar",
-    "btn_close_detail": "Fechar"
+    "detail_code": "Codigo Executado",
+    "detail_error": "Erro / Traceback",
+    "detail_output": "Saida",
+    "btn_copy_detail": "Copiar Erro",
+    "btn_close_detail": "Fechar",
+    "btn_resolve_copilot": "Resolver com Copilot"
   },
 
   "session_tabs": {

--- a/source/src/ui/components/output_panel.py
+++ b/source/src/ui/components/output_panel.py
@@ -1,72 +1,233 @@
 """
-Output/Logs Panel
+Output/Logs Panel - Structured, interactive log system.
 
-Displays log messages, command output, and errors.
+Each log entry is a rich item with metadata (block info, line number,
+timestamp, duration). Errors are navigable (double-click goes to error
+line) and inspectable (eye icon opens detail dialog).
 """
 
-from PyQt6.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QTextEdit, QPushButton, QDialog, QDialogButtonBox
-from PyQt6.QtCore import Qt, pyqtSignal
-from PyQt6.QtGui import QFont, QTextCursor
+import re
+from dataclasses import dataclass, field
 from datetime import datetime
-import html as html_module
+from typing import Optional, List
 
-from .buttons import IconButton, GhostButton
+from PyQt6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QListWidget, QListWidgetItem,
+    QLabel, QPushButton, QSizePolicy, QApplication,
+)
+from PyQt6.QtCore import Qt, pyqtSignal, QSize
+from PyQt6.QtGui import QFont
 
+from .buttons import GhostButton
 from src.language import S
 
 try:
     import qtawesome as qta
-
     HAS_QTAWESOME = True
 except ImportError:
     HAS_QTAWESOME = False
 
 
+# ---------------------------------------------------------------------------
+# Data Model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class LogEntry:
+    """Structured log entry with full execution context."""
+    timestamp: datetime = field(default_factory=datetime.now)
+    level: str = "info"           # info, success, warning, error, debug
+    log_type: str = ""            # SQL, PYTHON, SYSTEM, etc.
+    message: str = ""             # Short display message
+    detail: str = ""              # Full error / traceback
+    block_index: Optional[int] = None
+    block_name: str = ""
+    line_number: Optional[int] = None   # Parsed error line within the block
+    column_number: Optional[int] = None  # Parsed error column within the line
+    duration_ms: Optional[float] = None
+    code_snippet: str = ""        # The code that was executed
+    connection_name: str = ""
+    database_name: str = ""
+
+
+def _find_token_in_sql(token: str, sql: str) -> Optional[tuple]:
+    """Find a token in the SQL code and return (line, column) 1-based.
+
+    Used as fallback when the DB error message doesn't include line info
+    but mentions a specific identifier (column name, table name, etc.).
+    """
+    if not token or not sql:
+        return None
+    # Search case-insensitive
+    sql_lower = sql.lower()
+    token_lower = token.lower()
+    pos = sql_lower.find(token_lower)
+    if pos < 0:
+        return None
+    # Convert char offset to line/column
+    before = sql[:pos]
+    line = before.count('\n') + 1
+    last_nl = before.rfind('\n')
+    col = pos - last_nl if last_nl >= 0 else pos + 1
+    return (line, col)
+
+
+def _extract_error_token(error_text: str) -> Optional[str]:
+    """Extract the problematic identifier from a DB error message.
+
+    Patterns recognized:
+      - Unknown column 'xxx'
+      - Invalid column name 'xxx'
+      - column "xxx" does not exist
+      - Invalid object name 'xxx'
+      - Table 'xxx' doesn't exist
+      - near 'xxx'
+      - near "xxx"
+    """
+    patterns = [
+        r"Unknown column\s+'([^']+)'",
+        r"Invalid column name\s+'([^']+)'",
+        r'column\s+"([^"]+)"\s+does not exist',
+        r"Invalid object name\s+'([^']+)'",
+        r"Table\s+'([^']+)'\s+doesn't exist",
+        r"relation\s+\"([^\"]+)\"\s+does not exist",
+        r"near\s+'([^']+)'",
+        r'near\s+"([^"]+)"',
+    ]
+    for pat in patterns:
+        m = re.search(pat, error_text, re.IGNORECASE)
+        if m:
+            token = m.group(1)
+            # For qualified names like 'pa.adicionalid', also try the last part
+            return token
+    return None
+
+
+def parse_error_line(error_text: str, log_type: str = "SQL") -> Optional[int]:
+    """Extract line number from an error message.
+
+    Supports:
+      SQL Server : 'Line 5' / 'line 5'
+      MySQL      : 'at line 5'
+      PostgreSQL : 'LINE 5:'
+      Python     : 'File "<string>", line 5'
+      Generic    : 'line N' anywhere
+    """
+    if not error_text:
+        return None
+
+    patterns = [
+        # SQL Server: Msg N, Level N, State N, Line N
+        r'Line\s+(\d+)',
+        # MySQL: ... at line N
+        r'at\s+line\s+(\d+)',
+        # PostgreSQL: LINE N:
+        r'LINE\s+(\d+)\s*:',
+        # Python traceback: File "...", line N
+        r'line\s+(\d+)',
+    ]
+    for pat in patterns:
+        m = re.search(pat, error_text, re.IGNORECASE)
+        if m:
+            return int(m.group(1))
+    return None
+
+
+def parse_error_position(error_text: str, sql_code: str = "",
+                         log_type: str = "SQL") -> tuple:
+    """Extract (line, column) from an error, with token-based fallback.
+
+    Returns (line_or_None, column_or_None).
+    """
+    line = parse_error_line(error_text, log_type)
+    col = None
+
+    # If we already have a line from the message, try to also find column
+    # via token search within that line
+    if line and sql_code:
+        token = _extract_error_token(error_text)
+        if token:
+            pos = _find_token_in_sql(token, sql_code)
+            if pos and pos[0] == line:
+                col = pos[1]
+
+    # Fallback: no line in message but we have the SQL and a token
+    if line is None and sql_code:
+        token = _extract_error_token(error_text)
+        if token:
+            pos = _find_token_in_sql(token, sql_code)
+            if pos:
+                line, col = pos
+
+    return (line, col)
+
+
+# ---------------------------------------------------------------------------
+# OutputPanel Widget
+# ---------------------------------------------------------------------------
+
 class OutputPanel(QWidget):
-    """Output/logs panel with formatting"""
+    """Interactive output/logs panel with structured log entries."""
 
     # Signals
     cleared = pyqtSignal()
+    navigate_to_block = pyqtSignal(int, int, int)  # (block_index, line_number, column_number)
+    resolve_with_copilot = pyqtSignal(dict)    # context dict for Copilot
 
     def __init__(self, theme_manager=None, parent=None):
         super().__init__(parent)
-
         self.theme_manager = theme_manager
+        self._entries: List[LogEntry] = []
+        self._filter_errors_only = False
         self._setup_ui()
         self._apply_theme()
 
+    # ------------------------------------------------------------------
+    # UI Setup
+    # ------------------------------------------------------------------
+
     def _setup_ui(self):
-        """Configure UI"""
+        from src.design_system.tokens import get_colors
+        colors = get_colors()
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
 
-        # Output toolbar
+        # --- Toolbar ---
         toolbar = QWidget()
+        toolbar.setObjectName("outputToolbar")
         toolbar_layout = QHBoxLayout(toolbar)
-        toolbar_layout.setContentsMargins(5, 3, 5, 3)
-        toolbar_layout.setSpacing(5)
+        toolbar_layout.setContentsMargins(8, 4, 8, 4)
+        toolbar_layout.setSpacing(6)
+
+        # Filter: Errors only toggle
+        self._filter_btn = GhostButton(S.output_panel.filter_errors)
+        if HAS_QTAWESOME:
+            self._filter_btn.setIcon(qta.icon("mdi.filter-outline", color=colors.text_tertiary))
+        self._filter_btn.setCheckable(True)
+        self._filter_btn.setChecked(False)
+        self._filter_btn.toggled.connect(self._on_filter_toggled)
+        toolbar_layout.addWidget(self._filter_btn)
 
         toolbar_layout.addStretch()
 
         # Clear button
         self.btn_clear = GhostButton(S.output_panel.btn_clear)
         if HAS_QTAWESOME:
-            from src.design_system.tokens import get_colors
-            colors = get_colors()
-            self.btn_clear.setIcon(qta.icon("fa5s.trash", color=colors.text_tertiary))
+            self.btn_clear.setIcon(qta.icon("mdi.trash-can-outline", color=colors.text_tertiary))
         self.btn_clear.clicked.connect(self.clear)
         toolbar_layout.addWidget(self.btn_clear)
 
         # Copy button
         self.btn_copy = GhostButton(S.output_panel.btn_copy)
         if HAS_QTAWESOME:
-            self.btn_copy.setIcon(qta.icon("fa5s.copy", color=colors.text_tertiary))
+            self.btn_copy.setIcon(qta.icon("mdi.content-copy", color=colors.text_tertiary))
         self.btn_copy.clicked.connect(self._copy_to_clipboard)
         toolbar_layout.addWidget(self.btn_copy)
 
         toolbar.setStyleSheet(f"""
-            QWidget {{
+            #outputToolbar {{
                 background-color: {colors.bg_secondary};
                 border: none;
                 border-bottom: 1px solid {colors.border_default};
@@ -74,168 +235,298 @@ class OutputPanel(QWidget):
         """)
         layout.addWidget(toolbar)
 
-        # Text area
-        self.text_edit = QTextEdit()
-        self.text_edit.setReadOnly(True)
-        self.text_edit.setFont(QFont("Consolas", 10))
-        self.text_edit.mouseDoubleClickEvent = self._on_double_click
-        layout.addWidget(self.text_edit)
+        # --- Log list ---
+        self._list = QListWidget()
+        self._list.setSelectionMode(QListWidget.SelectionMode.SingleSelection)
+        self._list.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self._list.setVerticalScrollMode(QListWidget.ScrollMode.ScrollPerPixel)
+        self._list.setFont(QFont("Consolas", 10))
+        self._list.setSpacing(0)
+        self._list.itemDoubleClicked.connect(self._on_item_double_clicked)
+        layout.addWidget(self._list)
 
     def _apply_theme(self):
-        """Apply theme"""
         from src.design_system.tokens import get_colors, SCROLLBAR_STYLE
-        tokens = get_colors()
-        
-        if self.theme_manager:
-            colors = self.theme_manager.get_app_colors()
-        else:
-            colors = {"background": tokens.bg_primary, "foreground": tokens.text_primary}
+        colors = get_colors()
 
-        self.text_edit.setStyleSheet(f"""
-            QTextEdit {{
-                background-color: {colors["background"]};
-                color: {colors["foreground"]};
+        bg = colors.bg_primary
+        fg = colors.text_primary
+        border = colors.border_default
+        hover = colors.bg_elevated
+
+        self._list.setStyleSheet(f"""
+            QListWidget {{
+                background-color: {bg};
+                color: {fg};
                 border: none;
-                padding: 12px;
-                font-size: 13px;
-                line-height: 1.5;
+                outline: none;
+            }}
+            QListWidget::item {{
+                border-bottom: 1px solid {border};
+                padding: 0px;
+            }}
+            QListWidget::item:selected {{
+                background-color: {hover};
+            }}
+            QListWidget::item:hover:!selected {{
+                background-color: {hover};
             }}
             {SCROLLBAR_STYLE}
         """)
 
     def set_theme_manager(self, theme_manager):
-        """Set theme manager"""
         self.theme_manager = theme_manager
         self._apply_theme()
 
+    # ------------------------------------------------------------------
+    # Public API  (new structured)
+    # ------------------------------------------------------------------
+
+    def add_entry(self, entry: LogEntry):
+        """Add a structured LogEntry to the panel."""
+        self._entries.append(entry)
+        if self._filter_errors_only and entry.level not in ("error", "warning"):
+            return  # filtered out
+        self._add_item_for_entry(entry)
+
+    # ------------------------------------------------------------------
+    # Public API  (backward-compatible)
+    # ------------------------------------------------------------------
+
     def append(self, text: str, level: str = "info"):
-        """Add text to output
-
-        Args:
-            text: Text to add
-            level: Level ('info', 'success', 'warning', 'error')
-        """
-        from src.design_system.tokens import get_colors
-        tokens = get_colors()
-        
-        timestamp = datetime.now().strftime("%H:%M:%S")
-
-        colors = {"info": tokens.info, "success": tokens.success, "warning": tokens.warning, "error": tokens.danger, "debug": tokens.text_tertiary}
-        color = colors.get(level, colors["info"])
-
-        # Icons by level
-        icons = {"info": "", "success": S.output_panel.level_ok, "warning": S.output_panel.level_warning, "error": S.output_panel.level_error, "debug": S.output_panel.level_debug}
-        icon = icons.get(level, "")
-
-        # Escape HTML and convert \n to <br> to preserve formatting
-        safe_text = html_module.escape(text).replace("\n", "<br>")
-
-        if icon:
-            html = f'<span style="color: {tokens.text_tertiary};">[{timestamp}]</span> <span style="color: {color};">{icon} {safe_text}</span><br>'
-        else:
-            html = f'<span style="color: {tokens.text_tertiary};">[{timestamp}]</span> <span style="color: {color};">{safe_text}</span><br>'
-
-        self.text_edit.append(html)
-
-        # Scroll to end
-        cursor = self.text_edit.textCursor()
-        cursor.movePosition(QTextCursor.MoveOperation.End)
-        self.text_edit.setTextCursor(cursor)
+        entry = LogEntry(
+            timestamp=datetime.now(),
+            level=level,
+            message=text,
+        )
+        self.add_entry(entry)
 
     def append_output(self, text: str, error: bool = False):
-        """Compatibility method with old code"""
-        level = "error" if error else "info"
-        self.append(text, level)
+        self.append(text, "error" if error else "info")
 
     def log(self, text: str):
-        """Add info log"""
         self.append(text, "info")
 
     def success(self, text: str):
-        """Add success log"""
         self.append(text, "success")
 
     def warning(self, text: str):
-        """Add warning log"""
         self.append(text, "warning")
 
     def error(self, text: str):
-        """Add error log"""
         self.append(text, "error")
 
     def debug(self, text: str):
-        """Adiciona log de debug"""
         self.append(text, "debug")
 
-    def _on_double_click(self, event):
-        """Abre dialogo com log formatado ao dar duplo-clique"""
-        cursor = self.text_edit.cursorForPosition(event.pos())
-        block = cursor.block()
-        if not block.isValid() or not block.text().strip():
-            QTextEdit.mouseDoubleClickEvent(self.text_edit, event)
-            return
-
-        plain_text = block.text()
-
-        dlg = QDialog(self)
-        dlg.setWindowTitle(S.output_panel.dialog_log_detail)
-        dlg.resize(720, 400)
-        dlg.setMinimumSize(400, 200)
-
-        layout = QVBoxLayout(dlg)
-        layout.setContentsMargins(8, 8, 8, 8)
-
-        detail_edit = QTextEdit(dlg)
-        detail_edit.setReadOnly(True)
-        detail_edit.setFont(QFont("Consolas", 10))
-        detail_edit.setPlainText(plain_text)
-        from src.design_system.tokens import get_colors
-        colors = get_colors()
-        detail_edit.setStyleSheet(
-            f"QTextEdit {{ background: {colors.bg_primary}; color: {colors.text_primary}; border: none; }}"
-        )
-        layout.addWidget(detail_edit)
-
-        btn_layout = QHBoxLayout()
-        btn_layout.addStretch()
-
-        copy_btn = QPushButton(S.output_panel.btn_copy_detail)
-        copy_btn.clicked.connect(lambda: (
-            __import__("PyQt6.QtWidgets", fromlist=["QApplication"]).QApplication.clipboard().setText(plain_text)
-        ))
-        btn_layout.addWidget(copy_btn)
-
-        close_btn = QPushButton(S.output_panel.btn_close_detail)
-        close_btn.clicked.connect(dlg.accept)
-        btn_layout.addWidget(close_btn)
-
-        layout.addLayout(btn_layout)
-        dlg.exec()
-
     def clear(self):
-        """Limpa o output"""
-        self.text_edit.clear()
+        self._entries.clear()
+        self._list.clear()
         self.cleared.emit()
 
-    def _copy_to_clipboard(self):
-        """Copy content to clipboard"""
-        from PyQt6.QtWidgets import QApplication
-
-        text = self.text_edit.toPlainText()
-        QApplication.clipboard().setText(text)
-
     def get_text(self) -> str:
-        """Retorna texto plano"""
-        return self.text_edit.toPlainText()
-
-    def get_html(self) -> str:
-        """Retorna HTML"""
-        return self.text_edit.toHtml()
+        lines = []
+        for e in self._entries:
+            ts = e.timestamp.strftime("%H:%M:%S")
+            prefix = f"[{ts}]"
+            if e.log_type:
+                prefix += f"[{e.log_type}]"
+            lines.append(f"{prefix} {e.message}")
+        return "\n".join(lines)
 
     def toPlainText(self) -> str:
-        """Compatibilidade: retorna texto plano"""
-        return self.text_edit.toPlainText()
+        return self.get_text()
+
+    def get_html(self) -> str:
+        return self.get_text()
+
+    def _copy_to_clipboard(self):
+        QApplication.clipboard().setText(self.get_text())
+
+    # Compat: some code accesses .text_edit or .verticalScrollBar()
+    @property
+    def text_edit(self):
+        return self._list
 
     def verticalScrollBar(self):
-        """Compatibilidade: retorna barra de scroll vertical"""
-        return self.text_edit.verticalScrollBar()
+        return self._list.verticalScrollBar()
+
+    # ------------------------------------------------------------------
+    # Item rendering
+    # ------------------------------------------------------------------
+
+    def _add_item_for_entry(self, entry: LogEntry):
+        from src.design_system.tokens import get_colors
+        colors = get_colors()
+
+        widget = QWidget()
+        widget.setObjectName("logRow")
+        row = QHBoxLayout(widget)
+        row.setContentsMargins(10, 6, 10, 6)
+        row.setSpacing(8)
+
+        level_colors = {
+            "info": colors.info,
+            "success": colors.success,
+            "warning": colors.warning,
+            "error": colors.danger,
+            "debug": colors.text_tertiary,
+        }
+        level_icons = {
+            "info": "mdi.information-outline",
+            "success": "mdi.check-circle-outline",
+            "warning": "mdi.alert-outline",
+            "error": "mdi.close-circle-outline",
+            "debug": "mdi.bug-outline",
+        }
+        lcolor = level_colors.get(entry.level, colors.info)
+
+        # 1. Level icon
+        if HAS_QTAWESOME:
+            icon_name = level_icons.get(entry.level, "mdi.information-outline")
+            icon_label = QLabel()
+            icon_label.setPixmap(qta.icon(icon_name, color=lcolor).pixmap(QSize(16, 16)))
+            icon_label.setFixedWidth(18)
+            row.addWidget(icon_label)
+
+        # 2. Timestamp
+        ts_label = QLabel(entry.timestamp.strftime("%H:%M:%S"))
+        ts_label.setStyleSheet(f"color: {colors.text_tertiary}; font-size: 11px; font-family: Consolas;")
+        ts_label.setFixedWidth(58)
+        row.addWidget(ts_label)
+
+        # 3. Block badge (if applicable)
+        if entry.block_index is not None:
+            badge_text = entry.block_name or f"Block {entry.block_index + 1}"
+            badge = QLabel(badge_text)
+            badge.setStyleSheet(f"""
+                QLabel {{
+                    background-color: {lcolor}30;
+                    color: {lcolor};
+                    font-size: 10px;
+                    font-weight: bold;
+                    padding: 1px 6px;
+                    border-radius: 3px;
+                    font-family: Consolas;
+                }}
+            """)
+            badge.setFixedHeight(18)
+            row.addWidget(badge)
+
+            # Line:Column badge
+            if entry.line_number is not None:
+                pos_text = f"L{entry.line_number}"
+                if entry.column_number is not None:
+                    pos_text += f":{entry.column_number}"
+                line_badge = QLabel(pos_text)
+                line_badge.setStyleSheet(f"""
+                    QLabel {{
+                        color: {colors.text_tertiary};
+                        font-size: 10px;
+                        padding: 1px 4px;
+                        font-family: Consolas;
+                    }}
+                """)
+                line_badge.setFixedHeight(18)
+                row.addWidget(line_badge)
+
+        # 4. Message text
+        msg_label = QLabel(self._truncate(entry.message, 200))
+        msg_label.setStyleSheet(f"color: {lcolor}; font-size: 12px; font-family: Consolas;")
+        msg_label.setWordWrap(False)
+        msg_label.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
+        row.addWidget(msg_label, 1)
+
+        # 5. Duration badge
+        if entry.duration_ms is not None:
+            dur_text = self._format_duration(entry.duration_ms)
+            dur_label = QLabel(dur_text)
+            dur_label.setStyleSheet(f"color: {colors.text_tertiary}; font-size: 10px; font-family: Consolas;")
+            dur_label.setFixedWidth(52)
+            dur_label.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+            row.addWidget(dur_label)
+
+        # 6. Eye button (for errors/warnings with detail)
+        if entry.level in ("error", "warning") or entry.detail:
+            eye_btn = QPushButton()
+            if HAS_QTAWESOME:
+                eye_btn.setIcon(qta.icon("mdi.eye-outline", color=colors.text_tertiary))
+            eye_btn.setFixedSize(24, 24)
+            eye_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+            eye_btn.setStyleSheet(f"""
+                QPushButton {{
+                    background: transparent;
+                    border: none;
+                    border-radius: 4px;
+                }}
+                QPushButton:hover {{
+                    background-color: {colors.bg_elevated};
+                }}
+            """)
+            eye_btn.clicked.connect(lambda checked, e=entry: self._open_detail_dialog(e))
+            row.addWidget(eye_btn)
+
+        # Create list item
+        item = QListWidgetItem()
+        item.setData(Qt.ItemDataRole.UserRole, len(self._entries) - 1)  # index into _entries
+        item.setSizeHint(QSize(0, max(32, widget.sizeHint().height())))
+        self._list.addItem(item)
+        self._list.setItemWidget(item, widget)
+
+        # Scroll to bottom
+        self._list.scrollToBottom()
+
+    # ------------------------------------------------------------------
+    # Interactions
+    # ------------------------------------------------------------------
+
+    def _on_item_double_clicked(self, item: QListWidgetItem):
+        idx = item.data(Qt.ItemDataRole.UserRole)
+        if idx is None or idx >= len(self._entries):
+            return
+        entry = self._entries[idx]
+        if entry.block_index is not None:
+            line = entry.line_number or 1
+            col = entry.column_number or 0
+            self.navigate_to_block.emit(entry.block_index, line, col)
+        else:
+            self._open_detail_dialog(entry)
+
+    def _open_detail_dialog(self, entry: LogEntry):
+        from src.ui.dialogs.log_detail_dialog import LogDetailDialog
+        dlg = LogDetailDialog(entry, parent=self)
+        dlg.resolve_requested.connect(lambda ctx: self.resolve_with_copilot.emit(ctx))
+        dlg.exec()
+
+    def _on_filter_toggled(self, checked: bool):
+        self._filter_errors_only = checked
+        self._rebuild_list()
+
+    def _rebuild_list(self):
+        self._list.clear()
+        for entry in self._entries:
+            if self._filter_errors_only and entry.level not in ("error", "warning"):
+                continue
+            self._add_item_for_entry(entry)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _truncate(text: str, max_len: int) -> str:
+        first_line = text.split("\n")[0]
+        if len(first_line) > max_len:
+            return first_line[:max_len] + "..."
+        return first_line
+
+    @staticmethod
+    def _format_duration(ms: float) -> str:
+        if ms < 1000:
+            return f"{ms:.0f}ms"
+        s = ms / 1000
+        if s < 60:
+            return f"{s:.1f}s"
+        m = int(s // 60)
+        sec = s % 60
+        return f"{m}m{sec:.0f}s"

--- a/source/src/ui/components/session_widget.py
+++ b/source/src/ui/components/session_widget.py
@@ -16,6 +16,7 @@ import logging
 from io import StringIO
 from typing import Optional, Dict, Any
 from datetime import datetime
+import time
 
 from src.core.session import Session
 from src.core.theme_manager import ThemeManager
@@ -202,6 +203,14 @@ class SessionWidget(QWidget):
         self._queue_last_connection: str = ""
         self._queue_last_database: str = ""
 
+        # Per-execution context tracking (for structured LogEntry)
+        self._execution_start_time: float = 0.0
+        self._current_query: str = ""
+        self._current_code: str = ""
+        self._current_block_index: Optional[int] = None
+        self._current_connection_name_exec: str = ""
+        self._current_database_name_exec: str = ""
+
         # Overlay de loading
         self._loading_overlay: Optional[QLabel] = None
 
@@ -376,6 +385,18 @@ class SessionWidget(QWidget):
             output = main_window.global_output_panel if main_window else None
         if output:
             output.log(text)
+
+    def _log_entry(self, entry):
+        """Log a structured LogEntry to this session's output panel."""
+        info = self._get_own_panels()
+        output = info["output"] if info else None
+        if not output:
+            main_window = self._get_main_window()
+            output = main_window.global_output_panel if main_window else None
+        if output:
+            output.add_entry(entry)
+            if entry.level == "error":
+                self._show_output()
 
     def _clear_output(self):
         """Limpa output desta sessao"""
@@ -598,6 +619,13 @@ class SessionWidget(QWidget):
         self.status_changed.emit(S.session_widget.executing_sql.format(conn_label=conn_label))
         self.execution_started.emit()  # Notify main_window to show running indicator
 
+        # Track execution context for structured logs
+        self._execution_start_time = time.time()
+        self._current_query = query
+        self._current_block_index = self.editor.get_current_block_index()
+        self._current_connection_name_exec = connection_name or self.session.connection_name or ""
+        self._current_database_name_exec = database_name or ""
+
         # Criar worker e thread
         self._sql_thread = QThread()
         self._sql_worker = SessionSqlWorker(connector, query)
@@ -655,8 +683,27 @@ class SessionWidget(QWidget):
         current_block = self.editor.get_current_executing_block()
         self.editor.mark_execution_finished(current_block)
 
+        # Compute execution duration
+        duration_ms = (time.time() - self._execution_start_time) * 1000 if self._execution_start_time else None
+
         if error:
-            self.append_output(self._format_log("SQL", f"ERROR: {error}"), error=True)
+            from src.ui.components.output_panel import LogEntry, parse_error_position
+            err_line, err_col = parse_error_position(error, self._current_query, "SQL")
+            entry = LogEntry(
+                level="error",
+                log_type="SQL",
+                message=f"ERROR: {error.split(chr(10))[0][:120]}",
+                detail=error,
+                block_index=self._current_block_index,
+                block_name=self._current_block_name or "",
+                line_number=err_line,
+                column_number=err_col,
+                duration_ms=duration_ms,
+                code_snippet=self._current_query,
+                connection_name=self._current_connection_name_exec,
+                database_name=self._current_database_name_exec,
+            )
+            self._log_entry(entry)
             self.session.finish_execution(False, f"Error: {error[:50]}...")
             self.status_changed.emit(S.session_widget.status_sql_error)
             self._queue_had_error = True
@@ -675,13 +722,24 @@ class SessionWidget(QWidget):
             if isinstance(df, list):
                 # Multiple DataFrames - create variables
                 total_rows = sum(len(d) for d in df)
-                self.append_output(self._format_log("SQL", S.session_widget.sql_multi_result.format(count=len(df), rows=f"{total_rows:,}")))
+                from src.ui.components.output_panel import LogEntry
+                msg = S.session_widget.sql_multi_result.format(count=len(df), rows=f"{total_rows:,}")
+                entry = LogEntry(
+                    level="success", log_type="SQL", message=msg,
+                    block_index=self._current_block_index,
+                    block_name=self._current_block_name or "",
+                    duration_ms=duration_ms,
+                    code_snippet=self._current_query,
+                    connection_name=self._current_connection_name_exec,
+                    database_name=self._current_database_name_exec,
+                )
+                self._log_entry(entry)
 
                 # Create variables: test, test1, test2, ...
                 for i, dataframe in enumerate(df):
                     var_name = var_base if i == 0 else f"{var_base}{i}"
                     self.session.set_variable(var_name, dataframe)
-                    self.append_output(self._format_log("SQL", S.session_widget.sql_var_rows.format(var_name=var_name, rows=f"{len(dataframe):,}")))
+                    self._log(S.session_widget.sql_var_rows.format(var_name=var_name, rows=f"{len(dataframe):,}"))
 
                 # Display only last DataFrame in grid
                 last_df = df[-1]
@@ -699,7 +757,18 @@ class SessionWidget(QWidget):
                 # Single DataFrame
                 rows = len(df) if df is not None else 0
                 var_name = var_base
-                self.append_output(self._format_log("SQL", S.session_widget.sql_single_result.format(rows=f"{rows:,}", var_name=var_name)))
+                from src.ui.components.output_panel import LogEntry
+                msg = S.session_widget.sql_single_result.format(rows=f"{rows:,}", var_name=var_name)
+                entry = LogEntry(
+                    level="success", log_type="SQL", message=msg,
+                    block_index=self._current_block_index,
+                    block_name=self._current_block_name or "",
+                    duration_ms=duration_ms,
+                    code_snippet=self._current_query,
+                    connection_name=self._current_connection_name_exec,
+                    database_name=self._current_database_name_exec,
+                )
+                self._log_entry(entry)
                 self._set_results(df, var_name)
                 self.session.finish_execution(True, S.session_widget.status_sql_rows.format(rows=f"{rows:,}"))
                 self.status_changed.emit(S.session_widget.status_sql_rows.format(rows=f"{rows:,}"))
@@ -763,6 +832,13 @@ class SessionWidget(QWidget):
         self.session.start_execution("python")
         self.status_changed.emit(S.session_widget.executing_python)
         self.execution_started.emit()  # Notify main_window to show running indicator
+
+        # Track execution context for structured logs
+        self._execution_start_time = time.time()
+        self._current_code = code
+        self._current_block_index = self.editor.get_current_block_index()
+        self._current_connection_name_exec = ""
+        self._current_database_name_exec = ""
         
         # Prepare namespace with df if exists
         namespace = self.session.namespace.copy()
@@ -818,8 +894,25 @@ class SessionWidget(QWidget):
         current_block = self.editor.get_current_executing_block()
         self.editor.mark_execution_finished(current_block)
 
+        # Compute execution duration
+        duration_ms = (time.time() - self._execution_start_time) * 1000 if self._execution_start_time else None
+
         if error:
-            self.append_output(self._format_log("PYTHON", f"ERROR:\n{error}"), error=True)
+            from src.ui.components.output_panel import LogEntry, parse_error_position
+            err_line, err_col = parse_error_position(error, self._current_code, "PYTHON")
+            entry = LogEntry(
+                level="error",
+                log_type="PYTHON",
+                message=f"ERROR: {error.split(chr(10))[-2] if chr(10) in error else error[:120]}",
+                detail=error,
+                block_index=self._current_block_index,
+                block_name=self._current_block_name or "",
+                line_number=err_line,
+                column_number=err_col,
+                duration_ms=duration_ms,
+                code_snippet=self._current_code,
+            )
+            self._log_entry(entry)
             self.session.finish_execution(False, S.session_widget.status_python_error)
             self.status_changed.emit(S.session_widget.status_python_error)
             self._queue_had_error = True

--- a/source/src/ui/dialogs/log_detail_dialog.py
+++ b/source/src/ui/dialogs/log_detail_dialog.py
@@ -1,0 +1,246 @@
+"""
+Log Detail Dialog - Rich view of a single log entry.
+
+Shows timestamp, duration, block info, code snippet, full error/traceback,
+and action buttons (Copy Error, Resolve with Copilot).
+"""
+
+from PyQt6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QTextEdit,
+    QPushButton, QWidget, QApplication, QSizePolicy,
+)
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QFont
+
+from src.design_system.tokens import get_colors, RADIUS, SCROLLBAR_STYLE
+from src.language import S
+
+try:
+    import qtawesome as qta
+    HAS_QTAWESOME = True
+except ImportError:
+    HAS_QTAWESOME = False
+
+
+class LogDetailDialog(QDialog):
+    """Full detail view for a single LogEntry."""
+
+    resolve_requested = pyqtSignal(dict)  # context dict for Copilot
+
+    def __init__(self, entry, parent=None):
+        super().__init__(parent)
+        self._entry = entry
+        self._setup_ui()
+
+    def _setup_ui(self):
+        from src.ui.components.output_panel import LogEntry
+        colors = get_colors()
+        entry = self._entry
+
+        self.setWindowTitle(S.output_panel.dialog_log_detail)
+        self.resize(780, 520)
+        self.setMinimumSize(500, 300)
+        self.setStyleSheet(f"""
+            QDialog {{
+                background-color: {colors.bg_primary};
+                color: {colors.text_primary};
+            }}
+        """)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(16, 16, 16, 16)
+        layout.setSpacing(12)
+
+        # --- Header info bar ---
+        header = QWidget()
+        header.setStyleSheet(f"""
+            QWidget {{
+                background-color: {colors.bg_secondary};
+                border-radius: {RADIUS}px;
+            }}
+        """)
+        h_layout = QHBoxLayout(header)
+        h_layout.setContentsMargins(12, 8, 12, 8)
+        h_layout.setSpacing(16)
+
+        level_colors = {
+            "info": colors.info,
+            "success": colors.success,
+            "warning": colors.warning,
+            "error": colors.danger,
+            "debug": colors.text_tertiary,
+        }
+        lcolor = level_colors.get(entry.level, colors.info)
+
+        # Level badge
+        level_label = QLabel(entry.level.upper())
+        level_label.setStyleSheet(f"""
+            QLabel {{
+                background-color: {lcolor}30;
+                color: {lcolor};
+                font-size: 11px;
+                font-weight: bold;
+                padding: 2px 8px;
+                border-radius: 3px;
+            }}
+        """)
+        h_layout.addWidget(level_label)
+
+        # Timestamp
+        ts_label = QLabel(entry.timestamp.strftime("%H:%M:%S"))
+        ts_label.setStyleSheet(f"color: {colors.text_tertiary}; font-size: 12px; font-family: Consolas;")
+        h_layout.addWidget(ts_label)
+
+        # Block info
+        if entry.block_index is not None:
+            block_text = entry.block_name or f"Block {entry.block_index + 1}"
+            if entry.line_number is not None:
+                if entry.column_number:
+                    block_text += f" : L{entry.line_number}:{entry.column_number}"
+                else:
+                    block_text += f" : L{entry.line_number}"
+            block_label = QLabel(block_text)
+            block_label.setStyleSheet(f"color: {lcolor}; font-size: 12px; font-weight: bold; font-family: Consolas;")
+            h_layout.addWidget(block_label)
+
+        # Connection
+        if entry.connection_name:
+            conn_text = entry.connection_name
+            if entry.database_name:
+                conn_text += f" / {entry.database_name}"
+            conn_label = QLabel(conn_text)
+            conn_label.setStyleSheet(f"color: {colors.text_tertiary}; font-size: 11px;")
+            h_layout.addWidget(conn_label)
+
+        h_layout.addStretch()
+
+        # Duration
+        if entry.duration_ms is not None:
+            from src.ui.components.output_panel import OutputPanel
+            dur_text = OutputPanel._format_duration(entry.duration_ms)
+            dur_label = QLabel(dur_text)
+            dur_label.setStyleSheet(f"color: {colors.text_tertiary}; font-size: 12px; font-family: Consolas;")
+            h_layout.addWidget(dur_label)
+
+        layout.addWidget(header)
+
+        # --- Code snippet (if present) ---
+        if entry.code_snippet:
+            code_header = QLabel(S.output_panel.detail_code)
+            code_header.setStyleSheet(f"color: {colors.text_secondary}; font-size: 11px; font-weight: bold;")
+            layout.addWidget(code_header)
+
+            code_edit = QTextEdit()
+            code_edit.setReadOnly(True)
+            code_edit.setFont(QFont("Consolas", 10))
+            code_edit.setPlainText(entry.code_snippet)
+            code_edit.setMaximumHeight(150)
+            code_edit.setStyleSheet(f"""
+                QTextEdit {{
+                    background-color: {colors.bg_secondary};
+                    color: {colors.text_primary};
+                    border: 1px solid {colors.border_default};
+                    border-radius: {RADIUS}px;
+                    padding: 8px;
+                }}
+                {SCROLLBAR_STYLE}
+            """)
+            layout.addWidget(code_edit)
+
+        # --- Error / detail text ---
+        detail_text = entry.detail or entry.message
+        if detail_text:
+            detail_header_text = (
+                S.output_panel.detail_error
+                if entry.level == "error"
+                else S.output_panel.detail_output
+            )
+            detail_header = QLabel(detail_header_text)
+            detail_header.setStyleSheet(f"color: {colors.text_secondary}; font-size: 11px; font-weight: bold;")
+            layout.addWidget(detail_header)
+
+            detail_edit = QTextEdit()
+            detail_edit.setReadOnly(True)
+            detail_edit.setFont(QFont("Consolas", 10))
+            detail_edit.setPlainText(detail_text)
+            detail_edit.setStyleSheet(f"""
+                QTextEdit {{
+                    background-color: {colors.bg_secondary};
+                    color: {lcolor};
+                    border: 1px solid {colors.border_default};
+                    border-radius: {RADIUS}px;
+                    padding: 8px;
+                }}
+                {SCROLLBAR_STYLE}
+            """)
+            layout.addWidget(detail_edit, 1)
+
+        # --- Buttons ---
+        btn_row = QHBoxLayout()
+        btn_row.setSpacing(8)
+
+        # Copy button
+        copy_btn = QPushButton(S.output_panel.btn_copy_detail)
+        if HAS_QTAWESOME:
+            copy_btn.setIcon(qta.icon("mdi.content-copy", color=colors.text_primary))
+        copy_btn.setStyleSheet(self._btn_style(colors))
+        copy_btn.clicked.connect(lambda: QApplication.clipboard().setText(detail_text))
+        btn_row.addWidget(copy_btn)
+
+        # Resolve with Copilot (only for errors)
+        if entry.level == "error":
+            copilot_btn = QPushButton(S.output_panel.btn_resolve_copilot)
+            try:
+                from src.ui.components.copilot_chat_panel import _load_copilot_icon
+                copilot_icon = _load_copilot_icon("#ffffff", size=16)
+                if copilot_icon:
+                    copilot_btn.setIcon(copilot_icon)
+            except Exception:
+                if HAS_QTAWESOME:
+                    copilot_btn.setIcon(qta.icon("mdi.github", color="#ffffff"))
+            copilot_btn.setStyleSheet(self._btn_style(colors, accent=True))
+            copilot_btn.clicked.connect(self._on_resolve_copilot)
+            btn_row.addWidget(copilot_btn)
+
+        btn_row.addStretch()
+
+        # Close
+        close_btn = QPushButton(S.output_panel.btn_close_detail)
+        close_btn.setStyleSheet(self._btn_style(colors))
+        close_btn.clicked.connect(self.accept)
+        btn_row.addWidget(close_btn)
+
+        layout.addLayout(btn_row)
+
+    def _on_resolve_copilot(self):
+        entry = self._entry
+        context = {
+            "block_index": entry.block_index,
+            "block_name": entry.block_name,
+            "code": entry.code_snippet,
+            "error": entry.detail or entry.message,
+            "log_type": entry.log_type,
+            "connection": entry.connection_name,
+            "database": entry.database_name,
+        }
+        self.resolve_requested.emit(context)
+        self.accept()
+
+    @staticmethod
+    def _btn_style(colors, accent=False):
+        bg = colors.interactive_primary if accent else colors.bg_elevated
+        fg = "#ffffff" if accent else colors.text_primary
+        hover = colors.interactive_primary_hover if accent else colors.bg_secondary
+        return f"""
+            QPushButton {{
+                background-color: {bg};
+                color: {fg};
+                border: 1px solid {colors.border_default};
+                border-radius: {RADIUS}px;
+                padding: 6px 14px;
+                font-size: 12px;
+            }}
+            QPushButton:hover {{
+                background-color: {hover};
+            }}
+        """

--- a/source/src/ui/main_window/_execution.py
+++ b/source/src/ui/main_window/_execution.py
@@ -742,15 +742,13 @@ class ExecutionMixin:
 
     def _log_info(self, message: str):
         """Adds message to log with timestamp (without showing panel)"""
-        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S,%f")[:-3]
         if self.global_output_panel:
-            self.global_output_panel.text_edit.append(f"[{timestamp}] {message}")
+            self.global_output_panel.log(message)
 
     def _log(self, message: str):
         """Adds message to log with timestamp and shows output panel"""
-        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S,%f")[:-3]
         if self.global_output_panel:
-            self.global_output_panel.text_edit.append(f"[{timestamp}] {message}")
+            self.global_output_panel.log(message)
 
         # Mostrar painel de output
         self.show_panel("output")
@@ -759,17 +757,10 @@ class ExecutionMixin:
         """Shows error in Output in red and switches to the Output panel"""
         if not self.global_output_panel:
             return
-        # Adiciona timestamp e erro em vermelho usando HTML
-        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S,%f")[:-3]
-        error_html = f'<span style="color: #ff6b6b; font-weight: bold;">[{timestamp}] {error_msg}</span>'
-        self.global_output_panel.text_edit.append(error_html)
+        self.global_output_panel.error(error_msg)
 
         # Mostrar painel de output
         self.show_panel("output")
-
-        # Scroll para o final
-        scrollbar = self.global_output_panel.text_edit.verticalScrollBar()
-        scrollbar.setValue(scrollbar.maximum())
 
     def _update_variables_view(self):
         """Updates variable visualization in memory"""
@@ -798,5 +789,5 @@ class ExecutionMixin:
                 variables.clear()
             output = self.global_output_panel
             if output:
-                output.text_edit.clear()
+                output.clear()
             self.action_label.setText(S.status.results_cleared)

--- a/source/src/ui/main_window/_sessions.py
+++ b/source/src/ui/main_window/_sessions.py
@@ -557,6 +557,17 @@ class SessionsMixin:
         # Criar paineis por sessao (Results, Output, Variables)
         self._create_session_panels(session.session_id)
 
+        # Connect output panel signals (navigate + Copilot resolve)
+        panels = self._session_panel_indices.get(session.session_id)
+        if panels and panels.get("output"):
+            out_panel = panels["output"]
+            out_panel.navigate_to_block.connect(
+                lambda block_idx, line, col, w=widget: w.editor.focus_block_at_line(block_idx, line, col)
+            )
+            out_panel.resolve_with_copilot.connect(
+                lambda ctx: self._resolve_with_copilot(ctx)
+            )
+
         # Definir file_path no widget se disponivel na sessao
         if hasattr(session, "file_path") and session.file_path:
             widget.file_path = session.file_path
@@ -826,6 +837,32 @@ class SessionsMixin:
 
         # Atualizar titulo da janela quando muda de aba
         self._update_window_title()
+
+    def _resolve_with_copilot(self, context: dict):
+        """Send error context to the Copilot chat panel for resolution."""
+        if not hasattr(self, "_copilot_chat_panel") or not self._copilot_chat_panel:
+            return
+        panel = self._copilot_chat_panel
+        # Build a prompt from the error context
+        parts = []
+        block_name = context.get("block_name") or f"Block {(context.get('block_index') or 0) + 1}"
+        lang = context.get("log_type", "SQL")
+        parts.append(f"I got an error in {block_name} ({lang}):")
+        code = context.get("code", "")
+        if code:
+            parts.append(f"```{lang.lower()}\n{code}\n```")
+        err = context.get("error", "")
+        if err:
+            parts.append(f"Error:\n```\n{err}\n```")
+        parts.append("Help me fix it.")
+        prompt = "\n\n".join(parts)
+        # Set text in input and trigger send
+        panel._input.setPlainText(prompt)
+        panel._on_send()
+        # Show the Copilot chat dock
+        if hasattr(self, "copilot_chat_dock"):
+            self.copilot_chat_dock.show()
+            self.copilot_chat_dock.raise_()
 
     def _on_session_focused(self, session):
         """Callback when a session is focused"""

--- a/tests/test_output_panel.py
+++ b/tests/test_output_panel.py
@@ -1,0 +1,540 @@
+"""
+Tests for the refactored Output Panel (LogEntry, parse_error_line, OutputPanel, LogDetailDialog).
+"""
+
+import pytest
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from PyQt6.QtWidgets import QApplication
+from PyQt6.QtCore import Qt
+
+from src.ui.components.output_panel import (
+    LogEntry, parse_error_line, parse_error_position,
+    _find_token_in_sql, _extract_error_token, OutputPanel,
+)
+
+
+# ======================================================================
+# LogEntry dataclass
+# ======================================================================
+
+class TestLogEntry:
+    """Tests for the LogEntry dataclass."""
+
+    def test_default_values(self):
+        entry = LogEntry()
+        assert entry.level == "info"
+        assert entry.message == ""
+        assert entry.block_index is None
+        assert entry.line_number is None
+        assert entry.duration_ms is None
+        assert entry.code_snippet == ""
+        assert isinstance(entry.timestamp, datetime)
+
+    def test_custom_values(self):
+        entry = LogEntry(
+            level="error",
+            log_type="SQL",
+            message="Syntax error near 'SELCT'",
+            detail="Msg 102, Level 15, State 1, Line 3",
+            block_index=2,
+            block_name="query_users",
+            line_number=3,
+            duration_ms=145.2,
+            code_snippet="SELCT * FROM users",
+            connection_name="prod-db",
+            database_name="mydb",
+        )
+        assert entry.level == "error"
+        assert entry.log_type == "SQL"
+        assert entry.block_index == 2
+        assert entry.line_number == 3
+        assert entry.duration_ms == 145.2
+        assert entry.connection_name == "prod-db"
+
+    def test_multiple_entries_independent(self):
+        e1 = LogEntry(level="info", message="ok")
+        e2 = LogEntry(level="error", message="fail")
+        assert e1.level != e2.level
+        assert e1.message != e2.message
+
+
+# ======================================================================
+# parse_error_line
+# ======================================================================
+
+class TestParseErrorLine:
+    """Tests for parse_error_line()."""
+
+    def test_none_input(self):
+        assert parse_error_line(None) is None
+
+    def test_empty_string(self):
+        assert parse_error_line("") is None
+
+    def test_no_line_info(self):
+        assert parse_error_line("Something went wrong") is None
+
+    def test_sql_server_format(self):
+        error = "Msg 102, Level 15, State 1, Line 5\nIncorrect syntax near 'SELCT'."
+        assert parse_error_line(error, "SQL") == 5
+
+    def test_mysql_format(self):
+        error = "You have an error in your SQL syntax; check the manual at line 12"
+        assert parse_error_line(error, "SQL") == 12
+
+    def test_postgresql_format(self):
+        error = 'ERROR:  syntax error at or near "SELCT"\nLINE 3: SELCT * FROM users\n        ^'
+        assert parse_error_line(error, "SQL") == 3
+
+    def test_python_traceback(self):
+        error = '  File "<string>", line 7, in <module>\nNameError: name \'x\' is not defined'
+        assert parse_error_line(error, "PYTHON") == 7
+
+    def test_generic_line_ref(self):
+        error = "Error on line 42"
+        assert parse_error_line(error) == 42
+
+    def test_case_insensitive(self):
+        assert parse_error_line("line 10") == 10
+        assert parse_error_line("LINE 10:") == 10
+        assert parse_error_line("Line 10") == 10
+
+
+# ======================================================================
+# OutputPanel widget
+# ======================================================================
+
+@pytest.fixture
+def output_panel(qtbot):
+    panel = OutputPanel()
+    qtbot.addWidget(panel)
+    return panel
+
+
+class TestOutputPanel:
+    """Tests for the new OutputPanel widget."""
+
+    def test_initial_state(self, output_panel):
+        assert output_panel._entries == []
+        assert output_panel.get_text() == ""
+        assert output_panel._list.count() == 0
+
+    def test_append_creates_entry(self, output_panel):
+        output_panel.append("Hello world", "info")
+        assert len(output_panel._entries) == 1
+        assert output_panel._entries[0].level == "info"
+        assert output_panel._entries[0].message == "Hello world"
+        assert output_panel._list.count() == 1
+
+    def test_log_method(self, output_panel):
+        output_panel.log("Info message")
+        assert len(output_panel._entries) == 1
+        assert output_panel._entries[0].level == "info"
+
+    def test_error_method(self, output_panel):
+        output_panel.error("Error message")
+        assert len(output_panel._entries) == 1
+        assert output_panel._entries[0].level == "error"
+
+    def test_success_method(self, output_panel):
+        output_panel.success("Success message")
+        assert output_panel._entries[0].level == "success"
+
+    def test_warning_method(self, output_panel):
+        output_panel.warning("Warning message")
+        assert output_panel._entries[0].level == "warning"
+
+    def test_debug_method(self, output_panel):
+        output_panel.debug("Debug message")
+        assert output_panel._entries[0].level == "debug"
+
+    def test_append_output_compat(self, output_panel):
+        output_panel.append_output("Normal text", error=False)
+        output_panel.append_output("Error text", error=True)
+        assert len(output_panel._entries) == 2
+        assert output_panel._entries[0].level == "info"
+        assert output_panel._entries[1].level == "error"
+
+    def test_clear(self, output_panel):
+        output_panel.log("msg1")
+        output_panel.error("msg2")
+        assert len(output_panel._entries) == 2
+        output_panel.clear()
+        assert len(output_panel._entries) == 0
+        assert output_panel._list.count() == 0
+
+    def test_get_text_format(self, output_panel):
+        output_panel.log("Hello")
+        text = output_panel.get_text()
+        assert "Hello" in text
+        # Should contain timestamp
+        assert "[" in text
+
+    def test_toPlainText_compat(self, output_panel):
+        output_panel.log("test")
+        assert output_panel.toPlainText() == output_panel.get_text()
+
+    def test_add_entry_structured(self, output_panel):
+        entry = LogEntry(
+            level="error",
+            log_type="SQL",
+            message="Syntax error",
+            detail="Msg 102, Level 15, State 1, Line 3",
+            block_index=0,
+            block_name="main_query",
+            line_number=3,
+            duration_ms=250,
+            code_snippet="SELCT * FROM users",
+        )
+        output_panel.add_entry(entry)
+        assert len(output_panel._entries) == 1
+        assert output_panel._list.count() == 1
+
+    def test_filter_errors_only(self, output_panel):
+        output_panel.log("info msg")
+        output_panel.error("error msg")
+        output_panel.success("ok msg")
+        assert output_panel._list.count() == 3
+
+        # Enable filter
+        output_panel._filter_btn.setChecked(True)
+        # Should only show error
+        assert output_panel._list.count() == 1
+
+        # Disable filter
+        output_panel._filter_btn.setChecked(False)
+        assert output_panel._list.count() == 3
+
+    def test_filter_shows_warnings_too(self, output_panel):
+        output_panel.warning("warn")
+        output_panel.log("info")
+        output_panel._filter_btn.setChecked(True)
+        assert output_panel._list.count() == 1  # only warning
+
+    def test_navigate_signal_on_double_click(self, output_panel, qtbot):
+        entry = LogEntry(
+            level="error", message="fail", block_index=2, line_number=5,
+        )
+        output_panel.add_entry(entry)
+
+        with qtbot.waitSignal(output_panel.navigate_to_block, timeout=1000) as blocker:
+            item = output_panel._list.item(0)
+            output_panel._on_item_double_clicked(item)
+
+        assert blocker.args == [2, 5, 0]
+
+    def test_navigate_default_line_1(self, output_panel, qtbot):
+        entry = LogEntry(level="error", message="fail", block_index=1)
+        output_panel.add_entry(entry)
+
+        with qtbot.waitSignal(output_panel.navigate_to_block, timeout=1000) as blocker:
+            item = output_panel._list.item(0)
+            output_panel._on_item_double_clicked(item)
+
+        assert blocker.args == [1, 1, 0]  # default line=1, col=0
+
+    def test_multiple_entries_ordering(self, output_panel):
+        for i in range(5):
+            output_panel.log(f"msg {i}")
+        assert len(output_panel._entries) == 5
+        assert output_panel._list.count() == 5
+        assert output_panel._entries[0].message == "msg 0"
+        assert output_panel._entries[4].message == "msg 4"
+
+    def test_cleared_signal(self, output_panel, qtbot):
+        output_panel.log("test")
+        with qtbot.waitSignal(output_panel.cleared, timeout=1000):
+            output_panel.clear()
+
+    def test_vertical_scrollbar_compat(self, output_panel):
+        sb = output_panel.verticalScrollBar()
+        assert sb is not None
+
+    def test_get_text_with_log_type(self, output_panel):
+        entry = LogEntry(log_type="SQL", message="Done")
+        output_panel.add_entry(entry)
+        text = output_panel.get_text()
+        assert "[SQL]" in text
+        assert "Done" in text
+
+
+# ======================================================================
+# OutputPanel._format_duration
+# ======================================================================
+
+class TestFormatDuration:
+    """Tests for the static _format_duration helper."""
+
+    def test_milliseconds(self):
+        assert OutputPanel._format_duration(45) == "45ms"
+        assert OutputPanel._format_duration(999) == "999ms"
+
+    def test_seconds(self):
+        assert OutputPanel._format_duration(1500) == "1.5s"
+        assert OutputPanel._format_duration(30000) == "30.0s"
+
+    def test_minutes(self):
+        assert OutputPanel._format_duration(90000) == "1m30s"
+        assert OutputPanel._format_duration(125000) == "2m5s"
+
+
+# ======================================================================
+# OutputPanel._truncate
+# ======================================================================
+
+class TestTruncate:
+    """Tests for the static _truncate helper."""
+
+    def test_short_text(self):
+        assert OutputPanel._truncate("hello", 10) == "hello"
+
+    def test_long_text(self):
+        result = OutputPanel._truncate("a" * 300, 200)
+        assert len(result) == 203  # 200 + "..."
+        assert result.endswith("...")
+
+    def test_multiline_uses_first_line(self):
+        assert OutputPanel._truncate("line1\nline2\nline3", 200) == "line1"
+
+
+# ======================================================================
+# LogDetailDialog
+# ======================================================================
+
+class TestLogDetailDialog:
+    """Tests for LogDetailDialog."""
+
+    def test_dialog_creates_for_error(self, qtbot):
+        from src.ui.dialogs.log_detail_dialog import LogDetailDialog
+        entry = LogEntry(
+            level="error",
+            log_type="SQL",
+            message="Syntax error",
+            detail="Msg 102, Level 15, State 1, Line 3\nIncorrect syntax.",
+            block_index=0,
+            block_name="query1",
+            line_number=3,
+            duration_ms=100,
+            code_snippet="SELCT * FROM users",
+            connection_name="local",
+            database_name="testdb",
+        )
+        dlg = LogDetailDialog(entry)
+        qtbot.addWidget(dlg)
+        assert dlg.windowTitle()
+
+    def test_dialog_creates_for_info(self, qtbot):
+        from src.ui.dialogs.log_detail_dialog import LogDetailDialog
+        entry = LogEntry(level="info", message="All good")
+        dlg = LogDetailDialog(entry)
+        qtbot.addWidget(dlg)
+        assert dlg.windowTitle()
+
+    def test_resolve_signal(self, qtbot):
+        from src.ui.dialogs.log_detail_dialog import LogDetailDialog
+        entry = LogEntry(
+            level="error",
+            log_type="SQL",
+            message="fail",
+            detail="bad query",
+            code_snippet="SELECT * FRM t",
+            block_index=0,
+            block_name="q1",
+        )
+        dlg = LogDetailDialog(entry)
+        qtbot.addWidget(dlg)
+
+        with qtbot.waitSignal(dlg.resolve_requested, timeout=1000) as blocker:
+            dlg._on_resolve_copilot()
+
+        ctx = blocker.args[0]
+        assert ctx["error"] == "bad query"
+        assert ctx["code"] == "SELECT * FRM t"
+        assert ctx["block_name"] == "q1"
+
+
+# ======================================================================
+# _find_token_in_sql
+# ======================================================================
+
+class TestFindTokenInSql:
+    """Tests for _find_token_in_sql()."""
+
+    def test_none_inputs(self):
+        assert _find_token_in_sql(None, "SELECT 1") is None
+        assert _find_token_in_sql("col", None) is None
+        assert _find_token_in_sql("", "SELECT 1") is None
+        assert _find_token_in_sql("col", "") is None
+
+    def test_single_line(self):
+        sql = "SELECT pa.adicionalid FROM pedidos pa"
+        result = _find_token_in_sql("adicionalid", sql)
+        assert result is not None
+        assert result[0] == 1  # line 1
+        assert result[1] == 11  # column 11 (after "SELECT pa.")
+
+    def test_multiline(self):
+        sql = "SELECT\n  pa.nome,\n  pa.adicionalid\nFROM pedidos pa"
+        result = _find_token_in_sql("adicionalid", sql)
+        assert result is not None
+        assert result[0] == 3  # line 3
+        assert result[1] == 6  # "  pa.adicionalid" -> col 6
+
+    def test_case_insensitive(self):
+        sql = "SELECT PA.AdicionalId FROM pedidos"
+        result = _find_token_in_sql("adicionalid", sql)
+        assert result is not None
+        assert result[0] == 1
+
+    def test_not_found(self):
+        sql = "SELECT id FROM users"
+        assert _find_token_in_sql("nonexistent", sql) is None
+
+    def test_qualified_column(self):
+        sql = "SELECT a.id,\n  b.nome\nFROM tab_a a\nJOIN tab_b b ON a.xid = b.xid"
+        result = _find_token_in_sql("b.xid", sql)
+        assert result is not None
+        assert result[0] == 4
+
+
+# ======================================================================
+# _extract_error_token
+# ======================================================================
+
+class TestExtractErrorToken:
+    """Tests for _extract_error_token()."""
+
+    def test_unknown_column_mysql(self):
+        error = "(1054, \"Unknown column 'pa.adicionalid' in 'on clause'\")"
+        assert _extract_error_token(error) == "pa.adicionalid"
+
+    def test_invalid_column_sqlserver(self):
+        error = "Invalid column name 'adicionalid'."
+        assert _extract_error_token(error) == "adicionalid"
+
+    def test_column_not_exist_postgresql(self):
+        error = 'ERROR: column "adicionalid" does not exist'
+        assert _extract_error_token(error) == "adicionalid"
+
+    def test_invalid_object_name(self):
+        error = "Invalid object name 'dbo.pedidos'."
+        assert _extract_error_token(error) == "dbo.pedidos"
+
+    def test_table_not_exist_mysql(self):
+        error = "Table 'mydb.pedidos' doesn't exist"
+        assert _extract_error_token(error) == "mydb.pedidos"
+
+    def test_relation_not_exist_postgresql(self):
+        error = 'ERROR: relation "pedidos" does not exist'
+        assert _extract_error_token(error) == "pedidos"
+
+    def test_near_single_quotes(self):
+        error = "You have an error in your SQL syntax; check near 'SELCT'"
+        assert _extract_error_token(error) == "SELCT"
+
+    def test_no_token(self):
+        assert _extract_error_token("Connection refused") is None
+        assert _extract_error_token("") is None
+
+
+# ======================================================================
+# parse_error_position
+# ======================================================================
+
+class TestParseErrorPosition:
+    """Tests for parse_error_position()."""
+
+    def test_line_from_message_no_sql(self):
+        error = "Msg 102, Level 15, State 1, Line 3\nIncorrect syntax near 'SELCT'."
+        line, col = parse_error_position(error)
+        assert line == 3
+        assert col is None
+
+    def test_line_and_column_from_token(self):
+        error = "(1054, \"Unknown column 'pa.adicionalid' in 'on clause'\")"
+        sql = "SELECT pa.nome\nFROM pedidos pa\nJOIN adicional ad\n  ON pa.adicionalid = ad.id"
+        line, col = parse_error_position(error, sql, "SQL")
+        assert line == 4
+        assert col == 6  # "  ON pa.adicionalid..." -> col 6
+
+    def test_fallback_token_no_line_in_message(self):
+        # MySQL 1054 has NO line number in the message
+        error = "(1054, \"Unknown column 'xpto' in 'field list'\")"
+        sql = "SELECT id,\n  xpto\nFROM users"
+        line, col = parse_error_position(error, sql, "SQL")
+        assert line == 2
+        assert col == 3
+
+    def test_no_info_at_all(self):
+        error = "Connection timed out"
+        line, col = parse_error_position(error, "SELECT 1")
+        assert line is None
+        assert col is None
+
+    def test_python_traceback(self):
+        error = '  File "<string>", line 5, in <module>\nNameError: name \'xx\' is not defined'
+        code = "a = 1\nb = 2\nc = 3\nd = 4\nxx = yy"
+        line, col = parse_error_position(error, code, "PYTHON")
+        assert line == 5
+
+    def test_line_from_message_plus_token_on_same_line(self):
+        error = "Msg 102, Level 15, State 1, Line 2\nIncorrect syntax near 'SELCT'."
+        sql = "SELECT id FROM users\nSELCT * FROM orders"
+        line, col = parse_error_position(error, sql, "SQL")
+        assert line == 2
+        assert col == 1  # SELCT starts at col 1
+
+    def test_empty_sql(self):
+        error = "(1054, \"Unknown column 'x' in 'field list'\")"
+        line, col = parse_error_position(error, "", "SQL")
+        assert line is None
+
+
+# ======================================================================
+# Navigate signal includes column
+# ======================================================================
+
+class TestNavigateSignalColumn:
+    """Tests that navigate_to_block emits block_index, line, column."""
+
+    def test_navigate_emits_three_args(self, output_panel, qtbot):
+        entry = LogEntry(
+            level="error",
+            log_type="SQL",
+            message="Error",
+            block_index=2,
+            line_number=4,
+            column_number=42,
+        )
+        output_panel.add_entry(entry)
+
+        with qtbot.waitSignal(output_panel.navigate_to_block, timeout=1000) as blocker:
+            item = output_panel._list.item(0)
+            output_panel._on_item_double_clicked(item)
+
+        assert blocker.args == [2, 4, 42]
+
+    def test_navigate_no_column(self, output_panel, qtbot):
+        entry = LogEntry(
+            level="error",
+            log_type="SQL",
+            message="Error",
+            block_index=1,
+            line_number=3,
+        )
+        output_panel.add_entry(entry)
+
+        with qtbot.waitSignal(output_panel.navigate_to_block, timeout=1000) as blocker:
+            item = output_panel._list.item(0)
+            output_panel._on_item_double_clicked(item)
+
+        assert blocker.args == [1, 3, 0]
+
+    def test_column_in_log_entry(self):
+        entry = LogEntry(column_number=42)
+        assert entry.column_number == 42
+
+        entry2 = LogEntry()
+        assert entry2.column_number is None


### PR DESCRIPTION
## Output Panel Refatorado

Refatoracao completa do painel de output com entradas estruturadas e navegacao precisa para erros.

### Novas funcionalidades

**Output Panel interativo (QListWidget)**
- `LogEntry` dataclass com campos estruturados (level, log_type, block_index, line, column, duration, connection, etc.)
- Itens ricos com icone de nivel, badges de bloco/linha/conexao, duracao formatada
- Filtro errors-only toggle, copy to clipboard, clear com sinais
- Double-click navega para bloco/linha/coluna exata no editor

**LogDetailDialog**
- Dialog com detalhes expandidos do erro (traceback completo, code snippet)
- Botao "Resolve with Copilot" com icone SVG do Copilot
- Header com timestamp, bloco, linha:coluna, conexao

**Deteccao inteligente de posicao de erro**
- `parse_error_line()`: extrai linha de mensagens SQL Server, MySQL, PostgreSQL, Python
- `parse_error_position()`: combina parse_error_line + fallback por token
- `_find_token_in_sql()`: localiza identificador no SQL, retorna (linha, coluna) 1-based
- `_extract_error_token()`: reconhece padroes de erro (Unknown column, Invalid column name, column "x" does not exist, near 'x', Invalid object name, Table doesn't exist, relation does not exist)
- Exemplo: MySQL error 1054 "Unknown column 'pa.adicionalid'" sem linha na mensagem -> busca o token no SQL e encontra linha 4, coluna 42

**Navegacao com coluna**
- Signal `navigate_to_block(int, int, int)` - block_index, line, column
- `focus_block_at_line(block_index, line, column)` posiciona cursor na coluna exata
- Badge mostra `L4:42` (linha:coluna) quando disponivel

### Testes
- 65 testes em `test_output_panel.py`
- Cobertura: LogEntry, parse_error_line, parse_error_position, _find_token_in_sql, _extract_error_token, OutputPanel widget, LogDetailDialog, navigate signal 3-arg