### PR TITLE
Fix Python results in tab notifications

### DIFF
--- a/source/src/language/en-US.json
+++ b/source/src/language/en-US.json
@@ -593,7 +593,7 @@
     "section_config": "NOTIFICATION CONFIG",
     "enable_custom": "Enable custom notification for this tab",
     "section_template": "MESSAGE TEMPLATE",
-    "variables_hint": "Variables: {{rows}}, {{blocks}}, {{tab_name}}, {{block_name}}, {{connection}}, {{database}}, {{type}}. Use {{result[row][col]}} to access query result values (e.g. {{result[0][1]}}).",
+    "variables_hint": "Variables: {{rows}}, {{blocks}}, {{tab_name}}, {{block_name}}, {{connection}}, {{database}}, {{type}}. Use {{result[row][col]}} to access tabular result values (e.g. {{result[0][1]}}).",
     "label_title": "Title:",
     "label_message": "Message:",
     "label_color": "Color:",

--- a/source/src/language/pt-BR.json
+++ b/source/src/language/pt-BR.json
@@ -595,7 +595,7 @@
     "section_config": "CONFIGURACAO DE NOTIFICACAO",
     "enable_custom": "Ativar notificacao personalizada para esta aba",
     "section_template": "TEMPLATE DA MENSAGEM",
-    "variables_hint": "Variaveis: {{rows}}, {{blocks}}, {{tab_name}}, {{block_name}}, {{connection}}, {{database}}, {{type}}. Use {{result[linha][coluna]}} para acessar valores do resultado (ex: {{result[0][1]}}).",
+    "variables_hint": "Variaveis: {{rows}}, {{blocks}}, {{tab_name}}, {{block_name}}, {{connection}}, {{database}}, {{type}}. Use {{result[linha][coluna]}} para acessar valores tabulares do resultado (ex: {{result[0][1]}}).",
     "label_title": "Titulo:",
     "label_message": "Mensagem:",
     "label_color": "Cor:",

--- a/source/src/ui/components/session_widget.py
+++ b/source/src/ui/components/session_widget.py
@@ -745,7 +745,7 @@ class SessionWidget(QWidget):
                 last_df = df[-1]
                 last_var_name = f"{var_base}{len(df) - 1}" if len(df) > 1 else var_base
                 self._set_results(last_df, last_var_name)
-                self.session.set_variable("_last_result", last_df)
+                self._update_last_notification_result(last_df)
 
                 self.session.finish_execution(True, S.session_widget.status_sql_multi.format(count=len(df)))
                 self.status_changed.emit(S.session_widget.status_sql_multi.format(count=len(df)))
@@ -779,7 +779,7 @@ class SessionWidget(QWidget):
 
                 # Save in session namespace
                 self.session.set_variable(var_name, df)
-                self.session.set_variable("_last_result", df)
+                self._update_last_notification_result(df)
 
             # Clear block_name after use
             self._current_block_name = None
@@ -924,6 +924,10 @@ class SessionWidget(QWidget):
             has_dataframe_result = False
             has_figures = bool(figures)
             has_output = bool(output)
+            notification_result = self._normalize_notification_result(result)
+
+            if notification_result is not None:
+                self._update_last_notification_result(notification_result)
 
             # 1. Logs/print -> Output
             if output:
@@ -968,15 +972,35 @@ class SessionWidget(QWidget):
             self.session.finish_execution(True, S.session_widget.status_python_done)
             self._queue_blocks_done += 1
             self._queue_last_type = "python"
-            if has_dataframe_result and result is not None:
-                self._queue_last_rows = len(result)
-                self._queue_total_rows += len(result)
+            if notification_result is not None:
+                self._queue_last_rows = len(notification_result)
+                self._queue_total_rows += len(notification_result)
 
         # Process next in queue if exists
         self._is_executing = False
         self._process_next_in_queue()
 
     # === EXECUTION NOTIFICATION ===
+
+    @staticmethod
+    def _normalize_notification_result(result) -> Optional[pd.DataFrame]:
+        """Convert supported results into a tabular value for notification templates."""
+        if result is None:
+            return None
+
+        if isinstance(result, pd.DataFrame):
+            return result
+
+        if isinstance(result, pd.Series):
+            return result.to_frame(name=result.name or "value")
+
+        return None
+
+    def _update_last_notification_result(self, result):
+        """Persist the last tabular result used by {{result[row][col]}} templates."""
+        normalized = self._normalize_notification_result(result)
+        if normalized is not None:
+            self.session.set_variable("_last_result", normalized)
 
     @staticmethod
     def _resolve_result_refs(template: str, last_result) -> str:

--- a/source/src/ui/dialogs/tab_notification_dialog.py
+++ b/source/src/ui/dialogs/tab_notification_dialog.py
@@ -110,7 +110,7 @@ class TabNotificationDialog(QDialog):
         # Variables hint
         hint_text = (
             S.tab_notification.variables_hint if hasattr(S, 'tab_notification')
-            else "Variables: {{rows}}, {{blocks}}, {{tab_name}}, {{block_name}}, {{connection}}, {{database}}, {{type}}. Use {{result[row][col]}} to access query result values (e.g. {{result[0][1]}})."
+            else "Variables: {{rows}}, {{blocks}}, {{tab_name}}, {{block_name}}, {{connection}}, {{database}}, {{type}}. Use {{result[row][col]}} to access tabular result values (e.g. {{result[0][1]}})."
         )
         hint_label = QLabel(hint_text)
         hint_label.setWordWrap(True)

--- a/tests/test_tab_notification.py
+++ b/tests/test_tab_notification.py
@@ -215,6 +215,59 @@ class TestSessionWidgetTabNotification:
         widget.set_tab_notification_config(None)
         assert widget.get_tab_notification_config() is None
 
+    def test_python_dataframe_result_updates_last_result(self, widget):
+        """Python DataFrame results feed {{result[row][col]}} notifications."""
+        widget._process_next_in_queue = MagicMock()
+        df = pd.DataFrame({"value": [42]})
+
+        widget._on_python_finished(df, "", "", {}, [])
+
+        stored = widget.session.get_variable("_last_result")
+        assert stored is not None
+        assert stored.equals(df)
+        assert widget._queue_last_rows == 1
+
+    def test_python_series_result_updates_last_result(self, widget):
+        """Python Series results are normalized so notifications can index them."""
+        widget._process_next_in_queue = MagicMock()
+        series = pd.Series([10, 20], name="value")
+
+        widget._on_python_finished(series, "", "", {}, [])
+
+        stored = widget.session.get_variable("_last_result")
+        assert stored is not None
+        assert isinstance(stored, pd.DataFrame)
+        assert list(stored.columns) == ["value"]
+        assert stored.iloc[1, 0] == 20
+        assert widget._queue_last_rows == 2
+
+    def test_python_chart_and_dataframe_updates_last_result(self, widget):
+        """Chart-producing Python blocks still keep the tabular result for notifications."""
+        widget._process_next_in_queue = MagicMock()
+        df = pd.DataFrame({"value": [99]})
+
+        widget._on_python_finished(df, "", "", {}, [object()])
+
+        stored = widget.session.get_variable("_last_result")
+        assert stored is not None
+        assert stored.equals(df)
+        assert widget._queue_last_rows == 1
+
+    def test_python_notification_renders_result_reference(self, widget, qtbot):
+        """Per-tab notifications render {{result[row][col]}} after Python execution."""
+        widget.set_tab_notification_config({
+            "enabled": True,
+            "title": "{{tab_name}}",
+            "message": "Value: {{result[0][0]}}",
+            "color": "#1e8a3e",
+        })
+        df = pd.DataFrame({"value": [42]})
+
+        with qtbot.waitSignal(widget.execution_finished, timeout=1000) as blocker:
+            widget._on_python_finished(df, "", "", {}, [])
+
+        assert blocker.args == ["TestTab", "Value: 42", True]
+
 
 # ==================== DPW PERSISTENCE ====================
 


### PR DESCRIPTION
## Summary
- persist the last tabular Python result for per-tab notification templates
- support `{{result[row][col]}}` after Python DataFrame and Series executions, including chart + data flows
- update notification hint text and add focused tests for Python notification rendering

## Notes
- targeted notification tests passed
- full test suite still hits the pre-existing Copilot/update timeout in `_ui_setup.py` and `copilot_lsp_client.py`