### PR TITLE
feat: improve Copilot chat flow and stabilize Qt lifecycle

### DIFF
--- a/source/src/core/shortcut_manager.py
+++ b/source/src/core/shortcut_manager.py
@@ -35,6 +35,7 @@ class ShortcutManager:
         "find": "Ctrl+F",
         "replace": "Ctrl+H",
         "format_code": "Ctrl+Shift+F",
+        "show_entity_info": "Alt+F1",
         # Autocompletar
         "force_autocomplete": "Ctrl+.",
         # Conexoes

--- a/source/src/database/database_connector.py
+++ b/source/src/database/database_connector.py
@@ -844,6 +844,17 @@ class DatabaseConnector:
 
         return statements
 
+    @staticmethod
+    def _result_to_dataframe(result) -> pd.DataFrame:
+        """Build a DataFrame directly from the DBAPI/SQLAlchemy result rows.
+
+        This avoids pandas SQL readers applying their own dtype inference on top
+        of the values already returned by the database driver.
+        """
+        columns = list(result.keys())
+        rows = result.fetchall()
+        return pd.DataFrame.from_records(rows, columns=columns)
+
     def _execute_generic_query(self, query: str) -> pd.DataFrame:
         """Execute generic query for non-MSSQL databases"""
         # Split statements with DELIMITER-awareness
@@ -858,7 +869,8 @@ class DatabaseConnector:
                     if self._is_select_query(cmd):
                         # Is SELECT - capture result
                         try:
-                            df = pd.read_sql(cmd, self.engine)
+                            result = conn.execute(text(cmd))
+                            df = self._result_to_dataframe(result)
                             logger.info(f"SELECT executed: {len(df)} rows returned")
                             dataframes.append(df)
                         except Exception as e:
@@ -888,8 +900,10 @@ class DatabaseConnector:
             # Single command - use the cleaned statement (DELIMITER stripped)
             cmd = commands[0]
             if self._is_select_query(cmd):
-                # SELECT query - use read_sql and let errors propagate
-                df = pd.read_sql(cmd, self.engine)
+                # SELECT query - fetch rows directly so DB driver values are preserved
+                with self.engine.connect() as conn:
+                    result = conn.execute(text(cmd))
+                    df = self._result_to_dataframe(result)
                 logger.info(f"Query executed successfully. Rows returned: {len(df)}")
                 return df
             else:

--- a/source/src/editors/block_editor.py
+++ b/source/src/editors/block_editor.py
@@ -526,6 +526,7 @@ class BlockEditor(QWidget):
 
         # Remove from layout
         self.blocks_layout.removeWidget(block)
+        block.cleanup()
         block.deleteLater()
 
         # If first block was removed, lock the new first block
@@ -611,6 +612,7 @@ class BlockEditor(QWidget):
         """Remove all blocks and add an empty one"""
         for block in self._blocks[:]:
             self.blocks_layout.removeWidget(block)
+            block.cleanup()
             block.deleteLater()
         self._blocks.clear()
         self._focused_block = None
@@ -1013,6 +1015,10 @@ class BlockEditor(QWidget):
 
         block.editor.setFocus()
         self.content_changed.emit()
+
+    def cleanup(self):
+        for block in self._blocks[:]:
+            block.cleanup()
 
     def _find_drop_index(self, pos) -> int:
         """Find index where block should be inserted"""

--- a/source/src/editors/code_block.py
+++ b/source/src/editors/code_block.py
@@ -430,6 +430,8 @@ class CodeBlock(QFrame):
         self._block_name = ""  # Block name (namespace prefix)
         self._is_copilot_editing = False  # Copilot is editing this block
         self._copilot_editing_timer = None  # Auto-dismiss timer
+        self._copilot_animation = None
+        self._spinner_animation = None
         self._is_maximized = False  # Block is in maximized/focus mode
         self._is_active = True  # Block is active (included in execute all)
 
@@ -450,9 +452,42 @@ class CodeBlock(QFrame):
 
     def closeEvent(self, event):
         """Stop timers to prevent callbacks on deleted C++ objects."""
-        self._execution_tick_timer.stop()
-        self._spinner_widget.hide()
+        self.cleanup()
         super().closeEvent(event)
+
+    def cleanup(self):
+        try:
+            self._execution_tick_timer.stop()
+        except RuntimeError:
+            pass
+
+        if self._copilot_editing_timer is not None:
+            try:
+                self._copilot_editing_timer.stop()
+            except RuntimeError:
+                pass
+            self._copilot_editing_timer = None
+
+        for animation_name in ("_copilot_animation", "_spinner_animation"):
+            animation = getattr(self, animation_name, None)
+            if animation is not None:
+                try:
+                    animation.stop()
+                except RuntimeError:
+                    pass
+                setattr(self, animation_name, None)
+
+        try:
+            self._spinner_widget.hide()
+        except RuntimeError:
+            pass
+
+        editor = getattr(self, "editor", None)
+        if editor is not None and hasattr(editor, "cleanup"):
+            try:
+                editor.cleanup()
+            except RuntimeError:
+                pass
 
     def _setup_ui(self):
         self.setFrameStyle(QFrame.Shape.Box | QFrame.Shadow.Plain)
@@ -1191,13 +1226,19 @@ class CodeBlock(QFrame):
         
         # Start/stop animation on the icon
         if editing:
+            if self._copilot_animation is not None:
+                self._copilot_animation.stop()
+            self._copilot_animation = qta.Spin(self._copilot_icon)
             animated_icon = qta.icon(
                 "mdi.creation",
                 color="#b48ead",
-                animation=qta.Spin(self._copilot_icon),
+                animation=self._copilot_animation,
             )
             self._copilot_icon.setIcon(animated_icon)
         else:
+            if self._copilot_animation is not None:
+                self._copilot_animation.stop()
+                self._copilot_animation = None
             static_icon = qta.icon("mdi.creation", color="#b48ead")
             self._copilot_icon.setIcon(static_icon)
         
@@ -1269,13 +1310,19 @@ class CodeBlock(QFrame):
                 }
             """)
             # Show animated spinner
-            spin_icon = qta.icon("fa5s.spinner", animation=qta.Spin(self._spinner_widget), color="#f39c12")
+            if self._spinner_animation is not None:
+                self._spinner_animation.stop()
+            self._spinner_animation = qta.Spin(self._spinner_widget)
+            spin_icon = qta.icon("fa5s.spinner", animation=self._spinner_animation, color="#f39c12")
             self._spinner_widget.setIcon(spin_icon)
             self._spinner_widget.show()
             # Start elapsed time counter
             self._execution_tick_timer.start()
         else:
             self._execution_tick_timer.stop()
+            if self._spinner_animation is not None:
+                self._spinner_animation.stop()
+                self._spinner_animation = None
             self._spinner_widget.setIcon(qta.icon("fa5s.check", color="#2ecc71"))
             self._spinner_widget.show()
             self._update_style()  # Restore play icon with language color
@@ -1302,6 +1349,9 @@ class CodeBlock(QFrame):
         self._is_running = False
         self._is_waiting = False
         self._execution_tick_timer.stop()
+        if self._spinner_animation is not None:
+            self._spinner_animation.stop()
+            self._spinner_animation = None
         self._spinner_widget.setIcon(qta.icon("fa5s.spinner", color="#888"))
         self._spinner_widget.hide()
         self._update_style()
@@ -1322,6 +1372,9 @@ class CodeBlock(QFrame):
         self._is_running = False
         self._is_waiting = False
         self._execution_tick_timer.stop()
+        if self._spinner_animation is not None:
+            self._spinner_animation.stop()
+            self._spinner_animation = None
         self._spinner_widget.setIcon(qta.icon("fa5s.spinner", color="#888"))
         self._spinner_widget.hide()
         self._update_style()

--- a/source/src/editors/code_block.py
+++ b/source/src/editors/code_block.py
@@ -247,9 +247,15 @@ class BlockDatabasePanel(QFrame):
         colors = get_colors()
         
         self._database_name = database_name
+        display_name = database_name
+        if isinstance(display_name, str):
+            if display_name.startswith("CATALOG:"):
+                display_name = display_name[8:]
+            elif display_name.startswith("SCHEMA:"):
+                display_name = display_name[7:]
 
         if database_name:
-            self.name_label.setText(database_name)
+            self.name_label.setText(display_name)
             self.name_label.setStyleSheet(f"color: {colors.text_primary}; font-size: 11px; font-weight: 500;")
             self.icon_label.setPixmap(qta.icon("mdi.database", color=colors.info).pixmap(16, 16))
         else:

--- a/source/src/editors/monaco/monaco_editor.py
+++ b/source/src/editors/monaco/monaco_editor.py
@@ -15,12 +15,14 @@ from PyQt6.QtCore import (
     QUrl,
     QTimer,
     QEventLoop,
+    QEvent,
     Qt,
 )
 from PyQt6.QtGui import QColor
 from PyQt6.QtWidgets import QWidget, QVBoxLayout
 from PyQt6.QtWebEngineWidgets import QWebEngineView
 from PyQt6.QtWebEngineCore import QWebEnginePage
+from PyQt6 import sip
 from PyQt6.QtWebChannel import QWebChannel
 
 from .monaco_bridge import MonacoBridge
@@ -82,6 +84,7 @@ class MonacoEditor(QWidget):
         self._is_ready = False
         self._pending_operations = []
         self._read_only = read_only
+        self._cleaned_up = False
         
         # SQL/Python autocomplete data
         self._sql_schema: Dict[str, Any] = {}
@@ -126,6 +129,54 @@ class MonacoEditor(QWidget):
         self.setMinimumSize(200, 80)
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         self.setFocusProxy(self._web_view)
+
+    def cleanup(self):
+        """Release WebEngine resources owned by the editor."""
+        if self._cleaned_up:
+            return
+
+        self._cleaned_up = True
+        self._is_ready = False
+        self._pending_operations.clear()
+
+        web_view = getattr(self, "_web_view", None)
+        if web_view is not None and not sip.isdeleted(web_view):
+            try:
+                web_view.stop()
+                page = web_view.page()
+                if page is not None and not sip.isdeleted(page):
+                    try:
+                        page.setWebChannel(None)
+                    except (RuntimeError, TypeError):
+                        pass
+                    replacement_page = QWebEnginePage(web_view)
+                    web_view.setPage(replacement_page)
+                    sip.delete(page)
+                web_view.close()
+            except RuntimeError:
+                pass
+            try:
+                sip.delete(web_view)
+            except RuntimeError:
+                pass
+
+        self._web_view = None
+        self._page = None
+        self._channel = None
+        self._bridge = None
+
+    def closeEvent(self, event):
+        self.cleanup()
+        super().closeEvent(event)
+
+    def deleteLater(self):
+        self.cleanup()
+        super().deleteLater()
+
+    def event(self, event):
+        if event.type() == QEvent.Type.DeferredDelete:
+            self.cleanup()
+        return super().event(event)
     
     def _setup_channel(self):
         """Setup QWebChannel for Python<->JS communication."""
@@ -199,6 +250,9 @@ class MonacoEditor(QWidget):
     
     def _on_editor_ready(self):
         """Called when Monaco editor is fully loaded."""
+        if self._cleaned_up:
+            return
+
         self._is_ready = True
         
         # Apply pending operations
@@ -387,13 +441,20 @@ class MonacoEditor(QWidget):
 
     def _run_js(self, script: str, callback=None):
         """Execute JavaScript in the Monaco editor."""
+        web_view = getattr(self, "_web_view", None)
+        if self._cleaned_up or web_view is None or sip.isdeleted(web_view):
+            return
+
         if callback:
-            self._web_view.page().runJavaScript(script, callback)
+            web_view.page().runJavaScript(script, callback)
         else:
-            self._web_view.page().runJavaScript(script)
+            web_view.page().runJavaScript(script)
     
     def _run_js_when_ready(self, script: str, callback=None):
         """Execute JS when ready, or queue if not ready yet."""
+        if self._cleaned_up:
+            return
+
         if self._is_ready:
             # Log completion-related JS calls at debug level (less spam)
             if "receiveCompletion" in script:

--- a/source/src/editors/monaco/monaco_editor.py
+++ b/source/src/editors/monaco/monaco_editor.py
@@ -256,9 +256,9 @@ class MonacoEditor(QWidget):
             service = SqlAutoCompleteService()
             service.set_schema(self._sql_schema)
             
-            # Get completions for the prefix (alias or table name)
-            # Returns list of (name, category, detail) tuples
-            completions = service._dot_completions(prefix, full_text)
+            # Reuse the main completion path so dot completions honor
+            # cursor scope, aliases, CTEs, subqueries and temp objects.
+            completions = service.get_completions(full_text, line - 1, column - 1)
             
             # Format and send back to JavaScript
             js_completions = []
@@ -270,7 +270,7 @@ class MonacoEditor(QWidget):
                 
                 js_completions.append({
                     'label': name,
-                    'kind': 'field',
+                    'kind': 'variable' if category == 'variable' else 'field',
                     'insertText': name,
                     'detail': detail,
                     'category': category,
@@ -298,7 +298,7 @@ class MonacoEditor(QWidget):
             service.set_schema(self._sql_schema)
             
             # Get context-aware completions
-            completions = service.get_completions(full_text, line - 1, column)
+            completions = service.get_completions(full_text, line - 1, column - 1)
             
             # Format for JavaScript
             js_completions = []
@@ -314,10 +314,14 @@ class MonacoEditor(QWidget):
                     kind = 'keyword'
                 elif category == 'function':
                     kind = 'function'
+                elif category == 'routine':
+                    kind = 'function'
                 elif category == 'table':
                     kind = 'class'
                 elif category == 'column':
                     kind = 'field'
+                elif category == 'variable':
+                    kind = 'variable'
                 elif category == 'database':
                     kind = 'module'
                 

--- a/source/src/editors/monaco/monaco_template.html
+++ b/source/src/editors/monaco/monaco_template.html
@@ -471,9 +471,11 @@
         
         // Sort text helper - columns first, then tables, then keywords
         function getSortText(c) {
+            if (c.category === 'variable') return '0' + c.label;
             if (c.category === 'column') return '0' + c.label;
-            if (c.category === 'table') return '1' + c.label;
-            return '2' + c.label;
+            if (c.category === 'routine') return '1' + c.label;
+            if (c.category === 'table') return '2' + c.label;
+            return '3' + c.label;
         }
         
         // Request Python Jedi completions from Python
@@ -745,7 +747,7 @@
         function registerStandardCompletionProviders() {
             // SQL provider - ALWAYS requests from Python (SSMS-style)
             monaco.languages.registerCompletionItemProvider('sql', {
-                triggerCharacters: ['.', ' '],
+                triggerCharacters: ['.', ' ', ',', '(', '=', '@', '#'],
                 provideCompletionItems: async function(model, position, context) {
                     const word = model.getWordUntilPosition(position);
                     const range = {

--- a/source/src/language/en-US.json
+++ b/source/src/language/en-US.json
@@ -3,7 +3,6 @@
     "name": "English (US)",
     "code": "en-US"
   },
-
   "menu": {
     "file": "&File",
     "new_tab": "&New Tab",
@@ -35,13 +34,14 @@
     "tools": "&Tools",
     "package_manager": "&Package Manager...",
     "shortcut_settings": "&Settings...",
-    "auto_update": "Enable &Auto-Update",    "copilot_submenu": "&Copilot",
+    "auto_update": "Enable &Auto-Update",
+    "copilot_submenu": "&Copilot",
     "copilot_download_lsp": "Download &Language Server...",
-    "copilot_check_status": "Check &Status",    "help": "&Help",
+    "copilot_check_status": "Check &Status",
+    "help": "&Help",
     "check_updates": "Check for &Updates...",
     "about": "&About"
   },
-
   "toolbar": {
     "new_tab": " New Tab",
     "connection": " Connection",
@@ -53,7 +53,6 @@
     "run_timer_label": "Wait X seconds after completion and run again:",
     "run_timer_start": "Start"
   },
-
   "dock": {
     "connections": "Connections",
     "results": "Results",
@@ -62,7 +61,6 @@
     "object_explorer": "Object Explorer",
     "copilot": "Copilot Chat"
   },
-
   "status": {
     "ready": "Ready",
     "connected": "Connected",
@@ -118,17 +116,14 @@
     "cross_executed": "[Cross-Syntax] Executed successfully!",
     "execution_error_generic": "[{type}] Execution error"
   },
-
   "main_window": {
     "window_title": "DataPyn - IDE SQL + Python"
   },
-
   "empty_state": {
     "title": "No script open",
     "subtitle": "Create a new session or drag a file to get started",
     "start_button": "Start"
   },
-
   "about": {
     "title": "About DataPyn",
     "ide_name": "DataPyn IDE",
@@ -139,7 +134,6 @@
     "license": "License: MIT License",
     "built_with": "Built with Python and PyQt6"
   },
-
   "dialogs": {
     "warning": "Warning",
     "error": "Error",
@@ -192,7 +186,6 @@
     "language_restart_title": "Restart Required",
     "language_restart_msg": "Language change will take effect after restarting DataPyn.\n\nRestart now?"
   },
-
   "notification": {
     "sql_query": "SQL Query",
     "python": "Python",
@@ -205,7 +198,6 @@
     "executed": "Executed successfully!",
     "error": "Error: {error}..."
   },
-
   "log": {
     "sql_running": "[SQL] Running query...",
     "sql_database": "[SQL] Database: {name}",
@@ -217,7 +209,6 @@
     "sql_executed": "Executed successfully ({rows} rows returned)",
     "schema_loaded": "Schema loaded ({name}): {tables} tables, {cols} columns"
   },
-
   "connection_panel": {
     "section_active": "ACTIVE CONNECTION",
     "label_none": "None",
@@ -230,7 +221,6 @@
     "ctx_edit": "Edit",
     "error_loading_svg": "Error loading SVG: {error}"
   },
-
   "session_widget": {
     "connected_to": "Connected to {name}",
     "connect_failed": "Failed to connect to {name}",
@@ -266,7 +256,6 @@
     "conn_dialog_error": "Error opening connection dialog: {error}",
     "connecting_block": "Connecting to {name}..."
   },
-
   "results": {
     "btn_csv": "CSV",
     "btn_excel": "Excel",
@@ -323,7 +312,6 @@
     "ctx_copy_with_headers": "Copy with Headers",
     "ctx_select_all": "Select All"
   },
-
   "export_settings": {
     "dialog_title": "Export Settings",
     "tooltip_btn": "Export settings",
@@ -340,7 +328,6 @@
     "null_text": "NULL",
     "null_none": "None"
   },
-
   "csv_export": {
     "dialog_title": "Export CSV",
     "label_delimiter": "Delimiter:",
@@ -356,7 +343,6 @@
     "label_include_header": "Include header:",
     "label_open_folder": "Open folder after export:"
   },
-
   "object_explorer": {
     "no_connection": "No connection",
     "loading": "Loading schema...",
@@ -379,6 +365,9 @@
     "ctx_copy_db_name": "Copy name",
     "ctx_count_rows": "Count rows (COUNT)",
     "ctx_select_all_columns": "SELECT with all columns",
+    "ctx_commands_menu": "Commands",
+    "ctx_command_create_table": "Create Table",
+    "ctx_command_drop_create": "Drop and Create",
     "ctx_where_clause": "WHERE clause",
     "ctx_group_by": "GROUP BY clause",
     "ctx_order_by": "ORDER BY clause",
@@ -388,7 +377,6 @@
     "schema_error": "Error loading schema",
     "not_null": "NOT NULL"
   },
-
   "variables_panel": {
     "no_variables": "No variables",
     "one_variable": "1 variable",
@@ -415,7 +403,6 @@
     "ctx_size_chars": "Size: {n} chars",
     "ctx_remove_variable": "Remove variable"
   },
-
   "output_panel": {
     "btn_clear": "Clear",
     "btn_copy": "Copy",
@@ -432,7 +419,6 @@
     "btn_close_detail": "Close",
     "btn_resolve_copilot": "Resolve with Copilot"
   },
-
   "session_tabs": {
     "ctx_open_file_location": "Open File Location",
     "ctx_close_all": "Close All",
@@ -442,13 +428,11 @@
     "ctx_customize_notification": "Customize Notification",
     "ctx_close": "Close"
   },
-
   "bottom_tabs": {
     "results": "Results",
     "output": "Output",
     "variables": "Variables"
   },
-
   "block": {
     "conn_tab_default": "Tab Default",
     "conn_first_block_locked": "First block uses the tab connection",
@@ -474,7 +458,6 @@
     "copilot_editing": "Copilot editing...",
     "tooltip_active": "Enable/disable block (inactive blocks are skipped on execute all)"
   },
-
   "find_replace": {
     "placeholder_find": "Find...",
     "tooltip_match_case": "Match case",
@@ -492,12 +475,10 @@
     "no_results": "No results",
     "replacements_count": "{count} replacements"
   },
-
   "block_editor": {
     "tooltip_add_block": "Add block",
     "block_marker": "# === Block {n} ({lang}) ==="
   },
-
   "settings": {
     "title": "Settings",
     "tab_general": "General",
@@ -510,6 +491,40 @@
     "tip_shortcuts": "Tip: Double-click a shortcut to edit",
     "header_action": "Action",
     "header_shortcut": "Shortcut",
+    "shortcut_actions": {
+      "execute_sql": "Run current block",
+      "execute_all": "Run all blocks",
+      "execute_block_advance": "Run block and advance",
+      "clear_results": "Clear results",
+      "open_file": "Open file",
+      "save_file": "Save file",
+      "save_as": "Save as...",
+      "export_script": "Export as script",
+      "new_tab": "New tab",
+      "new_session": "New session",
+      "close_tab": "Close tab",
+      "add_block": "Add block",
+      "find": "Find",
+      "replace": "Replace",
+      "format_code": "Format code",
+      "show_entity_info": "Show entity information",
+      "force_autocomplete": "Force autocomplete",
+      "manage_connections": "Manage connections",
+      "new_connection": "New connection",
+      "reload_schema": "Reload SQL schema",
+      "settings": "Settings",
+      "copy_with_headers": "Copy with headers (grid)",
+      "exit_app": "Exit application",
+      "restore_view": "Restore default view",
+      "reset_layout": "Reset layout completely",
+      "editor_newline": "[Editor] New line (Shift+Enter)",
+      "editor_duplicate_line": "[Editor] Duplicate line/selection",
+      "editor_cut_line": "[Editor] Cut line",
+      "editor_transpose_line": "[Editor] Transpose lines",
+      "editor_lowercase": "[Editor] Lowercase",
+      "editor_uppercase": "[Editor] Uppercase",
+      "editor_delete_line": "[Editor] Delete line"
+    },
     "btn_restore_defaults": "Restore Defaults",
     "btn_cancel": "Cancel",
     "btn_save": "Save",
@@ -614,7 +629,48 @@
     "notification_channel_telegram": "Telegram",
     "notification_channel_email": "Email"
   },
-
+  "entity_info": {
+    "dialog_title": "Entity Information",
+    "loading": "Loading entity information...",
+    "no_selection": "Select an entity name in the SQL editor first.",
+    "no_active_sql_block": "Focus a SQL block to open entity information.",
+    "no_connection": "Connect to a database before opening entity information.",
+    "load_error": "Could not load entity information: {error}",
+    "load_error_status": "Error loading entity information: {error}",
+    "error_subtitle": "The requested details could not be loaded.",
+    "subtitle_ready": "Connection: {connection} | Database: {db_type}",
+    "header_connection": "Active connection: {connection}",
+    "field_type": "Type",
+    "field_database": "Database",
+    "field_catalog": "Catalog",
+    "field_schema": "Schema",
+    "field_rows": "Rows",
+    "field_size": "Size",
+    "section_columns": "Columns",
+    "section_indexes": "Indexes",
+    "columns_name": "Name",
+    "columns_type": "Type",
+    "columns_nullable": "Nullable",
+    "columns_default": "Default",
+    "indexes_name": "Name",
+    "indexes_type": "Type",
+    "indexes_columns": "Columns",
+    "nullable_yes": "Yes",
+    "nullable_no": "No",
+    "not_available": "Not available",
+    "no_columns": "No columns found.",
+    "no_indexes": "No indexes found.",
+    "indexes_not_supported": "Index information is not available for this database.",
+    "button_close": "Close",
+    "section_parameters": "Parameters",
+    "section_trigger_info": "Trigger Information",
+    "columns_direction": "Direction",
+    "no_parameters": "No parameters found.",
+    "trigger_event": "Event",
+    "trigger_parent_table": "Table",
+    "trigger_timing": "Timing",
+    "section_routine_not_available": "Index not available for this object type."
+  },
   "tab_notification": {
     "dialog_title": "Tab Notification",
     "section_config": "NOTIFICATION CONFIG",
@@ -663,7 +719,6 @@
     "btn_cancel": "Cancel",
     "badge_active": "Custom notification active"
   },
-
   "connections_manager": {
     "title": "Manage Connections",
     "btn_new_group": "New Group",
@@ -719,7 +774,6 @@
     "import_export_confirm_title": "Confirm Import",
     "import_export_confirm_msg": "This will import {count} connection(s) and {groups} group(s).\nExisting connections with the same name will be replaced.\nDo you want to continue?"
   },
-
   "connection_edit": {
     "title_new": "New Connection",
     "title_edit": "Edit Connection: {name}",
@@ -762,14 +816,12 @@
     "validation_name_required": "Connection name is required",
     "validation_host_required": "Host is required"
   },
-
   "connection_picker": {
     "title": "Select Connection",
     "header": "SELECT A CONNECTION",
     "hint": "Double-click to select",
     "btn_cancel": "Cancel"
   },
-
   "export_to_table": {
     "title": "Export to Table",
     "info_row_col": "{rows} rows x {cols} columns",
@@ -800,7 +852,6 @@
     "validation_connection_required": "Select a connection",
     "validation_no_data": "No data to export"
   },
-
   "file_import": {
     "title": "Import File",
     "header": "Import Data",
@@ -842,7 +893,6 @@
     "checkbox_json_lines": "JSON Lines (one line per record)",
     "label_format": "Format:"
   },
-
   "package_manager": {
     "title": "Package Manager",
     "subtitle": "Search, install and manage Python packages (pip)",
@@ -891,7 +941,6 @@
     "auth_token_placeholder": "PAT, API key or password",
     "auth_username_invalid": "The username field should contain a username or email, not a URL. Enter only the username for authentication."
   },
-
   "update_dialog": {
     "title": "Update Available",
     "new_version_label": "New version available: {version}",
@@ -914,7 +963,6 @@
     "checking_connecting": "Connecting to GitHub...",
     "checking_timeout": "Timed out."
   },
-
   "mixed_executor": {
     "no_connection": "No active database connection",
     "no_query_found": "No query found with {{ SQL }} syntax",
@@ -925,7 +973,6 @@
     "help_example": "FULL EXAMPLE:",
     "help_shortcut": "SHORTCUT: Ctrl+Shift+F5"
   },
-
   "workers": {
     "error_sql": "SQL Error: {msg}",
     "error_connection": "Connection error: {msg}",
@@ -934,7 +981,6 @@
     "error_db_switch": "Database switch error: {msg}",
     "error_failed_to_connect": "Failed to connect to database"
   },
-
   "session": {
     "default_title": "Script",
     "default_title_n": "Script {n}",
@@ -942,19 +988,16 @@
     "status_disconnected": "Disconnected",
     "status_ready": "Ready"
   },
-
   "schema_service": {
     "loading": "Loading database structure...",
     "loaded": "Schema loaded: {tables} tables, {cols} columns"
   },
-
   "docking": {
     "window_title": "DataPyn - Docking System",
     "menu_view": "&View",
     "menu_reset_layout": "&Reset Layout",
     "menu_panels": "&Panels"
   },
-
   "copilot": {
     "title": "Copilot",
     "input_placeholder": "Ask Copilot... (Enter to send, Shift+Enter for new line)",
@@ -968,7 +1011,7 @@
     "not_authenticated": "Please sign in with GitHub to use Copilot.",
     "auth_instructions": "To authenticate, enter the code **{code}** at:\n{url}\n\n(Code copied to clipboard)",
     "auth_code_instructions": "Enter this code on GitHub to authenticate:",
-    "copy_code": "Copy Code",
+    "copy_code": "Copy",
     "code_copied": "Copied!",
     "waiting_auth": "Waiting for authentication...",
     "auth_success": "Authenticated successfully! You can now chat with Copilot.",
@@ -1007,7 +1050,6 @@
     "tool_running": "running...",
     "tool_ok": "ok",
     "tool_error": "error",
-    "copy_code": "Copy",
     "copied_code": "Copied!",
     "insert_code": "Insert",
     "inserted_code": "Inserted!",
@@ -1015,7 +1057,6 @@
     "new_chat": "New Chat",
     "chat_history": "Chat History"
   },
-
   "copilot_download": {
     "title": "Copilot Autocomplete",
     "downloading_title": "Downloading Copilot Engine",

--- a/source/src/language/pt-BR.json
+++ b/source/src/language/pt-BR.json
@@ -3,7 +3,6 @@
     "name": "Portugues (Brasil)",
     "code": "pt-BR"
   },
-
   "menu": {
     "file": "&Arquivo",
     "new_tab": "&Nova Aba",
@@ -43,7 +42,6 @@
     "check_updates": "Verificar &Atualizacoes...",
     "about": "&Sobre"
   },
-
   "toolbar": {
     "new_tab": " Nova Aba",
     "connection": " Conexao",
@@ -55,7 +53,6 @@
     "run_timer_label": "Aguardar X segundos apos o termino e executar novamente:",
     "run_timer_start": "Iniciar"
   },
-
   "dock": {
     "connections": "Conexoes",
     "results": "Resultados",
@@ -64,7 +61,6 @@
     "object_explorer": "Explorador de Objetos",
     "copilot": "Copilot Chat"
   },
-
   "status": {
     "ready": "Pronto",
     "connected": "Conectado",
@@ -120,17 +116,14 @@
     "cross_executed": "[Cross-Syntax] Executado com sucesso!",
     "execution_error_generic": "[{type}] Erro na execucao"
   },
-
   "main_window": {
     "window_title": "DataPyn - IDE SQL + Python"
   },
-
   "empty_state": {
     "title": "Nenhum script aberto",
     "subtitle": "Crie uma nova sessao ou arraste um arquivo para comecar",
     "start_button": "Iniciar"
   },
-
   "about": {
     "title": "Sobre o DataPyn",
     "ide_name": "DataPyn IDE",
@@ -141,7 +134,6 @@
     "license": "Licenca: MIT License",
     "built_with": "Construido com Python e PyQt6"
   },
-
   "dialogs": {
     "warning": "Aviso",
     "error": "Erro",
@@ -194,7 +186,6 @@
     "language_restart_title": "Reinicializacao Necessaria",
     "language_restart_msg": "A mudanca de idioma tera efeito apos reiniciar o DataPyn.\n\nReiniciar agora?"
   },
-
   "notification": {
     "sql_query": "Consulta SQL",
     "python": "Python",
@@ -207,7 +198,6 @@
     "executed": "Executado com sucesso!",
     "error": "Erro: {error}..."
   },
-
   "log": {
     "sql_running": "[SQL] Executando consulta...",
     "sql_database": "[SQL] Banco: {name}",
@@ -219,7 +209,6 @@
     "sql_executed": "Executado com sucesso ({rows} linhas retornadas)",
     "schema_loaded": "Schema carregado ({name}): {tables} tabelas, {cols} colunas"
   },
-
   "connection_panel": {
     "section_active": "CONEXAO ATIVA",
     "label_none": "Nenhuma",
@@ -232,7 +221,6 @@
     "ctx_edit": "Editar",
     "error_loading_svg": "Erro ao carregar SVG: {error}"
   },
-
   "session_widget": {
     "connected_to": "Conectado a {name}",
     "connect_failed": "Falha ao conectar a {name}",
@@ -268,7 +256,6 @@
     "conn_dialog_error": "Erro ao abrir dialogo de conexao: {error}",
     "connecting_block": "Conectando a {name}..."
   },
-
   "results": {
     "btn_csv": "CSV",
     "btn_excel": "Excel",
@@ -325,7 +312,6 @@
     "ctx_copy_with_headers": "Copiar com Cabecalho",
     "ctx_select_all": "Selecionar Tudo"
   },
-
   "export_settings": {
     "dialog_title": "Configuracoes de Exportacao",
     "tooltip_btn": "Configuracoes de exportacao",
@@ -342,7 +328,6 @@
     "null_text": "NULL",
     "null_none": "None"
   },
-
   "csv_export": {
     "dialog_title": "Exportar CSV",
     "label_delimiter": "Delimitador:",
@@ -358,7 +343,6 @@
     "label_include_header": "Incluir cabecalho:",
     "label_open_folder": "Abrir pasta apos exportar:"
   },
-
   "object_explorer": {
     "no_connection": "Sem conexao",
     "loading": "Carregando schema...",
@@ -381,6 +365,9 @@
     "ctx_copy_db_name": "Copiar nome",
     "ctx_count_rows": "Contar linhas (COUNT)",
     "ctx_select_all_columns": "SELECT com todas as colunas",
+    "ctx_commands_menu": "Commands",
+    "ctx_command_create_table": "Create Table",
+    "ctx_command_drop_create": "Drop and Create",
     "ctx_where_clause": "Clausula WHERE",
     "ctx_group_by": "Clausula GROUP BY",
     "ctx_order_by": "Clausula ORDER BY",
@@ -390,7 +377,6 @@
     "schema_error": "Erro ao carregar schema",
     "not_null": "NOT NULL"
   },
-
   "variables_panel": {
     "no_variables": "Sem variaveis",
     "one_variable": "1 variavel",
@@ -417,7 +403,6 @@
     "ctx_size_chars": "Tamanho: {n} caracteres",
     "ctx_remove_variable": "Remover variavel"
   },
-
   "output_panel": {
     "btn_clear": "Limpar",
     "btn_copy": "Copiar",
@@ -434,7 +419,6 @@
     "btn_close_detail": "Fechar",
     "btn_resolve_copilot": "Resolver com Copilot"
   },
-
   "session_tabs": {
     "ctx_open_file_location": "Abrir Local do Arquivo",
     "ctx_close_all": "Fechar Todas",
@@ -444,13 +428,11 @@
     "ctx_customize_notification": "Personalizar Notificacao",
     "ctx_close": "Fechar"
   },
-
   "bottom_tabs": {
     "results": "Resultados",
     "output": "Saida",
     "variables": "Variaveis"
   },
-
   "block": {
     "conn_tab_default": "Padrao da Aba",
     "conn_first_block_locked": "O primeiro bloco usa a conexao da aba",
@@ -476,7 +458,6 @@
     "copilot_editing": "Copilot editando...",
     "tooltip_active": "Ativar/desativar bloco (blocos inativos sao pulados ao executar todos)"
   },
-
   "find_replace": {
     "placeholder_find": "Buscar...",
     "tooltip_match_case": "Diferenciar maiusculas/minusculas",
@@ -494,12 +475,10 @@
     "no_results": "Nenhum resultado",
     "replacements_count": "{count} substituicoes"
   },
-
   "block_editor": {
     "tooltip_add_block": "Adicionar bloco",
     "block_marker": "# === Bloco {n} ({lang}) ==="
   },
-
   "settings": {
     "title": "Configuracoes",
     "tab_general": "Geral",
@@ -512,6 +491,40 @@
     "tip_shortcuts": "Dica: Clique duplo em um atalho para editar",
     "header_action": "Acao",
     "header_shortcut": "Atalho",
+    "shortcut_actions": {
+      "execute_sql": "Executar bloco atual",
+      "execute_all": "Executar todos os blocos",
+      "execute_block_advance": "Executar bloco e avancar",
+      "clear_results": "Limpar resultados",
+      "open_file": "Abrir arquivo",
+      "save_file": "Salvar arquivo",
+      "save_as": "Salvar como...",
+      "export_script": "Exportar como script",
+      "new_tab": "Nova aba",
+      "new_session": "Nova sessao",
+      "close_tab": "Fechar aba",
+      "add_block": "Adicionar bloco",
+      "find": "Buscar",
+      "replace": "Substituir",
+      "format_code": "Formatar codigo",
+      "show_entity_info": "Mostrar informacoes da entidade",
+      "force_autocomplete": "Forcar autocomplete",
+      "manage_connections": "Gerenciar conexoes",
+      "new_connection": "Nova conexao",
+      "reload_schema": "Recarregar schema SQL",
+      "settings": "Configuracoes",
+      "copy_with_headers": "Copiar com cabecalho (grid)",
+      "exit_app": "Fechar aplicativo",
+      "restore_view": "Restaurar visualizacao padrao",
+      "reset_layout": "Resetar layout completamente",
+      "editor_newline": "[Editor] Nova linha (Shift+Enter)",
+      "editor_duplicate_line": "[Editor] Duplicar linha/selecao",
+      "editor_cut_line": "[Editor] Recortar linha",
+      "editor_transpose_line": "[Editor] Transpor linhas",
+      "editor_lowercase": "[Editor] Minusculas",
+      "editor_uppercase": "[Editor] Maiusculas",
+      "editor_delete_line": "[Editor] Excluir linha"
+    },
     "btn_restore_defaults": "Restaurar Padroes",
     "btn_cancel": "Cancelar",
     "btn_save": "Salvar",
@@ -616,7 +629,48 @@
     "notification_channel_telegram": "Telegram",
     "notification_channel_email": "Email"
   },
-
+  "entity_info": {
+    "dialog_title": "Informacoes da Entidade",
+    "loading": "Carregando informacoes da entidade...",
+    "no_selection": "Selecione o nome de uma entidade no editor SQL primeiro.",
+    "no_active_sql_block": "Foque em um bloco SQL para abrir as informacoes da entidade.",
+    "no_connection": "Conecte-se a um banco de dados antes de abrir as informacoes da entidade.",
+    "load_error": "Nao foi possivel carregar as informacoes da entidade: {error}",
+    "load_error_status": "Erro ao carregar informacoes da entidade: {error}",
+    "error_subtitle": "Nao foi possivel carregar os detalhes solicitados.",
+    "subtitle_ready": "Conexao: {connection} | Banco: {db_type}",
+    "header_connection": "Conexao ativa: {connection}",
+    "field_type": "Tipo",
+    "field_database": "Banco",
+    "field_catalog": "Catalogo",
+    "field_schema": "Schema",
+    "field_rows": "Linhas",
+    "field_size": "Tamanho",
+    "section_columns": "Colunas",
+    "section_indexes": "Indices",
+    "columns_name": "Nome",
+    "columns_type": "Tipo",
+    "columns_nullable": "Nulo",
+    "columns_default": "Padrao",
+    "indexes_name": "Nome",
+    "indexes_type": "Tipo",
+    "indexes_columns": "Colunas",
+    "nullable_yes": "Sim",
+    "nullable_no": "Nao",
+    "not_available": "Nao disponivel",
+    "no_columns": "Nenhuma coluna encontrada.",
+    "no_indexes": "Nenhum indice encontrado.",
+    "indexes_not_supported": "Informacoes de indice nao estao disponiveis para este banco.",
+    "button_close": "Fechar",
+    "section_parameters": "Parametros",
+    "section_trigger_info": "Informacoes do Trigger",
+    "columns_direction": "Direcao",
+    "no_parameters": "Nenhum parametro encontrado.",
+    "trigger_event": "Evento",
+    "trigger_parent_table": "Tabela",
+    "trigger_timing": "Momento",
+    "section_routine_not_available": "Indice nao disponivel para este tipo de objeto."
+  },
   "tab_notification": {
     "dialog_title": "Notificacao da Aba",
     "section_config": "CONFIGURACAO DE NOTIFICACAO",
@@ -665,7 +719,6 @@
     "btn_cancel": "Cancelar",
     "badge_active": "Notificacao personalizada ativa"
   },
-
   "connections_manager": {
     "title": "Gerenciar Conexoes",
     "btn_new_group": "Novo Grupo",
@@ -721,7 +774,6 @@
     "import_export_confirm_title": "Confirmar Importacao",
     "import_export_confirm_msg": "Isso vai importar {count} conexao(oes) e {groups} grupo(s).\nConexoes existentes com mesmo nome serao substituidas.\nDeseja continuar?"
   },
-
   "connection_edit": {
     "title_new": "Nova Conexao",
     "title_edit": "Editar Conexao: {name}",
@@ -764,14 +816,12 @@
     "validation_name_required": "Nome da conexao e obrigatorio",
     "validation_host_required": "Host e obrigatorio"
   },
-
   "connection_picker": {
     "title": "Selecionar Conexao",
     "header": "SELECIONE UMA CONEXAO",
     "hint": "Clique duplo para selecionar",
     "btn_cancel": "Cancelar"
   },
-
   "export_to_table": {
     "title": "Exportar para Tabela",
     "info_row_col": "{rows} linhas x {cols} colunas",
@@ -802,7 +852,6 @@
     "validation_connection_required": "Selecione uma conexao",
     "validation_no_data": "Sem dados para exportar"
   },
-
   "file_import": {
     "title": "Importar Arquivo",
     "header": "Importar Dados",
@@ -844,7 +893,6 @@
     "checkbox_json_lines": "JSON Lines (um registro por linha)",
     "label_format": "Formato:"
   },
-
   "package_manager": {
     "title": "Gerenciador de Pacotes",
     "subtitle": "Pesquisar, instalar e gerenciar pacotes Python (pip)",
@@ -893,7 +941,6 @@
     "auth_token_placeholder": "PAT, chave de API ou senha",
     "auth_username_invalid": "O campo usuario deve conter um nome de usuario ou email, nao uma URL. Informe apenas o usuario para autenticacao."
   },
-
   "update_dialog": {
     "title": "Atualizacao Disponivel",
     "new_version_label": "Nova versao disponivel: {version}",
@@ -916,7 +963,6 @@
     "checking_connecting": "Conectando ao GitHub...",
     "checking_timeout": "Tempo esgotado."
   },
-
   "mixed_executor": {
     "no_connection": "Nenhuma conexao ativa com o banco de dados",
     "no_query_found": "Nenhuma query encontrada com sintaxe {{ SQL }}",
@@ -927,7 +973,6 @@
     "help_example": "EXEMPLO COMPLETO:",
     "help_shortcut": "ATALHO: Ctrl+Shift+F5"
   },
-
   "workers": {
     "error_sql": "Erro SQL: {msg}",
     "error_connection": "Erro de conexao: {msg}",
@@ -936,7 +981,6 @@
     "error_db_switch": "Erro ao trocar banco: {msg}",
     "error_failed_to_connect": "Falha ao conectar ao banco de dados"
   },
-
   "session": {
     "default_title": "Script",
     "default_title_n": "Script {n}",
@@ -944,19 +988,16 @@
     "status_disconnected": "Desconectado",
     "status_ready": "Pronto"
   },
-
   "schema_service": {
     "loading": "Carregando estrutura do banco...",
     "loaded": "Schema carregado: {tables} tabelas, {cols} colunas"
   },
-
   "docking": {
     "window_title": "DataPyn - Sistema de Docking",
     "menu_view": "&Exibir",
     "menu_reset_layout": "&Resetar Layout",
     "menu_panels": "&Paineis"
   },
-
   "copilot": {
     "title": "Copilot",
     "input_placeholder": "Pergunte ao Copilot... (Enter para enviar, Shift+Enter para nova linha)",
@@ -970,7 +1011,7 @@
     "not_authenticated": "Faca login com o GitHub para usar o Copilot.",
     "auth_instructions": "Para autenticar, insira o codigo **{code}** em:\n{url}\n\n(Codigo copiado para a area de transferencia)",
     "auth_code_instructions": "Insira este codigo no GitHub para autenticar:",
-    "copy_code": "Copiar Codigo",
+    "copy_code": "Copiar",
     "code_copied": "Copiado!",
     "waiting_auth": "Aguardando autenticacao...",
     "auth_success": "Autenticado com sucesso! Voce ja pode conversar com o Copilot.",
@@ -1009,7 +1050,6 @@
     "tool_running": "executando...",
     "tool_ok": "ok",
     "tool_error": "erro",
-    "copy_code": "Copiar",
     "copied_code": "Copiado!",
     "insert_code": "Inserir",
     "inserted_code": "Inserido!",
@@ -1017,7 +1057,6 @@
     "new_chat": "Novo Chat",
     "chat_history": "Historico"
   },
-
   "copilot_download": {
     "title": "Copilot Autocomplete",
     "downloading_title": "Baixando Copilot Engine",

--- a/source/src/services/auto_update_service.py
+++ b/source/src/services/auto_update_service.py
@@ -279,10 +279,29 @@ class AutoUpdateService:
 
     def cleanup(self):
         """Clean up resources"""
-        if self._check_thread and self._check_thread.isRunning():
-            self._check_thread.quit()
-            self._check_thread.wait()
+        self._stop_thread("_check_thread")
+        self._stop_thread("_download_thread")
+        self._checker = None
+        self._downloader = None
 
-        if self._download_thread and self._download_thread.isRunning():
-            self._download_thread.quit()
-            self._download_thread.wait()
+    def _stop_thread(self, attr_name: str):
+        thread = getattr(self, attr_name, None)
+        if not thread:
+            return
+
+        try:
+            is_running = thread.isRunning()
+        except RuntimeError:
+            setattr(self, attr_name, None)
+            return
+
+        if is_running:
+            try:
+                thread.quit()
+                if not thread.wait(3000):
+                    thread.terminate()
+                    thread.wait(1000)
+            except RuntimeError:
+                pass
+
+        setattr(self, attr_name, None)

--- a/source/src/services/copilot/copilot_client_sdk.py
+++ b/source/src/services/copilot/copilot_client_sdk.py
@@ -286,6 +286,7 @@ class CopilotWorker(QObject):
         self._cancelled = False
         self._prompt = ""
         self._system_message = ""
+        self._session_signature = None
         self._loop = None  # Persistent event loop
         self._inline_prompt = ""  # For inline completions
 
@@ -561,10 +562,18 @@ class CopilotWorker(QObject):
             for t in self._sdk_tools:
                 logger.info(f"  Tool: {t.name}")
 
-        # Create session if needed (or recreate to update tools)
-        if not self._session:
+        session_signature = self._build_session_signature()
+
+        # Create session if needed, or recreate when stable session config changes.
+        if not self._session or self._session_signature != session_signature:
             logger.info("[CHAT] Creating new session")
+            if self._session:
+                try:
+                    await self._session.abort()
+                except Exception:
+                    pass
             await self._async_create_session()
+            self._session_signature = session_signature
             logger.info("[CHAT] Copilot session created")
 
         if not self._prompt:
@@ -735,6 +744,11 @@ class CopilotWorker(QObject):
         
         self._session = await self._sdk_client.create_session(config)
 
+    def _build_session_signature(self):
+        """Return a stable signature for SDK session configuration."""
+        tool_names = tuple(t.name for t in self._sdk_tools) if self._sdk_tools else ()
+        return (self._model, self._system_message, tool_names)
+
     def _build_sdk_tools(self, SDKTool) -> List[Any]:
         """Build SDK Tool objects from MCP tool definitions."""
         if not self._tool_executor:
@@ -810,6 +824,9 @@ class CopilotWorker(QObject):
         Called in background after authentication to pre-warm the session.
         """
         import asyncio
+
+        if self._cancelled:
+            return
         
         try:
             if not self._loop or self._loop.is_closed():
@@ -822,18 +839,25 @@ class CopilotWorker(QObject):
 
     async def _async_init_session(self):
         """Async session initialization without completion."""
+        if self._cancelled:
+            return
+
         SDKClient, _, EventType, import_err = _try_import_sdk()
         if SDKClient is None:
             return
         
         # Initialize client
         if not self._sdk_client:
+            if self._cancelled:
+                return
             self._sdk_client = SDKClient(_get_sdk_options())
             await self._sdk_client.start()
             logger.info("Copilot SDK client started (pre-init)")
         
         # Create session
         if not self._session:
+            if self._cancelled:
+                return
             config = {
                 "model": "gpt-4o-mini",  # Fast model for completions
                 "streaming": True,
@@ -1157,7 +1181,11 @@ class CopilotClient(QObject):
             messages: List of message dicts with "role" and "content" keys.
                       The last user message is used as the prompt.
         """
-        # Extract prompt from last user message
+        # Extract prompt from last user message and system rules from latest system message.
+        system_messages = [m for m in messages if m.get("role") == "system"]
+        if system_messages:
+            self._system_message = system_messages[-1].get("content", "")
+
         user_messages = [m for m in messages if m.get("role") == "user"]
         if not user_messages:
             self.chat_error.emit("No user message to send")
@@ -1361,6 +1389,7 @@ Output ONLY the completion text (what should replace <CURSOR>):"""
                 worker.cancel()
                 # Disconnect signals to prevent callbacks
                 worker.complete.disconnect()
+                worker.inline_complete.disconnect()
                 worker.error.disconnect()
                 worker.finished.disconnect()
             except (RuntimeError, TypeError):
@@ -1646,6 +1675,12 @@ Output ONLY the completion text (what should replace <CURSOR>):"""
 
     def cleanup(self) -> None:
         """Clean up all resources."""
+        if self._lsp_client:
+            try:
+                self._lsp_client.cleanup()
+            except Exception:
+                pass
+            self._lsp_client = None
         self._cleanup_worker()
         self._cleanup_session_worker()
         self._cleanup_completion_worker()

--- a/source/src/services/copilot/copilot_lsp_client.py
+++ b/source/src/services/copilot/copilot_lsp_client.py
@@ -55,6 +55,7 @@ class CopilotLSPClient(QObject):
         self._process: Optional[subprocess.Popen] = None
         self._reader_thread: Optional[threading.Thread] = None
         self._lock = threading.Lock()
+        self._stopping = False
         
         # Request tracking
         self._request_id = 0
@@ -139,6 +140,8 @@ class CopilotLSPClient(QObject):
                 creationflags=_CREATE_NO_WINDOW,
             )
             
+            self._stopping = False
+
             # Start reader thread
             self._reader_thread = threading.Thread(
                 target=self._read_loop,
@@ -157,23 +160,46 @@ class CopilotLSPClient(QObject):
     
     def stop(self) -> None:
         """Stop the language server."""
-        if self._process:
+        self._stopping = True
+        process = self._process
+
+        if process:
             try:
                 # Send shutdown request
                 self._send_request("shutdown", {})
                 self._send_notification("exit", {})
                 
                 # Give it a moment to close gracefully
-                self._process.wait(timeout=2)
+                process.wait(timeout=2)
             except Exception:
                 pass
+
+            for pipe_name in ("stdin", "stdout", "stderr"):
+                pipe = getattr(process, pipe_name, None)
+                if pipe:
+                    try:
+                        pipe.close()
+                    except Exception:
+                        pass
             
             try:
-                self._process.terminate()
+                if process.poll() is None:
+                    process.terminate()
+                    process.wait(timeout=2)
+            except Exception:
+                pass
+
+            try:
+                if process.poll() is None:
+                    process.kill()
             except Exception:
                 pass
             
             self._process = None
+
+        if self._reader_thread and self._reader_thread.is_alive():
+            self._reader_thread.join(timeout=2)
+        self._reader_thread = None
         
         self._initialized = False
         self._set_authenticated(False, "stop")
@@ -707,13 +733,13 @@ class CopilotLSPClient(QObject):
     def _read_loop(self) -> None:
         """Background thread loop for reading server responses."""
         try:
-            while self._process and self._process.poll() is None:
+            while not self._stopping and self._process and self._process.poll() is None:
                 try:
                     message = self._read_message()
                     if message:
                         self._handle_message(message)
                 except Exception as e:
-                    if self._process and self._process.poll() is None:
+                    if not self._stopping and self._process and self._process.poll() is None:
                         logger.error(f"[LSP] Read error: {e}")
                     break
         except Exception as e:
@@ -723,13 +749,14 @@ class CopilotLSPClient(QObject):
     
     def _read_message(self) -> Optional[Dict[str, Any]]:
         """Read a single JSON-RPC message from stdout."""
-        if not self._process:
+        process = self._process
+        if not process:
             return None
         
         # Read headers
         headers = {}
         while True:
-            line = self._process.stdout.readline()
+            line = process.stdout.readline()
             if not line:
                 return None
             
@@ -746,7 +773,7 @@ class CopilotLSPClient(QObject):
         if content_length <= 0:
             return None
         
-        content = self._process.stdout.read(content_length)
+        content = process.stdout.read(content_length)
         if not content:
             return None
         

--- a/source/src/services/copilot/mcp_tools.py
+++ b/source/src/services/copilot/mcp_tools.py
@@ -239,8 +239,9 @@ class MCPToolRegistry(QObject):
         self._register(MCPTool(
             name="run_silent_query",
             description=(
-                "Execute SQL WITHOUT creating a visible block. Returns results directly. "
-                "Use for: row counts, checking values, exploring data, validating queries."
+                "Execute SQL WITHOUT creating a visible block or output-panel noise. "
+                "Use for exploration, row counts, checking values, schema/data inspection, "
+                "and validating a query before creating the final visible block."
             ),
             parameters={
                 "query": {
@@ -256,7 +257,8 @@ class MCPToolRegistry(QObject):
             description=(
                 "Execute Python WITHOUT creating a visible block. Runs in session namespace "
                 "(accesses existing DataFrames/variables). Returns stdout + result. "
-                "Use for: data exploration, calculations, type checks, testing code."
+                "Use for data exploration, calculations, type checks, and testing draft logic "
+                "before editing or creating the final visible block."
             ),
             parameters={
                 "code": {
@@ -270,7 +272,11 @@ class MCPToolRegistry(QObject):
         # === EXECUTE VISIBLY (user sees the block) ===
         self._register(MCPTool(
             name="write_and_run",
-            description="Create a new block, write code, execute, and return results - all in one call. Block NAME becomes the DataFrame variable for SQL. MOST COMMON tool.",
+            description=(
+                "Create OR UPDATE the final visible block, write complete code, execute, and return results. "
+                "If a block with the requested name already exists, update and run it instead of creating a duplicate. "
+                "Use only for final user-facing artifacts, not scratch work."
+            ),
             parameters={
                 "language": {
                     "type": "string",
@@ -292,7 +298,11 @@ class MCPToolRegistry(QObject):
 
         self._register(MCPTool(
             name="create_block",
-            description="Create a new block and write code WITHOUT executing. Use for multi-block setup before running all.",
+            description=(
+                "Create OR UPDATE one final visible block WITHOUT executing. "
+                "If the named block already exists, update it instead of creating a duplicate. "
+                "Do not use for scratch/intermediate exploration."
+            ),
             parameters={
                 "language": {
                     "type": "string",
@@ -647,9 +657,9 @@ class MCPToolRegistry(QObject):
         self._register(MCPTool(
             name="run_silent_query",
             description=(
-                "QUICK EXECUTE a SQL query WITHOUT creating a visible block. Returns results directly. "
-                "USE THIS for: data exploration, row counts, checking values, validating queries before "
-                "showing code to user. For code the user should see, use write_and_run with language='sql' instead."
+                "QUICK EXECUTE a SQL query WITHOUT creating a visible block or output-panel noise. "
+                "Use for data exploration, row counts, checking values, and validating queries before "
+                "creating/updating the final visible block with write_and_run."
             ),
             parameters={
                 "query": {
@@ -834,6 +844,8 @@ class MCPToolRegistry(QObject):
 
         if hasattr(mw, "session_manager") and mw.session_manager:
             session = mw.session_manager.create_session(title=title)
+            if getattr(session, "session_id", None):
+                self.pin_session(session.session_id)
             logger.info(f"create_tab: Created session id={session.session_id}, title={session.title}")
             return {
                 "content": [{"type": "text", "text": f"Tab created: '{session.title}' (id: {session.session_id})"}]
@@ -861,8 +873,13 @@ class MCPToolRegistry(QObject):
             logger.error(f"create_block: No editor on session_widget {type(session_widget)}")
             return {"error": "Block editor not available."}
 
-        logger.info(f"create_block: Adding block with language={language}")
-        block = block_editor.add_block(language=language)
+        block = self._find_block_by_name(block_editor, name) if name else None
+        updated_existing = block is not None
+        if block:
+            logger.info(f"create_block: Updating existing block name={name}")
+        else:
+            logger.info(f"create_block: Adding block with language={language}")
+            block = block_editor.add_block(language=language)
         if code and block:
             # Show copilot editing indicator
             self._signal_copilot_editing(block, block_editor)
@@ -879,7 +896,8 @@ class MCPToolRegistry(QObject):
         actual_name = block.get_block_name() if block else f"block{block_index + 1}"
         logger.info(f"create_block: Success, total blocks={block_count}, name={actual_name}")
         
-        msg_parts = [f"Block created (language: {language}, index: {block_index}, name: '{actual_name}')"]
+        action = "updated" if updated_existing else "created"
+        msg_parts = [f"Block {action} (language: {language}, index: {block_index}, name: '{actual_name}')"]
         if language == "sql":
             msg_parts.append(f"When executed, the result will be stored as DataFrame `{actual_name}`.")
         return {
@@ -1001,6 +1019,10 @@ class MCPToolRegistry(QObject):
         # Use _connect_new_tab which always creates a new tab
         if hasattr(mw, "_connect_new_tab"):
             mw._connect_new_tab(connection_name)
+            current_widget = mw._get_current_session_widget() if hasattr(mw, "_get_current_session_widget") else None
+            session = getattr(current_widget, "session", None) if current_widget else None
+            if getattr(session, "session_id", None):
+                self.pin_session(session.session_id)
             return {
                 "content": [{"type": "text", "text": f"New tab created and connecting to '{connection_name}'."}]
             }
@@ -1231,6 +1253,20 @@ class MCPToolRegistry(QObject):
             return editor
         
         logger.warning(f"_get_block_editor: No valid editor found on {type(session_widget)}")
+        return None
+
+    def _find_block_by_name(self, block_editor, name: str):
+        """Find a block by semantic name, case-insensitive."""
+        if not block_editor or not name:
+            return None
+        target = str(name).strip().lower()
+        for block in getattr(block_editor, "blocks", []) or []:
+            try:
+                block_name = block.get_block_name() if hasattr(block, "get_block_name") else ""
+                if str(block_name).strip().lower() == target:
+                    return block
+            except Exception:
+                continue
         return None
 
     def _resolve_block(self, args: Dict[str, Any], require=False):
@@ -1702,26 +1738,32 @@ class MCPToolRegistry(QObject):
             logger.error(f"write_and_run: No block_editor on {type(session_widget)}")
             return {"error": "Block editor not available."}
 
-        # 1. Create the block
-        logger.info("write_and_run: Creating block...")
-        block = block_editor.add_block(language=language)
-        if not block:
-            logger.error("write_and_run: add_block returned None")
-            return {"error": "Failed to create block."}
+        block = self._find_block_by_name(block_editor, name) if name else None
+        if block:
+            logger.info(f"write_and_run: Updating existing block '{name}'")
+            if hasattr(block, "set_language"):
+                try:
+                    block.set_language(language)
+                except Exception as e:
+                    logger.debug(f"write_and_run: Could not set language on existing block: {e}")
+        else:
+            logger.info("write_and_run: Creating block...")
+            block = block_editor.add_block(language=language)
+            if not block:
+                logger.error("write_and_run: add_block returned None")
+                return {"error": "Failed to create block."}
 
-        # 2. Set block name if provided
-        if name:
-            block.set_block_name(name)
-            logger.info(f"write_and_run: Set block name to '{name}'")
+            if name:
+                block.set_block_name(name)
+                logger.info(f"write_and_run: Set block name to '{name}'")
 
-        # 3. Write the code
         logger.info("write_and_run: Setting code...")
         # Show copilot editing indicator and scroll into view
         self._signal_copilot_editing(block, block_editor)
         block.set_code(code)
-        block_index = len(block_editor.blocks) - 1
+        block_index = block_editor.blocks.index(block) if block in block_editor.blocks else len(block_editor.blocks) - 1
         actual_name = block.get_block_name()
-        logger.info(f"write_and_run: Block {block_index} ('{actual_name}') created with {len(code)} chars")
+        logger.info(f"write_and_run: Block {block_index} ('{actual_name}') prepared with {len(code)} chars")
 
         # 4. Execute the block and wait for results
         return self._execute_block_with_result(block, block_editor, block_index)

--- a/source/src/services/copilot/system_prompt.py
+++ b/source/src/services/copilot/system_prompt.py
@@ -1,10 +1,9 @@
 """
-System prompt template for the Copilot chat integration.
+System prompt helpers for the Copilot chat integration.
 
-The prompt is built dynamically with placeholders for:
-- {tools_list} - categorized tool descriptions
-- {context_json} - current editor state (blocks, connection, schema)
-- {schema_text} - database schema if connected
+The SDK keeps conversation state in a persistent session. To avoid recreating
+that session on every editor change, keep stable behavior rules in the system
+message and inject the current DataPyn state into each user turn.
 """
 
 SYSTEM_PROMPT_TEMPLATE = """\
@@ -29,33 +28,47 @@ All block tools accept `block_name` (preferred) OR `block_index`.
 - Omit both to target the focused block.
 
 ### EDIT vs CREATE (MOST IMPORTANT RULE)
-**Before writing code, ALWAYS call `get_context` to see existing blocks.**
-- If a block with that purpose ALREADY EXISTS -> use `edit_block` to UPDATE it.
-- If no relevant block exists -> use `write_and_run` to CREATE a new one.
-- NEVER create a duplicate block. If the user says "fix the vendas query", edit block "vendas" - do NOT create a new block.
-- NEVER delete and recreate a block. Use `edit_block` instead.
+- The request includes a current context snapshot. Use it before acting.
+- If a block with that purpose ALREADY EXISTS -> UPDATE it. Prefer `edit_block_lines` for small changes.
+- If a block rewrite is clearer and safe -> use `edit_block`, preserving name, language, position, and connection.
+- If no relevant block exists and the user wants a DataPyn deliverable -> create ONE final visible tab/block.
+- NEVER create scratch/intermediate blocks for planning, exploration, validation, or retries.
+- NEVER create a duplicate block. If the user says "fix the vendas query", edit block "vendas".
+- NEVER delete and recreate a block unless the user explicitly asks.
 
 ## SILENT vs VISIBLE
-- **SILENT** (`run_silent_query`, `run_silent_python`): Execute without creating blocks. Use for exploration, counting, checking values. The user does NOT see these.
-- **VISIBLE** (`write_and_run`, `create_block`): Create blocks the user sees. Use when user needs final code/results.
-- **RULE**: For questions ("how many rows?", "what columns?"), ALWAYS use silent tools. NEVER create a block just to answer a question.
+- **SILENT** (`run_silent_query`, `run_silent_python`): Execute without creating blocks or polluting output panels. Use for schema/data exploration, row counts, checking values, and validating draft logic.
+- **VISIBLE** (`write_and_run`, `create_block`, `create_tab`, `open_connection`): Produce a final user-facing artifact in DataPyn.
+- **RULE**: For pure questions ("how many rows?", "what columns?"), use silent tools and answer in chat. Do not create a block just to answer.
+- **RULE**: For actionable deliverables ("lista os produtos da base green", "gera a analise", "monta o grafico"), silently inspect what you need, then create or update at most the final useful tab/block and execute it when helpful.
 
 ## WORKFLOW
-1. `get_context` -> see all blocks with names, indexes, code, and variables.
-2. `think` -> plan: which blocks exist? do I need to EDIT or CREATE?
-3. Silent tools -> explore/validate data if needed.
-4. `edit_block(block_name=..., code=...)` to update existing blocks, or `write_and_run(...)` for new ones.
-5. `get_execution_results` -> verify results.
+1. Read the provided context snapshot first.
+2. `think` briefly: existing block to edit, silent exploration needed, final artifact needed?
+3. Use silent tools to inspect connections, schema, data, and validate logic.
+4. Edit an existing block when possible. Create/open a tab and create ONE final block only for a final deliverable.
+5. Execute automatically when it helps finish the task.
+6. Respond with a concise summary in the user's language. Keep detailed results in DataPyn panels/blocks.
 
 ## RULES
 - Give SQL blocks SEMANTIC NAMES (e.g., "vendas", not "block1").
 - Put COMPLETE code in one block.
 - NEVER delete blocks unless explicitly asked.
+- Keep the visible notebook clean: no scratch blocks, no duplicate blocks, no repeated near-identical retry blocks.
+- If a tool times out or execution is still running, tell the user it is continuing in DataPyn and how to inspect it.
 - Respond in the user's language.
 
-{tools_list}
+{tools_list}\
+"""
 
-{context_section}\
+
+REQUEST_PROMPT_TEMPLATE = """\
+Use this current DataPyn context for the request. It is internal context, not user-visible chat history.
+
+{context_section}
+
+User request:
+{user_prompt}\
 """
 
 
@@ -141,4 +154,12 @@ def build_context_section(context_json: str = "", schema_text: str = "") -> str:
         parts.append(f"## Current Editor State\n```json\n{context_json}\n```")
     if schema_text and "No schema" not in schema_text:
         parts.append(f"## Database Schema\n{schema_text}")
-    return "\n\n".join(parts)
+    return "\n\n".join(parts) if parts else "## Current DataPyn Context\n{}"
+
+
+def build_request_prompt(user_prompt: str, context_section: str = "") -> str:
+    """Build the per-turn prompt sent as the SDK user message."""
+    return REQUEST_PROMPT_TEMPLATE.format(
+        context_section=context_section or "## Current DataPyn Context\n{}",
+        user_prompt=user_prompt,
+    )

--- a/source/src/services/entity_metadata_service.py
+++ b/source/src/services/entity_metadata_service.py
@@ -1,0 +1,1098 @@
+"""
+Entity metadata service.
+
+Provides background-safe database introspection used by the SQL editor
+entity information dialog and shared type formatting helpers for schema UI.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Mapping
+
+from PyQt6.QtCore import QObject, pyqtSignal
+
+logger = logging.getLogger(__name__)
+
+RECOVERABLE_METADATA_ERROR_TOKENS = (
+    "permission denied",
+    "does not have permission",
+    "access denied",
+    "not authorized",
+    "authorization failed",
+    "insufficient privilege",
+    "view database performance state",
+    "view server performance state",
+    "the select permission was denied",
+)
+
+
+def _normalize_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {str(key).lower(): value for key, value in dict(row).items()}
+
+
+def _records(df) -> list[dict[str, Any]]:
+    if df is None or len(df) == 0:
+        return []
+    return [_normalize_row(row) for row in df.to_dict("records")]
+
+
+def _first_record(df) -> dict[str, Any] | None:
+    rows = _records(df)
+    return rows[0] if rows else None
+
+
+def _first_value(df) -> Any:
+    if df is None or len(df) == 0:
+        return None
+    return df.iloc[0, 0]
+
+
+def _int_or_none(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        try:
+            return int(float(value))
+        except (TypeError, ValueError):
+            return None
+
+
+def _bool_value(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    text = str(value).strip().lower()
+    return text in {"1", "true", "t", "yes", "y"}
+
+
+def _is_recoverable_metadata_error(exc: Exception) -> bool:
+    message = str(exc).strip().lower()
+    return any(token in message for token in RECOVERABLE_METADATA_ERROR_TOKENS)
+
+
+def sql_literal(value: str) -> str:
+    return value.replace("'", "''")
+
+
+def strip_identifier_quotes(value: str) -> str:
+    text = value.strip()
+    for left, right in (("[", "]"), ('"', '"'), ("`", "`")):
+        while text.startswith(left) and text.endswith(right) and len(text) >= 2:
+            text = text[1:-1].strip()
+    return text
+
+
+def split_qualified_name(identifier: str) -> list[str]:
+    parts = [strip_identifier_quotes(part) for part in identifier.strip().split(".")]
+    return [part for part in parts if part]
+
+
+def quote_identifier(db_type: str, *parts: str) -> str:
+    clean_parts = [part for part in (strip_identifier_quotes(p) for p in parts) if part]
+    if not clean_parts:
+        return ""
+
+    normalized = (db_type or "").lower()
+    if normalized in {"sqlserver", "mssql"}:
+        return ".".join(f"[{part}]" for part in clean_parts)
+    if normalized in {"mysql", "mariadb", "databricks"}:
+        return ".".join(f"`{part}`" for part in clean_parts)
+    return ".".join(f'"{part}"' for part in clean_parts)
+
+
+def _postgres_regclass_literal(*parts: str) -> str:
+    quoted = ".".join(f'"{strip_identifier_quotes(part)}"' for part in parts if part)
+    return sql_literal(quoted)
+
+
+def build_display_data_type(column_info: Mapping[str, Any], db_type: str) -> str:
+    info = _normalize_row(column_info)
+    raw_type = str(info.get("display_type") or info.get("data_type") or info.get("type") or "").strip()
+    if not raw_type:
+        return ""
+
+    if any(token in raw_type for token in ("(", "<", "[]")):
+        return raw_type
+
+    normalized_db = (db_type or "").lower()
+    normalized_type = raw_type.lower()
+    aliases = {
+        "character varying": "varchar",
+        "character": "char",
+    }
+    base_type = aliases.get(normalized_type, normalized_type)
+
+    if normalized_db == "postgresql":
+        udt_name = str(info.get("udt_name") or "").strip()
+        if normalized_type == "array" and udt_name.startswith("_"):
+            return f"{udt_name[1:]}[]"
+        if normalized_type == "user-defined" and udt_name:
+            return udt_name
+
+    length = _int_or_none(
+        info.get("character_maximum_length")
+        or info.get("max_length")
+        or info.get("character_length")
+    )
+    precision = _int_or_none(info.get("numeric_precision") or info.get("precision"))
+    scale = _int_or_none(info.get("numeric_scale") or info.get("scale"))
+    datetime_precision = _int_or_none(info.get("datetime_precision"))
+
+    if base_type in {"varchar", "nvarchar", "char", "nchar", "string", "varbinary", "binary"} and length is not None:
+        length_text = "max" if length < 0 else str(length)
+        return f"{base_type}({length_text})"
+
+    if base_type in {"decimal", "numeric", "number"} and precision is not None:
+        if scale is None:
+            return f"{base_type}({precision})"
+        return f"{base_type}({precision},{scale})"
+
+    if base_type in {"datetime2", "datetimeoffset", "time", "timestamp"} and datetime_precision is not None:
+        return f"{base_type}({datetime_precision})"
+
+    return base_type
+
+
+def format_size(size_bytes: Any) -> str:
+    size_value = _int_or_none(size_bytes)
+    if size_value is None or size_value < 0:
+        return ""
+
+    value = float(size_value)
+    units = ["B", "KB", "MB", "GB", "TB"]
+    unit_index = 0
+    while value >= 1024 and unit_index < len(units) - 1:
+        value /= 1024
+        unit_index += 1
+    if unit_index == 0:
+        return f"{int(value)} {units[unit_index]}"
+    return f"{value:.2f} {units[unit_index]}"
+
+
+def _group_indexes(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    grouped: dict[str, dict[str, Any]] = {}
+
+    for row in rows:
+        name = str(row.get("index_name") or row.get("indexname") or "").strip()
+        if not name:
+            continue
+
+        column_name = str(row.get("column_name") or row.get("attname") or "").strip()
+        ordinal = _int_or_none(row.get("key_ordinal") or row.get("seq_in_index") or row.get("ordinality")) or 0
+        unique = _bool_value(row.get("is_unique", not _bool_value(row.get("non_unique"))))
+        primary = _bool_value(row.get("is_primary_key") or row.get("indisprimary") or (name == "PRIMARY"))
+        type_desc = str(row.get("type_desc") or row.get("index_type") or row.get("indexdef") or "").strip()
+
+        index_info = grouped.setdefault(
+            name,
+            {
+                "name": name,
+                "unique": unique,
+                "primary": primary,
+                "type": type_desc,
+                "columns": [],
+            },
+        )
+        index_info["unique"] = index_info["unique"] or unique
+        index_info["primary"] = index_info["primary"] or primary
+        if type_desc and not index_info["type"]:
+            index_info["type"] = type_desc
+        if column_name:
+            index_info["columns"].append((ordinal, column_name))
+
+    results = []
+    for index_info in grouped.values():
+        ordered_columns = ", ".join(
+            column_name for _, column_name in sorted(index_info["columns"], key=lambda item: item[0])
+        )
+        if index_info["primary"]:
+            label = "PRIMARY KEY"
+        elif index_info["unique"]:
+            label = "UNIQUE"
+        elif index_info["type"]:
+            label = index_info["type"]
+        else:
+            label = "INDEX"
+
+        results.append(
+            {
+                "name": index_info["name"],
+                "type": label,
+                "columns": ordered_columns,
+                "unique": index_info["unique"],
+                "primary": index_info["primary"],
+            }
+        )
+
+    return sorted(results, key=lambda item: (not item["primary"], not item["unique"], item["name"].lower()))
+
+
+class EntityMetadataService:
+    """Database introspection service for relation metadata."""
+
+    def fetch_entity_info(self, connector, entity_name: str) -> dict[str, Any]:
+        db_type = str(getattr(connector, "db_type", "") or "").lower()
+        parts = split_qualified_name(entity_name)
+        if not parts:
+            raise ValueError("No entity name provided")
+
+        if db_type in {"sqlserver", "mssql"}:
+            return self._fetch_sqlserver_info(connector, parts)
+        if db_type == "postgresql":
+            return self._fetch_postgresql_info(connector, parts)
+        if db_type in {"mysql", "mariadb"}:
+            return self._fetch_mysql_info(connector, parts, db_type)
+        if db_type == "databricks":
+            return self._fetch_databricks_info(connector, parts)
+        raise ValueError(f"Unsupported database type: {db_type}")
+
+    def _execute_scalar(self, connector, query: str) -> Any:
+        return _first_value(connector.execute_query(query))
+
+    def _execute_optional_scalar(self, connector, query: str, *, context: str) -> Any:
+        try:
+            return self._execute_scalar(connector, query)
+        except Exception as exc:
+            if _is_recoverable_metadata_error(exc):
+                logger.info("Optional metadata query failed for %s: %s", context, exc)
+                return None
+            raise
+
+    def _execute_optional_records(
+        self,
+        connector,
+        query: str,
+        *,
+        context: str,
+    ) -> list[dict[str, Any]] | None:
+        try:
+            return _records(connector.execute_query(query))
+        except Exception as exc:
+            if _is_recoverable_metadata_error(exc):
+                logger.info("Optional metadata query failed for %s: %s", context, exc)
+                return None
+            raise
+
+    def _load_columns(self, connector, query: str, db_type: str) -> list[dict[str, Any]]:
+        rows = _records(connector.execute_query(query))
+        results = []
+        for row in rows:
+            results.append(
+                {
+                    "name": str(row.get("column_name") or row.get("name") or ""),
+                    "display_type": build_display_data_type(row, db_type),
+                    "nullable": str(row.get("is_nullable") or row.get("nullable") or "YES"),
+                    "default": row.get("column_default") or row.get("default_value") or "",
+                    "ordinal_position": _int_or_none(row.get("ordinal_position")) or 0,
+                }
+            )
+        return results
+
+    def _base_result(
+        self,
+        connector,
+        *,
+        database: str,
+        catalog: str,
+        schema: str,
+        entity_name: str,
+        entity_type: str,
+        row_count: int | None,
+        size_bytes: int | None,
+        columns: list[dict[str, Any]],
+        indexes: list[dict[str, Any]],
+        indexes_supported: bool = True,
+        parameters: list[dict[str, Any]] | None = None,
+        section_type: str = "table",
+        definition: str = "",
+    ) -> dict[str, Any]:
+        return {
+            "db_type": str(getattr(connector, "db_type", "") or "").lower(),
+            "database": database,
+            "catalog": catalog,
+            "schema": schema,
+            "entity_name": entity_name,
+            "entity_type": entity_type,
+            "qualified_name": ".".join(part for part in (catalog, schema, entity_name) if part),
+            "row_count": row_count,
+            "size_bytes": size_bytes,
+            "size_pretty": format_size(size_bytes),
+            "columns": sorted(columns, key=lambda item: item["ordinal_position"]),
+            "indexes": indexes,
+            "indexes_supported": indexes_supported,
+            "parameters": parameters or [],
+            "section_type": section_type,
+            "definition": definition,
+        }
+
+    def _sqlserver_row_count(self, connector, schema_name: str, entity_name: str, entity_type: str) -> int | None:
+        if entity_type.upper() == "VIEW":
+            return None
+        return _int_or_none(
+            self._execute_optional_scalar(
+                connector,
+                f"""
+                SELECT CAST(SUM(p.rows) AS BIGINT)
+                FROM sys.tables t
+                JOIN sys.schemas s ON s.schema_id = t.schema_id
+                JOIN sys.partitions p ON p.object_id = t.object_id
+                WHERE s.name = '{sql_literal(schema_name)}'
+                  AND t.name = '{sql_literal(entity_name)}'
+                  AND p.index_id IN (0, 1)
+                """,
+                context=f"SQL Server row count for {schema_name}.{entity_name}",
+            )
+        )
+
+    def _sqlserver_size_bytes(self, connector, schema_name: str, entity_name: str, entity_type: str) -> int | None:
+        if entity_type.upper() == "VIEW":
+            return None
+        return _int_or_none(
+            self._execute_optional_scalar(
+                connector,
+                f"""
+                SELECT CAST(SUM(a.total_pages) * 8192 AS BIGINT)
+                FROM sys.tables t
+                JOIN sys.schemas s ON s.schema_id = t.schema_id
+                JOIN sys.indexes i ON i.object_id = t.object_id
+                JOIN sys.partitions p ON p.object_id = i.object_id AND p.index_id = i.index_id
+                JOIN sys.allocation_units a
+                    ON a.container_id = CASE WHEN a.type IN (1, 3) THEN p.hobt_id ELSE p.partition_id END
+                WHERE s.name = '{sql_literal(schema_name)}'
+                  AND t.name = '{sql_literal(entity_name)}'
+                  AND i.index_id IN (0, 1)
+                """,
+                context=f"SQL Server size for {schema_name}.{entity_name}",
+            )
+        )
+
+    def _sqlserver_indexes(self, connector, schema_name: str, entity_name: str) -> tuple[list[dict[str, Any]], bool]:
+        rows = self._execute_optional_records(
+            connector,
+            f"""
+            SELECT
+                i.name AS index_name,
+                i.type_desc AS type_desc,
+                i.is_unique AS is_unique,
+                i.is_primary_key AS is_primary_key,
+                c.name AS column_name,
+                ic.key_ordinal AS key_ordinal
+            FROM sys.indexes i
+            JOIN sys.index_columns ic
+                ON i.object_id = ic.object_id AND i.index_id = ic.index_id
+            JOIN sys.columns c
+                ON ic.object_id = c.object_id AND ic.column_id = c.column_id
+            JOIN sys.objects o ON i.object_id = o.object_id
+            JOIN sys.schemas s ON o.schema_id = s.schema_id
+            WHERE s.name = '{sql_literal(schema_name)}'
+              AND o.name = '{sql_literal(entity_name)}'
+              AND i.is_hypothetical = 0
+              AND i.name IS NOT NULL
+            ORDER BY i.is_primary_key DESC, i.is_unique DESC, i.name, ic.key_ordinal
+            """,
+            context=f"SQL Server indexes for {schema_name}.{entity_name}",
+        )
+        if rows is None:
+            return [], False
+        return _group_indexes(rows), True
+
+    def _postgres_row_count(self, connector, schema_name: str, entity_name: str, entity_type: str) -> int | None:
+        if entity_type.upper() == "VIEW":
+            return None
+        return _int_or_none(
+            self._execute_scalar(
+                connector,
+                f"""
+                SELECT CAST(COALESCE(stat.n_live_tup, cls.reltuples, 0) AS BIGINT)
+                FROM pg_class cls
+                JOIN pg_namespace ns ON ns.oid = cls.relnamespace
+                LEFT JOIN pg_stat_all_tables stat ON stat.relid = cls.oid
+                WHERE ns.nspname = '{sql_literal(schema_name)}'
+                  AND cls.relname = '{sql_literal(entity_name)}'
+                LIMIT 1
+                """,
+            )
+        )
+
+    def _mysql_row_count(self, resolved: Mapping[str, Any], entity_type: str) -> int | None:
+        if entity_type.upper() == "VIEW":
+            return None
+        return _int_or_none(resolved.get("table_rows"))
+
+    def _databricks_row_count(self, detail: Mapping[str, Any] | None, entity_type: str) -> int | None:
+        if entity_type.upper() == "VIEW" or not detail:
+            return None
+        return _int_or_none(detail.get("numrows"))
+
+    def _sqlserver_parameters(
+        self, connector, schema_name: str, routine_name: str, db_type: str
+    ) -> list[dict[str, Any]]:
+        rows = self._execute_optional_records(
+            connector,
+            f"""
+            SELECT
+                COALESCE(PARAMETER_NAME, '') AS parameter_name,
+                DATA_TYPE AS data_type,
+                COALESCE(PARAMETER_MODE, 'IN') AS parameter_mode,
+                CHARACTER_MAXIMUM_LENGTH AS character_maximum_length,
+                NUMERIC_PRECISION AS numeric_precision,
+                NUMERIC_SCALE AS numeric_scale,
+                ORDINAL_POSITION AS ordinal_position
+            FROM INFORMATION_SCHEMA.PARAMETERS
+            WHERE SPECIFIC_SCHEMA = '{sql_literal(schema_name)}'
+              AND SPECIFIC_NAME = '{sql_literal(routine_name)}'
+            ORDER BY ORDINAL_POSITION
+            """,
+            context=f"SQL Server parameters for {schema_name}.{routine_name}",
+        )
+        if not rows:
+            return []
+        result = []
+        for row in rows:
+            result.append(
+                {
+                    "name": str(row.get("parameter_name") or ""),
+                    "display_type": build_display_data_type(row, db_type),
+                    "direction": str(row.get("parameter_mode") or "IN"),
+                    "default": "",
+                    "ordinal_position": _int_or_none(row.get("ordinal_position")) or 0,
+                }
+            )
+        return result
+
+    def _sqlserver_trigger_columns(
+        self, connector, schema_name: str, trigger_name: str
+    ) -> list[dict[str, Any]]:
+        records = self._execute_optional_records(
+            connector,
+            f"""
+            SELECT
+                t.name AS trigger_name,
+                p.name AS parent_table,
+                ps.name AS parent_schema,
+                CASE t.is_instead_of_trigger WHEN 1 THEN 'INSTEAD OF' ELSE 'AFTER' END AS timing,
+                CONCAT(
+                    CASE WHEN OBJECTPROPERTY(t.object_id, 'ExecIsInsertTrigger') = 1 THEN 'INSERT ' ELSE '' END,
+                    CASE WHEN OBJECTPROPERTY(t.object_id, 'ExecIsUpdateTrigger') = 1 THEN 'UPDATE ' ELSE '' END,
+                    CASE WHEN OBJECTPROPERTY(t.object_id, 'ExecIsDeleteTrigger') = 1 THEN 'DELETE' ELSE '' END
+                ) AS events,
+                CASE WHEN t.is_disabled = 1 THEN 'Disabled' ELSE 'Enabled' END AS status
+            FROM sys.triggers t
+            JOIN sys.objects p ON t.parent_id = p.object_id
+            JOIN sys.schemas ps ON p.schema_id = ps.schema_id
+            WHERE t.name = '{sql_literal(trigger_name)}'
+            """,
+            context=f"SQL Server trigger info for {trigger_name}",
+        )
+        row = (records or [{}])[0]
+        return [
+            {"name": "Parent Table", "display_type": str(row.get("parent_schema") or "") + "." + str(row.get("parent_table") or ""), "direction": "", "default": "", "ordinal_position": 1},
+            {"name": "Events", "display_type": str(row.get("events") or "").strip(), "direction": "", "default": "", "ordinal_position": 2},
+            {"name": "Timing", "display_type": str(row.get("timing") or ""), "direction": "", "default": "", "ordinal_position": 3},
+            {"name": "Status", "display_type": str(row.get("status") or ""), "direction": "", "default": "", "ordinal_position": 4},
+        ]
+
+    def _fetch_sqlserver_info(self, connector, parts: list[str]) -> dict[str, Any]:
+        preferred_schema = parts[-2] if len(parts) >= 2 else "dbo"
+        schema_filter = (
+            f"AND s.name = '{sql_literal(parts[-2])}'" if len(parts) >= 2 else ""
+        )
+        entity_name = parts[-1]
+        resolved = _first_record(
+            connector.execute_query(
+                f"""
+                SELECT TOP 1
+                    s.name AS schema_name,
+                    o.name AS entity_name,
+                    CASE o.type
+                        WHEN 'U' THEN 'TABLE'
+                        WHEN 'V' THEN 'VIEW'
+                        WHEN 'P' THEN 'PROCEDURE'
+                        WHEN 'FN' THEN 'FUNCTION'
+                        WHEN 'IF' THEN 'FUNCTION'
+                        WHEN 'TF' THEN 'FUNCTION'
+                        WHEN 'TR' THEN 'TRIGGER'
+                        ELSE RTRIM(o.type_desc)
+                    END AS entity_type,
+                    o.type AS object_type_code
+                FROM sys.objects o
+                JOIN sys.schemas s ON s.schema_id = o.schema_id
+                WHERE o.type IN ('U', 'V', 'P', 'FN', 'IF', 'TF', 'TR')
+                  AND o.name = '{sql_literal(entity_name)}'
+                  {schema_filter}
+                ORDER BY CASE WHEN s.name = '{sql_literal(preferred_schema)}' THEN 0 ELSE 1 END, s.name
+                """
+            )
+        )
+        if not resolved:
+            raise ValueError(f"Entity not found: {entity_name}")
+
+        schema_name = str(resolved["schema_name"])
+        resolved_name = str(resolved["entity_name"])
+        entity_type = str(resolved["entity_type"])
+        database_name = str(getattr(connector, "get_current_database", lambda: "")() or "")
+
+        if entity_type in ("PROCEDURE", "FUNCTION"):
+            params = self._sqlserver_parameters(connector, schema_name, resolved_name, "sqlserver")
+            return self._base_result(
+                connector,
+                database=database_name,
+                catalog="",
+                schema=schema_name,
+                entity_name=resolved_name,
+                entity_type=entity_type,
+                row_count=None,
+                size_bytes=None,
+                columns=[],
+                indexes=[],
+                indexes_supported=False,
+                parameters=params,
+                section_type="routine",
+            )
+
+        if entity_type == "TRIGGER":
+            trigger_cols = self._sqlserver_trigger_columns(connector, schema_name, resolved_name)
+            return self._base_result(
+                connector,
+                database=database_name,
+                catalog="",
+                schema=schema_name,
+                entity_name=resolved_name,
+                entity_type=entity_type,
+                row_count=None,
+                size_bytes=None,
+                columns=[],
+                indexes=[],
+                indexes_supported=False,
+                parameters=trigger_cols,
+                section_type="trigger",
+            )
+
+        row_count = self._sqlserver_row_count(connector, schema_name, resolved_name, entity_type)
+        size_bytes = self._sqlserver_size_bytes(connector, schema_name, resolved_name, entity_type)
+
+        columns = self._load_columns(
+            connector,
+            f"""
+            SELECT
+                COLUMN_NAME,
+                DATA_TYPE,
+                CHARACTER_MAXIMUM_LENGTH,
+                NUMERIC_PRECISION,
+                NUMERIC_SCALE,
+                DATETIME_PRECISION,
+                IS_NULLABLE,
+                COLUMN_DEFAULT,
+                ORDINAL_POSITION
+            FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_SCHEMA = '{sql_literal(schema_name)}'
+              AND TABLE_NAME = '{sql_literal(resolved_name)}'
+            ORDER BY ORDINAL_POSITION
+            """,
+            "sqlserver",
+        )
+        indexes, indexes_supported = self._sqlserver_indexes(connector, schema_name, resolved_name)
+
+        return self._base_result(
+            connector,
+            database=database_name,
+            catalog="",
+            schema=schema_name,
+            entity_name=resolved_name,
+            entity_type=entity_type,
+            row_count=row_count,
+            size_bytes=size_bytes,
+            columns=columns,
+            indexes=indexes,
+            indexes_supported=indexes_supported,
+        )
+
+    def _fetch_postgresql_info(self, connector, parts: list[str]) -> dict[str, Any]:
+        preferred_schema = parts[-2] if len(parts) >= 2 else str(
+            self._execute_scalar(connector, "SELECT current_schema()")
+            or "public"
+        )
+        schema_filter = (
+            f"AND table_schema = '{sql_literal(parts[-2])}'" if len(parts) >= 2 else ""
+        )
+        entity_name = parts[-1]
+
+        resolved = _first_record(
+            connector.execute_query(
+                f"""
+                SELECT table_schema AS schema_name, table_name AS entity_name, table_type AS entity_type
+                FROM information_schema.tables
+                WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
+                  AND table_name = '{sql_literal(entity_name)}'
+                  {schema_filter}
+                ORDER BY CASE WHEN table_schema = '{sql_literal(preferred_schema)}' THEN 0 ELSE 1 END, table_schema
+                LIMIT 1
+                """
+            )
+        )
+
+        if not resolved:
+            # Check routines
+            routine_schema_filter = (
+                f"AND routine_schema = '{sql_literal(parts[-2])}'" if len(parts) >= 2 else ""
+            )
+            resolved = _first_record(
+                self._execute_optional_records(
+                    connector,
+                    f"""
+                    SELECT routine_schema AS schema_name, routine_name AS entity_name,
+                           routine_type AS entity_type
+                    FROM information_schema.routines
+                    WHERE routine_schema NOT IN ('pg_catalog', 'information_schema')
+                      AND routine_name = '{sql_literal(entity_name)}'
+                      {routine_schema_filter}
+                    ORDER BY CASE WHEN routine_schema = '{sql_literal(preferred_schema)}' THEN 0 ELSE 1 END, routine_schema
+                    LIMIT 1
+                    """,
+                    context=f"PostgreSQL routines for {entity_name}",
+                )
+                or []
+            )
+
+        if not resolved:
+            raise ValueError(f"Entity not found: {entity_name}")
+
+        schema_name = str(resolved["schema_name"])
+        resolved_name = str(resolved["entity_name"])
+        entity_type = str(resolved["entity_type"]).upper()
+        if entity_type == "BASE TABLE":
+            entity_type = "TABLE"
+
+        database_name = str(getattr(connector, "get_current_database", lambda: "")() or "")
+
+        if entity_type in ("PROCEDURE", "FUNCTION"):
+            params = self._execute_optional_records(
+                connector,
+                f"""
+                SELECT
+                    COALESCE(parameter_name, '') AS parameter_name,
+                    data_type,
+                    COALESCE(parameter_mode, 'IN') AS parameter_mode,
+                    character_maximum_length,
+                    numeric_precision,
+                    numeric_scale,
+                    ordinal_position
+                FROM information_schema.parameters
+                WHERE specific_schema = '{sql_literal(schema_name)}'
+                  AND specific_name = '{sql_literal(resolved_name)}'
+                ORDER BY ordinal_position
+                """,
+                context=f"PostgreSQL parameters for {schema_name}.{resolved_name}",
+            ) or []
+            parameters = [
+                {
+                    "name": str(r.get("parameter_name") or ""),
+                    "display_type": build_display_data_type(r, "postgresql"),
+                    "direction": str(r.get("parameter_mode") or "IN"),
+                    "default": "",
+                    "ordinal_position": _int_or_none(r.get("ordinal_position")) or 0,
+                }
+                for r in params
+            ]
+            return self._base_result(
+                connector,
+                database=database_name,
+                catalog="",
+                schema=schema_name,
+                entity_name=resolved_name,
+                entity_type=entity_type,
+                row_count=None,
+                size_bytes=None,
+                columns=[],
+                indexes=[],
+                indexes_supported=False,
+                parameters=parameters,
+                section_type="routine",
+            )
+
+        regclass_name = _postgres_regclass_literal(schema_name, resolved_name)
+
+        row_count = self._postgres_row_count(connector, schema_name, resolved_name, entity_type)
+        size_bytes = _int_or_none(
+            self._execute_scalar(
+                connector,
+                f"SELECT pg_total_relation_size('{regclass_name}'::regclass)",
+            )
+        )
+
+        columns = self._load_columns(
+            connector,
+            f"""
+            SELECT
+                column_name,
+                data_type,
+                udt_name,
+                character_maximum_length,
+                numeric_precision,
+                numeric_scale,
+                datetime_precision,
+                is_nullable,
+                column_default,
+                ordinal_position
+            FROM information_schema.columns
+            WHERE table_schema = '{sql_literal(schema_name)}'
+              AND table_name = '{sql_literal(resolved_name)}'
+            ORDER BY ordinal_position
+            """,
+            "postgresql",
+        )
+        indexes = _group_indexes(
+            _records(
+                connector.execute_query(
+                    f"""
+                    SELECT
+                        i.relname AS index_name,
+                        ix.indisunique AS is_unique,
+                        ix.indisprimary AS is_primary_key,
+                        a.attname AS column_name,
+                        key_columns.ordinality AS ordinality
+                    FROM pg_class t
+                    JOIN pg_namespace ns ON ns.oid = t.relnamespace
+                    JOIN pg_index ix ON t.oid = ix.indrelid
+                    JOIN pg_class i ON i.oid = ix.indexrelid
+                    JOIN LATERAL unnest(ix.indkey) WITH ORDINALITY AS key_columns(attnum, ordinality) ON true
+                    JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = key_columns.attnum
+                    WHERE ns.nspname = '{sql_literal(schema_name)}'
+                      AND t.relname = '{sql_literal(resolved_name)}'
+                    ORDER BY ix.indisprimary DESC, ix.indisunique DESC, i.relname, key_columns.ordinality
+                    """
+                )
+            )
+        )
+
+        return self._base_result(
+            connector,
+            database=database_name,
+            catalog="",
+            schema=schema_name,
+            entity_name=resolved_name,
+            entity_type=entity_type,
+            row_count=row_count,
+            size_bytes=size_bytes,
+            columns=columns,
+            indexes=indexes,
+        )
+
+    def _fetch_mysql_info(self, connector, parts: list[str], db_type: str) -> dict[str, Any]:
+        preferred_schema = parts[-2] if len(parts) >= 2 else str(
+            getattr(connector, "get_current_database", lambda: "")() or ""
+        )
+        schema_filter = (
+            f"AND TABLE_SCHEMA = '{sql_literal(parts[-2])}'" if len(parts) >= 2 else ""
+        )
+        entity_name = parts[-1]
+        resolved = _first_record(
+            connector.execute_query(
+                f"""
+                SELECT
+                    TABLE_SCHEMA AS schema_name,
+                    TABLE_NAME AS entity_name,
+                    TABLE_TYPE AS entity_type,
+                    TABLE_ROWS AS table_rows,
+                    DATA_LENGTH + INDEX_LENGTH AS size_bytes
+                FROM INFORMATION_SCHEMA.TABLES
+                WHERE TABLE_NAME = '{sql_literal(entity_name)}'
+                  {schema_filter}
+                ORDER BY CASE WHEN TABLE_SCHEMA = '{sql_literal(preferred_schema)}' THEN 0 ELSE 1 END, TABLE_SCHEMA
+                LIMIT 1
+                """
+            )
+        )
+
+        if not resolved:
+            # Check routines
+            routine_schema_filter = (
+                f"AND ROUTINE_SCHEMA = '{sql_literal(parts[-2])}'" if len(parts) >= 2 else ""
+            )
+            resolved = _first_record(
+                self._execute_optional_records(
+                    connector,
+                    f"""
+                    SELECT
+                        ROUTINE_SCHEMA AS schema_name,
+                        ROUTINE_NAME AS entity_name,
+                        ROUTINE_TYPE AS entity_type
+                    FROM INFORMATION_SCHEMA.ROUTINES
+                    WHERE ROUTINE_NAME = '{sql_literal(entity_name)}'
+                      {routine_schema_filter}
+                    ORDER BY CASE WHEN ROUTINE_SCHEMA = '{sql_literal(preferred_schema)}' THEN 0 ELSE 1 END, ROUTINE_SCHEMA
+                    LIMIT 1
+                    """,
+                    context=f"MySQL routines for {entity_name}",
+                )
+                or []
+            )
+            if resolved:
+                resolved.setdefault("table_rows", None)
+                resolved.setdefault("size_bytes", None)
+
+        if not resolved:
+            raise ValueError(f"Entity not found: {entity_name}")
+
+        schema_name = str(resolved["schema_name"])
+        resolved_name = str(resolved["entity_name"])
+        entity_type = str(resolved["entity_type"]).upper()
+        if entity_type == "BASE TABLE":
+            entity_type = "TABLE"
+
+        database_name = str(getattr(connector, "get_current_database", lambda: "")() or "")
+
+        if entity_type in ("PROCEDURE", "FUNCTION"):
+            params = self._execute_optional_records(
+                connector,
+                f"""
+                SELECT
+                    COALESCE(PARAMETER_NAME, '') AS parameter_name,
+                    DATA_TYPE AS data_type,
+                    COALESCE(PARAMETER_MODE, 'IN') AS parameter_mode,
+                    CHARACTER_MAXIMUM_LENGTH AS character_maximum_length,
+                    NUMERIC_PRECISION AS numeric_precision,
+                    NUMERIC_SCALE AS numeric_scale,
+                    ORDINAL_POSITION AS ordinal_position
+                FROM INFORMATION_SCHEMA.PARAMETERS
+                WHERE SPECIFIC_SCHEMA = '{sql_literal(schema_name)}'
+                  AND SPECIFIC_NAME = '{sql_literal(resolved_name)}'
+                ORDER BY ORDINAL_POSITION
+                """,
+                context=f"MySQL parameters for {schema_name}.{resolved_name}",
+            ) or []
+            parameters = [
+                {
+                    "name": str(r.get("parameter_name") or ""),
+                    "display_type": build_display_data_type(r, db_type),
+                    "direction": str(r.get("parameter_mode") or "IN"),
+                    "default": "",
+                    "ordinal_position": _int_or_none(r.get("ordinal_position")) or 0,
+                }
+                for r in params
+            ]
+            return self._base_result(
+                connector,
+                database=database_name,
+                catalog="",
+                schema=schema_name,
+                entity_name=resolved_name,
+                entity_type=entity_type,
+                row_count=None,
+                size_bytes=None,
+                columns=[],
+                indexes=[],
+                indexes_supported=False,
+                parameters=parameters,
+                section_type="routine",
+            )
+
+        row_count = self._mysql_row_count(resolved, entity_type)
+        size_bytes = _int_or_none(resolved.get("size_bytes"))
+
+        columns = self._load_columns(
+            connector,
+            f"""
+            SELECT
+                COLUMN_NAME,
+                DATA_TYPE,
+                CHARACTER_MAXIMUM_LENGTH,
+                NUMERIC_PRECISION,
+                NUMERIC_SCALE,
+                DATETIME_PRECISION,
+                IS_NULLABLE,
+                COLUMN_DEFAULT,
+                ORDINAL_POSITION
+            FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_SCHEMA = '{sql_literal(schema_name)}'
+              AND TABLE_NAME = '{sql_literal(resolved_name)}'
+            ORDER BY ORDINAL_POSITION
+            """,
+            db_type,
+        )
+        indexes = _group_indexes(
+            _records(
+                connector.execute_query(
+                    f"""
+                    SELECT
+                        INDEX_NAME AS index_name,
+                        NON_UNIQUE AS non_unique,
+                        COLUMN_NAME AS column_name,
+                        SEQ_IN_INDEX AS seq_in_index
+                    FROM INFORMATION_SCHEMA.STATISTICS
+                    WHERE TABLE_SCHEMA = '{sql_literal(schema_name)}'
+                      AND TABLE_NAME = '{sql_literal(resolved_name)}'
+                    ORDER BY INDEX_NAME, SEQ_IN_INDEX
+                    """
+                )
+            )
+        )
+
+        return self._base_result(
+            connector,
+            database=database_name,
+            catalog="",
+            schema=schema_name,
+            entity_name=resolved_name,
+            entity_type=entity_type,
+            row_count=row_count,
+            size_bytes=size_bytes,
+            columns=columns,
+            indexes=indexes,
+        )
+
+    def _fetch_databricks_info(self, connector, parts: list[str]) -> dict[str, Any]:
+        current_catalog = str(getattr(connector, "get_current_catalog", lambda: "")() or "")
+        current_schema = str(getattr(connector, "get_current_schema", lambda: "default")() or "default")
+
+        if len(parts) >= 3:
+            target_catalog, preferred_schema, entity_name = parts[-3], parts[-2], parts[-1]
+        elif len(parts) == 2:
+            target_catalog, preferred_schema, entity_name = current_catalog, parts[0], parts[1]
+        else:
+            target_catalog, preferred_schema, entity_name = current_catalog, current_schema, parts[0]
+
+        if target_catalog and target_catalog != current_catalog:
+            connector.change_database(f"CATALOG:{target_catalog}")
+        if preferred_schema and preferred_schema != current_schema:
+            connector.change_database(f"SCHEMA:{preferred_schema}")
+
+        schema_filter = (
+            f"AND table_schema = '{sql_literal(preferred_schema)}'" if preferred_schema else ""
+        )
+        resolved = _first_record(
+            connector.execute_query(
+                f"""
+                SELECT table_schema AS schema_name, table_name AS entity_name, table_type AS entity_type
+                FROM information_schema.tables
+                WHERE table_name = '{sql_literal(entity_name)}'
+                  {schema_filter}
+                ORDER BY CASE WHEN table_schema = '{sql_literal(preferred_schema)}' THEN 0 ELSE 1 END, table_schema
+                LIMIT 1
+                """
+            )
+        )
+        if not resolved:
+            raise ValueError(f"Entity not found: {entity_name}")
+
+        schema_name = str(resolved["schema_name"])
+        resolved_name = str(resolved["entity_name"])
+        entity_type = str(resolved["entity_type"])
+        quoted_name = quote_identifier("databricks", target_catalog, schema_name, resolved_name)
+
+        detail = None
+        size_bytes = None
+        try:
+            detail = _first_record(connector.execute_query(f"DESCRIBE DETAIL {quoted_name}"))
+            if detail:
+                size_bytes = _int_or_none(detail.get("sizeinbytes"))
+        except Exception as exc:
+            logger.info("Databricks DESCRIBE DETAIL unavailable for %s: %s", quoted_name, exc)
+        row_count = self._databricks_row_count(detail, entity_type)
+
+        columns = self._load_columns(
+            connector,
+            f"""
+            SELECT
+                column_name,
+                data_type,
+                is_nullable,
+                ordinal_position
+            FROM information_schema.columns
+            WHERE table_schema = '{sql_literal(schema_name)}'
+              AND table_name = '{sql_literal(resolved_name)}'
+            ORDER BY ordinal_position
+            """,
+            "databricks",
+        )
+
+        return self._base_result(
+            connector,
+            database=target_catalog,
+            catalog=target_catalog,
+            schema=schema_name,
+            entity_name=resolved_name,
+            entity_type=entity_type,
+            row_count=row_count,
+            size_bytes=size_bytes,
+            columns=columns,
+            indexes=[],
+            indexes_supported=False,
+        )
+
+
+class EntityMetadataWorker(QObject):
+    """Background worker that resolves a connector and fetches entity metadata."""
+
+    loaded = pyqtSignal(dict)
+    error = pyqtSignal(str)
+    finished = pyqtSignal()
+
+    def __init__(
+        self,
+        *,
+        entity_name: str,
+        connector=None,
+        fallback_connector=None,
+        connection_config: dict[str, Any] | None = None,
+        database_override: str = "",
+    ):
+        super().__init__()
+        self.entity_name = entity_name
+        self.connector = connector
+        self.fallback_connector = fallback_connector
+        self.connection_config = connection_config or {}
+        self.database_override = database_override or ""
+
+    def run(self):
+        from src.database.database_connector import DatabaseConnector
+
+        temp_connector = None
+        try:
+            connector = self.connector
+            if connector is None:
+                config = self.connection_config
+                if config:
+                    temp_connector = DatabaseConnector()
+                    try:
+                        temp_connector.connect(
+                            db_type=config["db_type"],
+                            host=config["host"],
+                            port=config["port"],
+                            database=config["database"],
+                            username=config.get("username", ""),
+                            password=config.get("password", ""),
+                            use_windows_auth=config.get("use_windows_auth", False),
+                            trust_server_certificate=config.get("trust_server_certificate", False),
+                            http_path=config.get("http_path", ""),
+                        )
+                        connector = temp_connector
+                    except Exception:
+                        if self.fallback_connector is not None and not self.database_override:
+                            connector = self.fallback_connector
+                            temp_connector = None
+                        else:
+                            raise
+                elif self.fallback_connector is not None:
+                    connector = self.fallback_connector
+                else:
+                    raise ValueError("Missing connection configuration")
+
+            if self.database_override:
+                connector.change_database(self.database_override)
+
+            metadata = EntityMetadataService().fetch_entity_info(connector, self.entity_name)
+            self.loaded.emit(metadata)
+        except Exception as exc:
+            self.error.emit(str(exc))
+        finally:
+            if temp_connector is not None:
+                try:
+                    temp_connector.disconnect()
+                except Exception:
+                    logger.debug("Failed to close temporary metadata connector", exc_info=True)
+            self.finished.emit()

--- a/source/src/services/schema_service.py
+++ b/source/src/services/schema_service.py
@@ -9,6 +9,7 @@ Errors are silenced - user can force reload manually.
 """
 
 from PyQt6.QtCore import QObject, QThread, pyqtSignal
+from PyQt6 import sip
 from typing import Dict, List, Optional
 import logging
 import traceback
@@ -25,6 +26,7 @@ class SchemaWorker(QObject):
     finished = pyqtSignal(dict)  # {tables: [...], columns: {...}}
     error = pyqtSignal(str)
     progress = pyqtSignal(str)  # progress message
+    completed = pyqtSignal()
 
     def __init__(self, connector):
         super().__init__()
@@ -173,6 +175,11 @@ class SchemaWorker(QObject):
                 self.error.emit(str(e))
             except RuntimeError:
                 pass  # Qt object may have been deleted
+        finally:
+            try:
+                self.completed.emit()
+            except RuntimeError:
+                pass
 
     def _get_databases_query(self) -> str:
         """Query to get list of all server databases"""
@@ -338,6 +345,7 @@ class SchemaService(QObject):
     def __init__(self, parent=None):
         super().__init__(parent)
         self._active_threads: list = []  # active threads to keep reference
+        self._shutting_down = False
         # Cache per session: key = "session_id:connection_name" for isolation
         # Each tab can have its own database context (USE CATALOG, etc.)
         self._cache: Dict[str, dict] = {}
@@ -359,6 +367,9 @@ class SchemaService(QObject):
             connection_name: Connection name (for cache)
             session_id: Session ID for per-session cache isolation
         """
+        if self._shutting_down:
+            return
+
         # Cancel previous workers (won't emit signals)
         self._cancel_pending_workers()
 
@@ -376,14 +387,34 @@ class SchemaService(QObject):
 
             # Connect signals
             thread.started.connect(worker.run)
-            worker.finished.connect(lambda schema: self._on_finished(schema, connection_name, session_id))
-            worker.error.connect(self._on_error)
-            worker.progress.connect(self.loading_progress.emit)
+            def handle_finished(schema, service=self):
+                if sip.isdeleted(service) or service._shutting_down:
+                    return
+                service._on_finished(schema, connection_name, session_id)
+
+            def cleanup_thread(service=self, active_thread=thread, active_worker=worker):
+                if sip.isdeleted(service):
+                    return
+                service._cleanup_thread(active_thread, active_worker)
+
+            def handle_error(error, service=self):
+                if sip.isdeleted(service) or service._shutting_down:
+                    return
+                service._on_error(error)
+
+            def handle_progress(message, service=self):
+                if sip.isdeleted(service) or service._shutting_down:
+                    return
+                service.loading_progress.emit(message)
+
+            worker.finished.connect(handle_finished)
+            worker.error.connect(handle_error)
+            worker.progress.connect(handle_progress)
 
             # Safe cleanup: worker and thread are deleted after completion
-            worker.finished.connect(thread.quit)
-            worker.error.connect(thread.quit)
-            thread.finished.connect(lambda: self._cleanup_thread(thread, worker))
+            worker.completed.connect(thread.quit)
+            worker.completed.connect(worker.deleteLater)
+            thread.finished.connect(cleanup_thread)
 
             # Keep reference to avoid garbage collection
             self._active_threads.append((thread, worker))
@@ -394,6 +425,9 @@ class SchemaService(QObject):
 
     def _on_finished(self, schema: dict, connection_name: str, session_id: str = ""):
         """Schema loaded successfully"""
+        if self._shutting_down:
+            return
+
         try:
             if connection_name:
                 cache_key = self._cache_key(connection_name, session_id)
@@ -404,6 +438,9 @@ class SchemaService(QObject):
 
     def _on_error(self, error: str):
         """Error loading schema - silence to not disturb user"""
+        if self._shutting_down:
+            return
+
         logger.warning(f"Error loading schema: {error}")
         try:
             self.schema_error.emit(error)
@@ -462,6 +499,8 @@ class SchemaService(QObject):
 
     def cleanup(self):
         """Clean up resources - wait for threads to finish with timeout"""
+        self._shutting_down = True
+
         # Cancel all workers
         for thread, worker in self._active_threads:
             try:
@@ -759,13 +798,26 @@ class SchemaService(QObject):
                 finally:
                     self.finished.emit()
         
+        def safe_callback(result):
+            if sip.isdeleted(self) or self._shutting_down:
+                return
+            try:
+                callback(result)
+            except RuntimeError:
+                pass
+
+        def cleanup_thread():
+            if sip.isdeleted(self):
+                return
+            self._cleanup_thread(thread, worker)
+
         worker = Worker(func)
         worker.moveToThread(thread)
         
         thread.started.connect(worker.run)
-        worker.result_ready.connect(callback)
+        worker.result_ready.connect(safe_callback)
         worker.finished.connect(thread.quit)
-        thread.finished.connect(lambda: self._cleanup_thread(thread, worker))
+        thread.finished.connect(cleanup_thread)
         
         self._active_threads.append((thread, worker))
         thread.start()

--- a/source/src/services/schema_service.py
+++ b/source/src/services/schema_service.py
@@ -16,6 +16,7 @@ import traceback
 logger = logging.getLogger(__name__)
 
 from src.language import S
+from src.services.entity_metadata_service import build_display_data_type
 
 
 class SchemaWorker(QObject):
@@ -41,7 +42,7 @@ class SchemaWorker(QObject):
         """
         try:
             self.progress.emit(S.schema_service.loading)
-            schema = {"tables": [], "columns": {}, "database": "", "databases": []}
+            schema = {"tables": [], "columns": {}, "database": "", "databases": [], "db_type": "", "routines": []}
 
             if self._cancelled:
                 return
@@ -49,6 +50,7 @@ class SchemaWorker(QObject):
             # Get current database
             try:
                 db_type = getattr(self.connector, "db_type", "").lower()
+                schema["db_type"] = db_type
                 if db_type == "databricks":
                     # For Databricks, use get_current_catalog which has proper fallback
                     db_name = self.connector.get_current_catalog() if hasattr(self.connector, "get_current_catalog") else ""
@@ -122,6 +124,7 @@ class SchemaWorker(QObject):
                         col_info = {
                             "name": str(row.get("column_name", "")),
                             "type": str(row.get("data_type", "")) if "data_type" in df.columns else "",
+                            "display_type": build_display_data_type(row, db_type),
                             "nullable": str(row.get("is_nullable", "YES")) if "is_nullable" in df.columns else "YES",
                         }
                         if table_name not in schema["columns"]:
@@ -133,9 +136,33 @@ class SchemaWorker(QObject):
             if self._cancelled:
                 return
 
+            # Get stored procedures and functions
+            try:
+                routines_query = self._get_routines_query()
+                if routines_query:
+                    df = self.connector.execute_query(routines_query)
+                    if df is not None and len(df) > 0:
+                        for _, row in df.iterrows():
+                            if self._cancelled:
+                                return
+                            routine_name = str(row.get("routine_name", row.iloc[0]))
+                            routine_schema = str(row.get("routine_schema", "")) if "routine_schema" in df.columns else ""
+                            routine_type = str(row.get("routine_type", "PROCEDURE")) if "routine_type" in df.columns else "PROCEDURE"
+                            schema["routines"].append({
+                                "name": routine_name,
+                                "schema": routine_schema,
+                                "type": routine_type.upper(),
+                            })
+            except Exception as e:
+                logger.debug(f"Error loading routines: {e}")
+
+            if self._cancelled:
+                return
+
             self.progress.emit(
                 f"Schema loaded: {len(schema['tables'])} tables, "
-                f"{sum(len(v) for v in schema['columns'].values())} columns"
+                f"{sum(len(v) for v in schema['columns'].values())} columns, "
+                f"{len(schema['routines'])} routines"
             )
             self.finished.emit(schema)
 
@@ -211,6 +238,10 @@ class SchemaWorker(QObject):
                        TABLE_NAME as table_name,
                        COLUMN_NAME as column_name,
                        DATA_TYPE as data_type,
+                       CHARACTER_MAXIMUM_LENGTH as character_maximum_length,
+                       NUMERIC_PRECISION as numeric_precision,
+                       NUMERIC_SCALE as numeric_scale,
+                       DATETIME_PRECISION as datetime_precision,
                        IS_NULLABLE as is_nullable,
                        ORDINAL_POSITION as ordinal_position
                 FROM INFORMATION_SCHEMA.COLUMNS
@@ -218,8 +249,9 @@ class SchemaWorker(QObject):
             """
         elif db_type == "postgresql":
             return """
-                SELECT table_schema, table_name, column_name, data_type, is_nullable,
-                       ordinal_position
+                SELECT table_schema, table_name, column_name, data_type, udt_name,
+                       character_maximum_length, numeric_precision, numeric_scale,
+                       datetime_precision, is_nullable, ordinal_position
                 FROM information_schema.columns
                 WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
                 ORDER BY table_schema, table_name, ordinal_position
@@ -240,12 +272,47 @@ class SchemaWorker(QObject):
                 SELECT TABLE_NAME as table_name,
                        COLUMN_NAME as column_name,
                        DATA_TYPE as data_type,
+                       CHARACTER_MAXIMUM_LENGTH as character_maximum_length,
+                       NUMERIC_PRECISION as numeric_precision,
+                       NUMERIC_SCALE as numeric_scale,
+                       DATETIME_PRECISION as datetime_precision,
                        IS_NULLABLE as is_nullable,
                        ORDINAL_POSITION as ordinal_position
                 FROM INFORMATION_SCHEMA.COLUMNS
                 WHERE TABLE_SCHEMA = DATABASE()
                 ORDER BY TABLE_NAME, ORDINAL_POSITION
             """
+
+    def _get_routines_query(self) -> str | None:
+        """Query to get stored procedures and functions."""
+        db_type = getattr(self.connector, "db_type", "").lower()
+
+        if db_type in ("mssql", "sqlserver"):
+            return """
+                SELECT ROUTINE_SCHEMA as routine_schema,
+                       ROUTINE_NAME as routine_name,
+                       ROUTINE_TYPE as routine_type
+                FROM INFORMATION_SCHEMA.ROUTINES
+                ORDER BY ROUTINE_SCHEMA, ROUTINE_NAME
+            """
+        elif db_type == "postgresql":
+            return """
+                SELECT routine_schema, routine_name, routine_type
+                FROM information_schema.routines
+                WHERE routine_schema NOT IN ('pg_catalog', 'information_schema')
+                ORDER BY routine_schema, routine_name
+            """
+        elif db_type in ("mysql", "mariadb"):
+            return """
+                SELECT ROUTINE_SCHEMA as routine_schema,
+                       ROUTINE_NAME as routine_name,
+                       ROUTINE_TYPE as routine_type
+                FROM INFORMATION_SCHEMA.ROUTINES
+                WHERE ROUTINE_SCHEMA = DATABASE()
+                ORDER BY ROUTINE_NAME
+            """
+        # Databricks and others don't have a standard routines view
+        return None
 
 
 class SchemaService(QObject):
@@ -593,11 +660,14 @@ class SchemaService(QObject):
                             columns.append({
                                 "name": col_name,
                                 "type": str(row.get("data_type", row.iloc[1] if len(row) > 1 else "")),
+                                "display_type": build_display_data_type(row, db_type),
                                 "nullable": "YES",  # DESCRIBE doesn't give nullable info
                             })
                 elif db_type in ("mssql", "sqlserver"):
                     query = f"""
-                        SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE
+                        SELECT COLUMN_NAME, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH,
+                               NUMERIC_PRECISION, NUMERIC_SCALE, DATETIME_PRECISION,
+                               IS_NULLABLE
                         FROM INFORMATION_SCHEMA.COLUMNS
                         WHERE TABLE_SCHEMA = '{_schema_name}' AND TABLE_NAME = '{_table_name}'
                         ORDER BY ORDINAL_POSITION
@@ -608,11 +678,14 @@ class SchemaService(QObject):
                             columns.append({
                                 "name": str(row.get("COLUMN_NAME", row.iloc[0])),
                                 "type": str(row.get("DATA_TYPE", "")),
+                                "display_type": build_display_data_type(row, db_type),
                                 "nullable": str(row.get("IS_NULLABLE", "YES")),
                             })
                 elif db_type == "postgresql":
                     query = f"""
-                        SELECT column_name, data_type, is_nullable
+                        SELECT column_name, data_type, udt_name,
+                               character_maximum_length, numeric_precision,
+                               numeric_scale, datetime_precision, is_nullable
                         FROM information_schema.columns
                         WHERE table_schema = '{_schema_name}' AND table_name = '{_table_name}'
                         ORDER BY ordinal_position
@@ -623,12 +696,15 @@ class SchemaService(QObject):
                             columns.append({
                                 "name": str(row.get("column_name", row.iloc[0])),
                                 "type": str(row.get("data_type", "")),
+                                "display_type": build_display_data_type(row, db_type),
                                 "nullable": str(row.get("is_nullable", "YES")),
                             })
                 else:
                     # MySQL/MariaDB
                     query = f"""
-                        SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE
+                        SELECT COLUMN_NAME, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH,
+                               NUMERIC_PRECISION, NUMERIC_SCALE, DATETIME_PRECISION,
+                               IS_NULLABLE
                         FROM INFORMATION_SCHEMA.COLUMNS
                         WHERE TABLE_SCHEMA = '{_schema_name}' AND TABLE_NAME = '{_table_name}'
                         ORDER BY ORDINAL_POSITION
@@ -639,6 +715,7 @@ class SchemaService(QObject):
                             columns.append({
                                 "name": str(row.get("COLUMN_NAME", row.iloc[0])),
                                 "type": str(row.get("DATA_TYPE", "")),
+                                "display_type": build_display_data_type(row, db_type),
                                 "nullable": str(row.get("IS_NULLABLE", "YES")),
                             })
 

--- a/source/src/services/sql_autocomplete_service.py
+++ b/source/src/services/sql_autocomplete_service.py
@@ -16,7 +16,8 @@ Uses sqlglot for advanced parsing of:
 
 import logging
 import re
-from typing import Dict, List, Optional, Tuple, Set
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +25,7 @@ logger = logging.getLogger(__name__)
 try:
     import sqlglot
     from sqlglot import exp
+    from sqlglot.optimizer.scope import traverse_scope
     HAS_SQLGLOT = True
 except ImportError:
     HAS_SQLGLOT = False
@@ -37,6 +39,8 @@ CAT_TABLE = "table"
 CAT_COLUMN = "column"
 CAT_DATABASE = "database"
 CAT_FUNCTION = "function"
+CAT_VARIABLE = "variable"
+CAT_ROUTINE = "routine"
 
 # Context constants
 CTX_TABLE = "table"         # Expects table names (FROM, JOIN, INTO, UPDATE, etc.)
@@ -44,6 +48,7 @@ CTX_COLUMN = "column"       # Expects column names (SELECT, WHERE, ON, etc.)
 CTX_DOT = "dot"             # After "something." - resolve to table/alias columns
 CTX_DATABASE = "database"   # Expects database names (USE)
 CTX_DEFAULT = "default"     # Keywords + tables
+CTX_ROUTINE = "routine"     # After EXEC/EXECUTE/CALL - expects procedure/function names
 
 SQL_KEYWORDS = [
     "SELECT", "FROM", "WHERE", "AND", "OR", "NOT", "IN", "BETWEEN",
@@ -91,6 +96,28 @@ _COLUMN_CONTEXT_KW = {
 _RE_LINE_COMMENT = re.compile(r"--[^\n]*", re.DOTALL)
 _RE_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
 _RE_STRING_LITERAL = re.compile(r"'[^']*'")
+_RE_GO_BATCH = re.compile(r"(?im)^[ \t]*GO(?:[ \t]+--[^\n]*)?[ \t]*$")
+_RE_SQL_TOKEN = re.compile(
+    r"""
+    \[[^\]]+\]
+    |`[^`]+`
+    |"[^"]+"
+    |@@?[A-Za-z_][\w$]*
+    |##?[A-Za-z_][\w$]*
+    |[A-Za-z_][\w$]*
+    |[,().]
+    """,
+    re.VERBOSE,
+)
+_RE_DOT_CONTEXT = re.compile(
+    r'((?:@@?[A-Za-z_][\w$]*|##?[A-Za-z_][\w$]*|[A-Za-z_][\w$]*|\[[^\]]+\]|`[^`]+`|"[^"]+")'
+    r'(?:\.(?:@@?[A-Za-z_][\w$]*|##?[A-Za-z_][\w$]*|[A-Za-z_][\w$]*|\[[^\]]+\]|`[^`]+`|"[^"]+"))*)'
+    r'\.\s*(?:[@#A-Za-z_][\w$]*)?$',
+    re.IGNORECASE,
+)
+
+CURSOR_PLACEHOLDER = "__datapyn_cursor__"
+DEFAULT_SCHEMA_PRIORITY = ("dbo", "public")
 
 # Regex for alias detection in FROM/JOIN clauses
 # Matches: table_name AS alias, table_name alias (not a keyword)
@@ -280,6 +307,23 @@ class SqlContextParser:
         return result
 
 
+@dataclass
+class StatementContext:
+    """Current SQL statement slices around the cursor."""
+
+    previous_sql: str
+    statement_before_cursor: str
+    statement_after_cursor: str
+
+    @property
+    def current_statement(self) -> str:
+        return f"{self.statement_before_cursor}{self.statement_after_cursor}"
+
+    @property
+    def cursor_offset(self) -> int:
+        return len(self.statement_before_cursor)
+
+
 class SqlAutoCompleteService:
     """
     Context-aware SQL autocomplete service.
@@ -293,58 +337,62 @@ class SqlAutoCompleteService:
     def __init__(self):
         self._schema: dict = {}
         self._keywords_lower = {kw.lower() for kw in SQL_KEYWORDS}
-        self._context_parser = SqlContextParser()
+        self._schema_db_type = ""
+        self._table_entries: List[dict[str, Any]] = []
+        self._table_lookup: dict[str, List[dict[str, Any]]] = {}
 
     def set_schema(self, schema: Optional[dict]) -> None:
-        """Update the database schema used for completions.
-
-        Args:
-            schema: dict with {tables: [...], columns: {...}, database: str, databases: [str]}
-        """
+        """Update the database schema used for completions."""
         self._schema = schema if schema else {}
+        self._schema_db_type = str(self._schema.get("db_type", "") or "").lower()
+        self._rebuild_schema_index()
 
     def get_schema(self) -> dict:
         """Return current schema dict."""
         return self._schema
 
-    def get_completions(
-        self, text: str, cursor_line: int, cursor_col: int
-    ) -> List[Tuple[str, str, str]]:
-        """
-        Get contextual completions at cursor position.
-
-        Args:
-            text: Full SQL text of the editor.
-            cursor_line: 0-based line number of cursor.
-            cursor_col: 0-based column of cursor.
-
-        Returns:
-            List of (name, category, detail) tuples.
-        """
+    def get_completions(self, text: str, cursor_line: int, cursor_col: int) -> List[Tuple[str, str, str]]:
+        """Get contextual completions at the cursor position."""
         text_before = self._text_before_cursor(text, cursor_line, cursor_col)
         if not text_before.strip():
             return self._keyword_completions()
 
-        # Strip comments and string literals for cleaner parsing
-        cleaned = self._strip_noise(text_before)
-
-        # Detect context
-        context, context_arg = self._detect_context(cleaned)
-
-        return self._build_completions(context, context_arg, text)
-
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
+        statement_context = self._statement_context(text, cursor_line, cursor_col)
+        cleaned_before = self._strip_noise(statement_context.statement_before_cursor)
+        context, context_arg = self._detect_context(cleaned_before)
+        analysis = self._analyze_context(statement_context, context)
+        return self._build_completions(context, context_arg, analysis)
 
     @staticmethod
     def _text_before_cursor(text: str, line: int, col: int) -> str:
         """Extract text from start up to cursor position."""
         lines = text.split("\n")
+        if not lines:
+            return ""
+
+        line = max(0, line)
+        col = max(0, col)
         if line >= len(lines):
             return text
+
         result_lines = lines[:line]
         result_lines.append(lines[line][:col])
+        return "\n".join(result_lines)
+
+    @staticmethod
+    def _text_after_cursor(text: str, line: int, col: int) -> str:
+        """Extract text from cursor position to the end."""
+        lines = text.split("\n")
+        if not lines:
+            return ""
+
+        line = max(0, line)
+        col = max(0, col)
+        if line >= len(lines):
+            return ""
+
+        result_lines = [lines[line][col:]]
+        result_lines.extend(lines[line + 1 :])
         return "\n".join(result_lines)
 
     @staticmethod
@@ -355,107 +403,1095 @@ class SqlAutoCompleteService:
         text = _RE_STRING_LITERAL.sub("''", text)
         return text
 
+    @staticmethod
+    def _normalize_batches(text: str) -> str:
+        """Treat T-SQL GO batch separators like semicolons."""
+        return _RE_GO_BATCH.sub(";", text)
+
+    def _statement_context(self, text: str, line: int, col: int) -> StatementContext:
+        """Get the current statement and all finished statements before it."""
+        before_cursor = self._normalize_batches(self._text_before_cursor(text, line, col))
+        after_cursor = self._normalize_batches(self._text_after_cursor(text, line, col))
+
+        before_parts = before_cursor.split(";")
+        statement_before = before_parts[-1]
+        previous_sql = ";".join(before_parts[:-1]).strip()
+        statement_after = after_cursor.split(";", 1)[0]
+
+        return StatementContext(
+            previous_sql=previous_sql,
+            statement_before_cursor=statement_before,
+            statement_after_cursor=statement_after,
+        )
+
+    @staticmethod
+    def _strip_identifier_quotes(value: Any) -> str:
+        text = str(value or "").strip()
+        for left, right in (("[", "]"), ("`", "`"), ('"', '"')):
+            while text.startswith(left) and text.endswith(right) and len(text) >= 2:
+                text = text[1:-1].strip()
+        return text
+
+    @classmethod
+    def _split_identifier_parts(cls, value: Any) -> List[str]:
+        text = str(value or "").strip()
+        if not text:
+            return []
+
+        parts: List[str] = []
+        current: List[str] = []
+        quote_char = ""
+        bracket_depth = 0
+
+        for char in text:
+            if quote_char:
+                current.append(char)
+                if char == quote_char:
+                    quote_char = ""
+                continue
+
+            if char in {'"', "`"}:
+                quote_char = char
+                current.append(char)
+                continue
+
+            if char == "[":
+                bracket_depth += 1
+                current.append(char)
+                continue
+
+            if char == "]" and bracket_depth:
+                bracket_depth -= 1
+                current.append(char)
+                continue
+
+            if char == "." and bracket_depth == 0:
+                part = cls._strip_identifier_quotes("".join(current))
+                if part:
+                    parts.append(part)
+                current = []
+                continue
+
+            current.append(char)
+
+        tail = cls._strip_identifier_quotes("".join(current))
+        if tail:
+            parts.append(tail)
+        return parts
+
+    @classmethod
+    def _normalize_name(cls, value: Any) -> str:
+        return cls._strip_identifier_quotes(value).lower()
+
+    @classmethod
+    def _normalize_relation_key(cls, value: Any) -> str:
+        parts = cls._split_identifier_parts(value)
+        if not parts:
+            return cls._normalize_name(value)
+        return ".".join(cls._normalize_name(part) for part in parts if part)
+
+    def _clone_columns(self, columns: Any) -> List[dict[str, Any]]:
+        cloned: List[dict[str, Any]] = []
+        for column in columns or []:
+            if isinstance(column, dict):
+                cloned.append(dict(column))
+            else:
+                cloned.append({"name": str(column), "type": ""})
+        return cloned
+
+    def _make_relation(
+        self,
+        display_name: str,
+        columns: List[dict[str, Any]],
+        source_type: str,
+        detail: str,
+        preferred_qualifier: str = "",
+        lookup_names: Optional[Set[str]] = None,
+    ) -> dict[str, Any]:
+        names = {self._normalize_relation_key(display_name)}
+        if preferred_qualifier:
+            names.add(self._normalize_relation_key(preferred_qualifier))
+        if lookup_names:
+            names.update({name for name in lookup_names if name})
+        return {
+            "display_name": display_name,
+            "columns": self._clone_columns(columns),
+            "source_type": source_type,
+            "detail": detail,
+            "preferred_qualifier": preferred_qualifier or display_name,
+            "lookup_names": names,
+        }
+
+    def _clone_relation(
+        self,
+        relation: dict[str, Any],
+        *,
+        preferred_qualifier: str = "",
+        extra_lookup_names: Optional[Set[str]] = None,
+    ) -> dict[str, Any]:
+        cloned = self._make_relation(
+            relation["display_name"],
+            relation.get("columns", []),
+            relation.get("source_type", ""),
+            relation.get("detail", ""),
+            preferred_qualifier=preferred_qualifier or relation.get("preferred_qualifier", ""),
+            lookup_names=set(relation.get("lookup_names", set())),
+        )
+        if extra_lookup_names:
+            cloned["lookup_names"].update(extra_lookup_names)
+        return cloned
+
+    def _rebuild_schema_index(self) -> None:
+        self._table_entries = []
+        self._table_lookup = {}
+
+        columns_map = self._schema.get("columns", {}) or {}
+        registered_keys: Set[str] = set()
+
+        for table in self._schema.get("tables", []) or []:
+            if isinstance(table, dict):
+                table_name = str(table.get("name", "") or "")
+                schema_name = str(table.get("schema", "") or "")
+                table_key = str(table.get("key") or (f"{schema_name}.{table_name}" if schema_name else table_name))
+                table_type = str(table.get("type", "TABLE") or "TABLE")
+            else:
+                table_name = str(table)
+                schema_name = ""
+                table_key = table_name
+                table_type = "TABLE"
+
+            if not table_name:
+                continue
+
+            entry_columns = self._clone_columns(columns_map.get(table_key) or columns_map.get(table_name) or [])
+            self._register_table_entry(
+                name=table_name,
+                schema_name=schema_name,
+                table_key=table_key,
+                table_type=table_type,
+                columns=entry_columns,
+            )
+            registered_keys.add(self._normalize_relation_key(table_key))
+
+        for table_key, cols in columns_map.items():
+            normalized_key = self._normalize_relation_key(table_key)
+            if normalized_key in registered_keys:
+                continue
+            parts = self._split_identifier_parts(table_key)
+            table_name = parts[-1] if parts else str(table_key)
+            schema_name = parts[-2] if len(parts) >= 2 else ""
+            self._register_table_entry(
+                name=table_name,
+                schema_name=schema_name,
+                table_key=str(table_key),
+                table_type="TABLE",
+                columns=self._clone_columns(cols),
+            )
+
+    def _register_table_entry(
+        self,
+        *,
+        name: str,
+        schema_name: str,
+        table_key: str,
+        table_type: str,
+        columns: List[dict[str, Any]],
+    ) -> None:
+        display_detail = f"{schema_name}.{name}" if schema_name else name
+        parts = self._split_identifier_parts(table_key)
+        lookup_names = {self._normalize_relation_key(name), self._normalize_relation_key(table_key)}
+        if schema_name:
+            lookup_names.add(self._normalize_relation_key(f"{schema_name}.{name}"))
+        for index in range(len(parts)):
+            suffix = ".".join(parts[index:])
+            lookup_names.add(self._normalize_relation_key(suffix))
+
+        entry = {
+            "name": name,
+            "schema": schema_name,
+            "key": table_key,
+            "type": table_type,
+            "detail": display_detail,
+            "columns": self._clone_columns(columns),
+            "lookup_names": lookup_names,
+        }
+        self._table_entries.append(entry)
+        for lookup_name in lookup_names:
+            self._table_lookup.setdefault(lookup_name, []).append(entry)
+
+    def _preferred_dialects(self) -> List[Optional[str]]:
+        db_type = self._schema_db_type
+        primary = {
+            "sqlserver": "tsql",
+            "mssql": "tsql",
+            "mysql": "mysql",
+            "mariadb": "mysql",
+            "postgresql": "postgres",
+            "databricks": "databricks",
+        }.get(db_type)
+
+        dialects: List[Optional[str]] = []
+        for dialect in (primary, None, "tsql", "mysql", "postgres", "spark"):
+            if dialect not in dialects:
+                dialects.append(dialect)
+        return dialects
+
+    def _parse_statement(self, sql: str):
+        if not HAS_SQLGLOT or not sql.strip():
+            return None
+
+        for dialect in self._preferred_dialects():
+            try:
+                parsed = sqlglot.parse_one(sql, dialect=dialect, error_level="ignore")
+                if parsed is not None:
+                    return parsed
+            except Exception:
+                continue
+        return None
+
+    def _split_sql_statements(self, sql: str) -> List[str]:
+        normalized = self._normalize_batches(sql)
+        return [statement.strip() for statement in normalized.split(";") if statement.strip()]
+
+    def _tokenize_with_depth(self, text: str) -> List[Tuple[str, int]]:
+        tokens: List[Tuple[str, int]] = []
+        depth = 0
+        for match in _RE_SQL_TOKEN.finditer(text):
+            token = match.group(0)
+            if token == "(":
+                tokens.append((token, depth))
+                depth += 1
+                continue
+            if token == ")":
+                depth = max(depth - 1, 0)
+                tokens.append((token, depth))
+                continue
+            tokens.append((token, depth))
+        return tokens
+
     def _detect_context(self, cleaned_text: str) -> Tuple[str, Optional[str]]:
-        """
-        Determine what type of completions to show based on text before cursor.
-
-        Returns:
-            (context_type, context_arg) where context_arg is table/alias name for DOT context.
-        """
+        """Determine what type of completions to show based on text before cursor."""
         stripped = cleaned_text.rstrip()
+        if not stripped:
+            return CTX_DEFAULT, None
 
-        # Check for dot context: "something." at the end
-        dot_match = re.search(r"(\w+)\.\s*(\w*)$", stripped)
-        if dot_match and stripped.rstrip().endswith("."):
-            prefix = dot_match.group(1)
-            return CTX_DOT, prefix
+        dot_match = _RE_DOT_CONTEXT.search(stripped)
+        if dot_match:
+            return CTX_DOT, dot_match.group(1)
 
-        # Also handle partial word after dot: "t.col_na"
-        dot_partial = re.search(r"(\w+)\.(\w+)$", stripped)
-        if dot_partial:
-            prefix = dot_partial.group(1)
-            return CTX_DOT, prefix
+        variable_tail = re.search(r"@\w*$", stripped)
+        if variable_tail:
+            parent_context, _ = self._detect_context(stripped[: variable_tail.start()])
+            return (CTX_COLUMN if parent_context == CTX_DEFAULT else parent_context), None
 
-        # Tokenize: find the last significant keyword/phrase
-        # Normalize whitespace
-        normalized = re.sub(r"\s+", " ", stripped).upper().strip()
+        normalized = re.sub(r"\s+", " ", stripped).upper()
+        if normalized.endswith(("ORDER BY", "GROUP BY", "PARTITION BY")):
+            return CTX_COLUMN, None
+        if normalized.endswith(
+            (
+                "INNER JOIN",
+                "LEFT JOIN",
+                "RIGHT JOIN",
+                "FULL JOIN",
+                "CROSS JOIN",
+                "LEFT OUTER JOIN",
+                "RIGHT OUTER JOIN",
+                "FULL OUTER JOIN",
+            )
+        ):
+            return CTX_TABLE, None
 
-        # Check multi-word keywords first (ORDER BY, GROUP BY, etc.)
-        for multi_kw in ("ORDER BY", "GROUP BY", "PARTITION BY",
-                         "INNER JOIN", "LEFT JOIN", "RIGHT JOIN",
-                         "FULL JOIN", "CROSS JOIN",
-                         "LEFT OUTER JOIN", "RIGHT OUTER JOIN",
-                         "FULL OUTER JOIN"):
-            pattern = re.escape(multi_kw) + r"(?:\s+\w+\s*,)*\s*(?:\w+\.?\w*\s*,\s*)*\s*\w*$"
-            if re.search(pattern, normalized):
-                if multi_kw in _TABLE_CONTEXT_KW:
-                    return CTX_TABLE, None
-                if multi_kw in _COLUMN_CONTEXT_KW:
-                    return CTX_COLUMN, None
-
-        # Check single keywords - find the last relevant keyword
-        # Split by non-identifier chars, walk backwards
-        tokens = re.findall(r"\w+", normalized)
+        tokens = self._tokenize_with_depth(stripped)
         if not tokens:
             return CTX_DEFAULT, None
 
-        # Walk backwards to find last context-setting keyword
-        for i in range(len(tokens) - 1, -1, -1):
-            tk = tokens[i]
+        current_depth = tokens[-1][1]
+        words = [
+            token.upper()
+            for token, depth in tokens
+            if depth == current_depth and token not in {".", "(", ")", ","} and token.strip()
+        ]
 
-            # USE -> database context
-            if tk == "USE":
+        if not words:
+            return CTX_DEFAULT, None
+
+        for index in range(len(words) - 1, -1, -1):
+            token = words[index]
+            if token == "USE":
                 return CTX_DATABASE, None
 
-            # Check if this token + next form a multi-word kw
-            if i < len(tokens) - 1:
-                pair = tk + " " + tokens[i + 1]
+            if token in {"EXEC", "EXECUTE", "CALL"}:
+                if index == len(words) - 1:
+                    return CTX_ROUTINE, None
+
+            if index >= 2:
+                triple = f"{words[index - 2]} {words[index - 1]} {token}"
+                if triple in _TABLE_CONTEXT_KW:
+                    return CTX_TABLE, None
+                if triple in _COLUMN_CONTEXT_KW:
+                    return CTX_COLUMN, None
+
+            if index >= 1:
+                pair = f"{words[index - 1]} {token}"
                 if pair in _TABLE_CONTEXT_KW:
                     return CTX_TABLE, None
                 if pair in _COLUMN_CONTEXT_KW:
                     return CTX_COLUMN, None
 
-            if tk in {"FROM", "JOIN", "INTO", "UPDATE", "TABLE", "TRUNCATE"}:
+            if token in _TABLE_CONTEXT_KW:
                 return CTX_TABLE, None
-
-            if tk in {"SELECT", "WHERE", "ON", "SET", "HAVING", "AND", "OR"}:
+            if token in _COLUMN_CONTEXT_KW or token in {"VALUES", "WHEN"}:
                 return CTX_COLUMN, None
 
-            # After comma in SELECT clause -> column context
-            # After comma in FROM clause -> table context
-            if tk == ",":
-                # Need to find what clause we're in
-                continue
-
-            # If we hit a table-context keyword before, these are values after
-            # e.g., SELECT a, b, c FROM  -> after FROM
-            # If we already passed the last keyword, stop
-            if tk in self._keywords_lower or tk in {k.upper() for k in self._keywords_lower}:
-                # It's a keyword but not context-setting, continue looking
-                continue
-
-        # Default: keywords + tables
         return CTX_DEFAULT, None
 
-    def _build_completions(
-        self, context: str, context_arg: Optional[str], full_text: str
-    ) -> List[Tuple[str, str, str]]:
-        """Build completion list based on detected context."""
+    def _analyze_context(self, statement_context: StatementContext, context: str) -> dict[str, Any]:
+        script_state = self._collect_script_state(statement_context.previous_sql)
+        scope_sources: List[dict[str, Any]] = []
+        scope_lookup: dict[str, dict[str, Any]] = {}
+        cte_sources: List[dict[str, Any]] = []
+        cte_lookup: dict[str, dict[str, Any]] = {}
+
+        current_statement = statement_context.current_statement
+        if current_statement.strip():
+            parsed_analysis = self._analyze_current_statement(
+                current_statement,
+                statement_context.cursor_offset,
+                context,
+                script_state,
+            )
+            scope_sources = parsed_analysis["scope_sources"]
+            scope_lookup = parsed_analysis["scope_lookup"]
+            cte_sources = parsed_analysis["cte_sources"]
+            cte_lookup = parsed_analysis["cte_lookup"]
+
+        return {
+            "script_state": script_state,
+            "scope_sources": scope_sources,
+            "scope_lookup": scope_lookup,
+            "cte_sources": cte_sources,
+            "cte_lookup": cte_lookup,
+        }
+
+    def _inject_cursor_placeholder(self, statement_sql: str, cursor_offset: int, context: str) -> str:
+        before = statement_sql[:cursor_offset]
+        after = statement_sql[cursor_offset:]
 
         if context == CTX_DOT:
-            return self._dot_completions(context_arg, full_text)
+            dot_match = _RE_DOT_CONTEXT.search(before.rstrip())
+            if dot_match:
+                start = dot_match.start(0)
+                prefix = dot_match.group(1)
+                remainder = re.sub(r"^[@#A-Za-z_][\w$]*", "", after, count=1)
+                return f"{statement_sql[:start]}{prefix}.{CURSOR_PLACEHOLDER}{remainder}"
 
+        token_start = cursor_offset
+        token_end = cursor_offset
+
+        left_match = re.search(r"[@#A-Za-z_][\w$]*$", before)
+        if left_match:
+            token_start = left_match.start()
+
+        right_match = re.match(r"^[@#A-Za-z_][\w$]*", after)
+        if right_match:
+            token_end = cursor_offset + right_match.end()
+
+        placeholder = CURSOR_PLACEHOLDER
+        if before[token_start:cursor_offset].startswith("@") or after[: max(token_end - cursor_offset, 0)].startswith("@"):
+            placeholder = f"@{CURSOR_PLACEHOLDER}"
+
+        return f"{statement_sql[:token_start]}{placeholder}{statement_sql[token_end:]}"
+
+    def _scope_has_cursor(self, scope) -> bool:
+        for column in getattr(scope, "columns", []):
+            if self._normalize_name(column.name) == CURSOR_PLACEHOLDER:
+                return True
+            if self._normalize_name(getattr(column, "table", "")) == CURSOR_PLACEHOLDER:
+                return True
+
+        for table in getattr(scope, "tables", []):
+            if self._normalize_name(getattr(table, "name", "")) == CURSOR_PLACEHOLDER:
+                return True
+            if self._normalize_name(getattr(table, "db", "")) == CURSOR_PLACEHOLDER:
+                return True
+
+        return False
+
+    def _analyze_current_statement(
+        self,
+        statement_sql: str,
+        cursor_offset: int,
+        context: str,
+        script_state: dict[str, Any],
+    ) -> dict[str, Any]:
+        parsed = self._parse_statement(self._inject_cursor_placeholder(statement_sql, cursor_offset, context))
+        if parsed is None or not HAS_SQLGLOT:
+            fallback_sources, fallback_lookup = self._fallback_scope_relations(statement_sql, script_state)
+            return {
+                "scope_sources": fallback_sources,
+                "scope_lookup": fallback_lookup,
+                "cte_sources": [],
+                "cte_lookup": {},
+            }
+
+        scopes = list(traverse_scope(parsed))
+        output_cache: dict[int, List[dict[str, Any]]] = {}
+        cte_sources, cte_lookup = self._collect_cte_sources(scopes, script_state, output_cache)
+
+        target_scope = None
+        for scope in scopes:
+            if self._scope_has_cursor(scope):
+                target_scope = scope
+                break
+        if target_scope is None and scopes:
+            target_scope = scopes[-1]
+
+        scope_sources: List[dict[str, Any]] = []
+        scope_lookup: dict[str, dict[str, Any]] = {}
+        if target_scope is not None:
+            scope_sources, scope_lookup = self._resolve_scope_sources(target_scope, script_state, output_cache)
+
+        update_relation = self._resolve_update_target(parsed, script_state)
+        if update_relation is not None:
+            self._append_relation(scope_sources, scope_lookup, update_relation)
+
+        return {
+            "scope_sources": scope_sources,
+            "scope_lookup": scope_lookup,
+            "cte_sources": cte_sources,
+            "cte_lookup": cte_lookup,
+        }
+
+    def _collect_cte_sources(
+        self,
+        scopes,
+        script_state: dict[str, Any],
+        output_cache: dict[int, List[dict[str, Any]]],
+    ) -> Tuple[List[dict[str, Any]], dict[str, dict[str, Any]]]:
+        relations: List[dict[str, Any]] = []
+        lookup: dict[str, dict[str, Any]] = {}
+        seen: Set[str] = set()
+
+        for scope in scopes:
+            cte_alias_columns = {
+                self._normalize_name(cte.alias): list(cte.alias_column_names or [])
+                for cte in getattr(scope, "ctes", [])
+                if getattr(cte, "alias", "")
+            }
+            for cte in getattr(scope, "ctes", []):
+                cte_name = str(getattr(cte, "alias", "") or "")
+                normalized_name = self._normalize_name(cte_name)
+                if not cte_name or normalized_name in seen:
+                    continue
+                source_scope = scope.sources.get(cte_name) or scope.sources.get(normalized_name)
+                if not hasattr(source_scope, "expression"):
+                    continue
+                columns = self._scope_output_columns(source_scope, script_state, output_cache)
+                alias_columns = cte_alias_columns.get(normalized_name) or []
+                if alias_columns:
+                    columns = self._override_column_names(columns, alias_columns)
+                relation = self._make_relation(
+                    cte_name,
+                    columns,
+                    "cte",
+                    f"CTE - {cte_name}",
+                    preferred_qualifier=cte_name,
+                )
+                self._append_relation(relations, lookup, relation)
+                seen.add(normalized_name)
+
+        return relations, lookup
+
+    def _resolve_scope_sources(
+        self,
+        scope,
+        script_state: dict[str, Any],
+        output_cache: dict[int, List[dict[str, Any]]],
+    ) -> Tuple[List[dict[str, Any]], dict[str, dict[str, Any]]]:
+        relations: List[dict[str, Any]] = []
+        lookup: dict[str, dict[str, Any]] = {}
+        cte_names = {
+            self._normalize_name(cte.alias)
+            for cte in getattr(scope, "ctes", [])
+            if getattr(cte, "alias", "")
+        }
+        cte_alias_columns = {
+            self._normalize_name(cte.alias): list(cte.alias_column_names or [])
+            for cte in getattr(scope, "ctes", [])
+            if getattr(cte, "alias", "")
+        }
+
+        for alias, selected in getattr(scope, "selected_sources", {}).items():
+            source_expression, source_object = selected
+            relation = self._relation_from_source(
+                alias,
+                source_expression,
+                source_object,
+                script_state,
+                output_cache,
+                cte_names,
+                cte_alias_columns,
+            )
+            if relation is None:
+                continue
+            self._append_relation(relations, lookup, relation)
+
+        return relations, lookup
+
+    def _append_relation(
+        self,
+        relations: List[dict[str, Any]],
+        lookup: dict[str, dict[str, Any]],
+        relation: dict[str, Any],
+    ) -> None:
+        relation_key = (
+            relation.get("display_name", "").lower(),
+            relation.get("preferred_qualifier", "").lower(),
+            relation.get("source_type", ""),
+        )
+        if not any(
+            (
+                existing.get("display_name", "").lower(),
+                existing.get("preferred_qualifier", "").lower(),
+                existing.get("source_type", ""),
+            )
+            == relation_key
+            for existing in relations
+        ):
+            relations.append(relation)
+
+        for lookup_name in relation.get("lookup_names", set()):
+            lookup[lookup_name] = relation
+
+    def _relation_from_source(
+        self,
+        alias: str,
+        source_expression,
+        source_object,
+        script_state: dict[str, Any],
+        output_cache: dict[int, List[dict[str, Any]]],
+        cte_names: Set[str],
+        cte_alias_columns: dict[str, List[str]],
+    ) -> Optional[dict[str, Any]]:
+        alias_name = str(alias or "")
+
+        if isinstance(source_object, exp.Table):
+            return self._relation_from_table_expression(source_object, alias_name, script_state)
+
+        if hasattr(source_object, "expression"):
+            source_name = ""
+            if isinstance(source_expression, exp.Table):
+                source_name = self._table_identifier_from_expression(source_expression) or source_expression.name
+
+            columns = self._scope_output_columns(source_object, script_state, output_cache)
+            normalized_source_name = self._normalize_relation_key(source_name)
+            if normalized_source_name in cte_alias_columns and cte_alias_columns[normalized_source_name]:
+                columns = self._override_column_names(columns, cte_alias_columns[normalized_source_name])
+
+            source_type = "cte" if normalized_source_name in cte_names else "subquery"
+            detail_label = "CTE" if source_type == "cte" else "Subquery"
+            display_name = source_name or alias_name or detail_label.lower()
+
+            lookup_names = {self._normalize_relation_key(alias_name), self._normalize_relation_key(display_name)}
+            if isinstance(source_expression, exp.Table) and source_expression.name:
+                lookup_names.add(self._normalize_relation_key(source_expression.name))
+                if source_expression.db:
+                    lookup_names.add(self._normalize_relation_key(f"{source_expression.db}.{source_expression.name}"))
+
+            return self._make_relation(
+                display_name,
+                columns,
+                source_type,
+                f"{detail_label} - {display_name}",
+                preferred_qualifier=alias_name or display_name,
+                lookup_names=lookup_names,
+            )
+
+        return None
+
+    def _resolve_update_target(self, parsed, script_state: dict[str, Any]) -> Optional[dict[str, Any]]:
+        if not isinstance(parsed, exp.Update):
+            return None
+        table_expression = parsed.this if isinstance(parsed.this, exp.Table) else None
+        if table_expression is None:
+            return None
+        return self._relation_from_table_expression(table_expression, "", script_state)
+
+    def _scope_output_columns(
+        self,
+        scope,
+        script_state: dict[str, Any],
+        output_cache: dict[int, List[dict[str, Any]]],
+    ) -> List[dict[str, Any]]:
+        scope_id = id(scope)
+        if scope_id in output_cache:
+            return self._clone_columns(output_cache[scope_id])
+
+        output_cache[scope_id] = []
+        source_relations, _ = self._resolve_scope_sources(scope, script_state, output_cache)
+
+        columns: List[dict[str, Any]] = []
+        for expression in getattr(scope.expression, "expressions", []) or []:
+            columns.extend(self._expression_output_columns(expression, source_relations))
+
+        output_cache[scope_id] = self._dedupe_columns(columns)
+        return self._clone_columns(output_cache[scope_id])
+
+    def _expression_output_columns(
+        self,
+        expression,
+        source_relations: List[dict[str, Any]],
+    ) -> List[dict[str, Any]]:
+        if isinstance(expression, exp.Alias):
+            alias_name = str(expression.alias or "").strip()
+            if alias_name and self._normalize_name(alias_name) != CURSOR_PLACEHOLDER:
+                inferred_type = self._expression_type_hint(expression.this, source_relations)
+                return [{"name": alias_name, "type": inferred_type, "display_type": inferred_type}]
+            return []
+
+        if isinstance(expression, exp.Star):
+            return self._expand_star_columns("", source_relations)
+
+        if isinstance(expression, exp.Column):
+            if self._normalize_name(expression.name) == CURSOR_PLACEHOLDER:
+                return []
+            if expression.name == "*":
+                return self._expand_star_columns(getattr(expression, "table", ""), source_relations)
+            inferred_type = self._expression_type_hint(expression, source_relations)
+            return [{"name": expression.name, "type": inferred_type, "display_type": inferred_type}]
+
+        return []
+
+    def _expand_star_columns(self, qualifier: str, source_relations: List[dict[str, Any]]) -> List[dict[str, Any]]:
+        normalized_qualifier = self._normalize_relation_key(qualifier)
+        columns: List[dict[str, Any]] = []
+        for relation in source_relations:
+            if normalized_qualifier and normalized_qualifier not in relation.get("lookup_names", set()):
+                continue
+            columns.extend(self._clone_columns(relation.get("columns", [])))
+        return columns
+
+    def _expression_type_hint(self, expression, source_relations: List[dict[str, Any]]) -> str:
+        if isinstance(expression, exp.Column):
+            target_column = self._find_column_definition(
+                source_relations,
+                getattr(expression, "table", ""),
+                expression.name,
+            )
+            if target_column is not None:
+                return str(target_column.get("display_type") or target_column.get("type") or "")
+        return ""
+
+    def _find_column_definition(
+        self,
+        relations: List[dict[str, Any]],
+        qualifier: str,
+        column_name: str,
+    ) -> Optional[dict[str, Any]]:
+        normalized_column = self._normalize_name(column_name)
+        normalized_qualifier = self._normalize_relation_key(qualifier)
+
+        for relation in relations:
+            if normalized_qualifier and normalized_qualifier not in relation.get("lookup_names", set()):
+                continue
+            for column in relation.get("columns", []):
+                if self._normalize_name(column.get("name", "")) == normalized_column:
+                    return column
+        return None
+
+    def _dedupe_columns(self, columns: List[dict[str, Any]]) -> List[dict[str, Any]]:
+        seen: Set[str] = set()
+        deduped: List[dict[str, Any]] = []
+        for column in columns:
+            normalized_name = self._normalize_name(column.get("name", ""))
+            if not normalized_name or normalized_name in seen:
+                continue
+            seen.add(normalized_name)
+            deduped.append(column)
+        return deduped
+
+    def _override_column_names(self, columns: List[dict[str, Any]], alias_names: List[str]) -> List[dict[str, Any]]:
+        renamed: List[dict[str, Any]] = []
+        for index, alias_name in enumerate(alias_names):
+            base = dict(columns[index]) if index < len(columns) else {"type": "", "display_type": ""}
+            base["name"] = alias_name
+            renamed.append(base)
+        return self._dedupe_columns(renamed)
+
+    def _collect_script_state(self, previous_sql: str) -> dict[str, Any]:
+        state = {
+            "relation_sources": [],
+            "relation_lookup": {},
+            "variables": {},
+        }
+        if not previous_sql.strip():
+            return state
+
+        for statement in self._split_sql_statements(previous_sql):
+            parsed = self._parse_statement(statement)
+            if parsed is None:
+                continue
+
+            if isinstance(parsed, exp.Create):
+                self._register_create_relation(parsed, state)
+                continue
+
+            if isinstance(parsed, exp.Declare):
+                self._register_declared_symbols(parsed, state)
+                continue
+
+            if isinstance(parsed, exp.Select) and getattr(parsed, "args", {}).get("into") is not None:
+                self._register_select_into_relation(parsed, state)
+
+        return state
+
+    def _register_state_relation(self, state: dict[str, Any], relation: dict[str, Any]) -> None:
+        state["relation_sources"] = [
+            existing
+            for existing in state["relation_sources"]
+            if existing.get("display_name", "").lower() != relation.get("display_name", "").lower()
+        ]
+        state["relation_sources"].append(relation)
+
+        for lookup_name, existing in list(state["relation_lookup"].items()):
+            if existing.get("display_name", "").lower() == relation.get("display_name", "").lower():
+                del state["relation_lookup"][lookup_name]
+        for lookup_name in relation.get("lookup_names", set()):
+            state["relation_lookup"][lookup_name] = relation
+
+    def _register_create_relation(self, parsed, state: dict[str, Any]) -> None:
+        schema_expression = parsed.this if isinstance(parsed.this, exp.Schema) else None
+        table_expression = None
+        if isinstance(schema_expression, exp.Schema) and isinstance(schema_expression.this, exp.Table):
+            table_expression = schema_expression.this
+        elif isinstance(parsed.this, exp.Table):
+            table_expression = parsed.this
+
+        if table_expression is None:
+            return
+
+        is_temporary = self._table_is_temporary(table_expression)
+        properties = getattr(parsed, "args", {}).get("properties")
+        if not is_temporary and properties is not None:
+            for prop in getattr(properties, "expressions", []) or []:
+                if isinstance(prop, exp.TemporaryProperty):
+                    is_temporary = True
+                    break
+        if not is_temporary:
+            return
+
+        relation_name = self._table_identifier_from_expression(table_expression)
+        if not relation_name:
+            return
+
+        columns: List[dict[str, Any]] = []
+        if isinstance(schema_expression, exp.Schema):
+            columns = self._column_defs_to_columns(getattr(schema_expression, "expressions", []) or [])
+
+        create_expression = getattr(parsed, "args", {}).get("expression")
+        if create_expression is not None and not columns and isinstance(create_expression, exp.Select):
+            columns = self._select_output_columns(create_expression, state)
+
+        relation = self._make_relation(
+            relation_name,
+            columns,
+            "temporary",
+            f"Temporary table - {relation_name}",
+            preferred_qualifier=relation_name,
+            lookup_names=self._relation_lookup_names(relation_name),
+        )
+        self._register_state_relation(state, relation)
+
+    def _register_declared_symbols(self, parsed, state: dict[str, Any]) -> None:
+        for item in getattr(parsed, "expressions", []) or []:
+            variable_names = []
+            for parameter in getattr(item, "this", []) or []:
+                variable_name = self._parameter_identifier(parameter)
+                if variable_name:
+                    variable_names.append(variable_name)
+            if not variable_names:
+                continue
+
+            kind = getattr(item, "kind", None) or getattr(item, "args", {}).get("kind")
+            if isinstance(kind, exp.Schema):
+                columns = self._column_defs_to_columns(getattr(kind, "expressions", []) or [])
+                relation_name = variable_names[0]
+                relation = self._make_relation(
+                    relation_name,
+                    columns,
+                    "table_variable",
+                    f"Table variable - {relation_name}",
+                    preferred_qualifier=relation_name,
+                    lookup_names=self._relation_lookup_names(relation_name),
+                )
+                self._register_state_relation(state, relation)
+                continue
+
+            type_detail = kind.sql() if kind is not None else ""
+            for variable_name in variable_names:
+                state["variables"][self._normalize_name(variable_name)] = type_detail
+
+    def _register_select_into_relation(self, parsed, state: dict[str, Any]) -> None:
+        into_expression = getattr(parsed, "args", {}).get("into")
+        table_expression = into_expression.this if into_expression is not None else None
+        if not isinstance(table_expression, exp.Table):
+            return
+        if not self._table_is_temporary(table_expression):
+            return
+
+        relation_name = self._table_identifier_from_expression(table_expression)
+        if not relation_name:
+            return
+
+        columns = self._select_output_columns(parsed, state)
+        relation = self._make_relation(
+            relation_name,
+            columns,
+            "temporary",
+            f"Temporary table - {relation_name}",
+            preferred_qualifier=relation_name,
+            lookup_names=self._relation_lookup_names(relation_name),
+        )
+        self._register_state_relation(state, relation)
+
+    def _column_defs_to_columns(self, column_defs) -> List[dict[str, Any]]:
+        columns: List[dict[str, Any]] = []
+        for column_def in column_defs:
+            if not isinstance(column_def, exp.ColumnDef):
+                continue
+            kind = getattr(column_def, "kind", None)
+            display_type = kind.sql() if kind is not None else ""
+            columns.append(
+                {
+                    "name": column_def.name,
+                    "type": display_type,
+                    "display_type": display_type,
+                }
+            )
+        return columns
+
+    def _select_output_columns(self, select_expression, state: dict[str, Any]) -> List[dict[str, Any]]:
+        if not HAS_SQLGLOT:
+            return []
+
+        output_cache: dict[int, List[dict[str, Any]]] = {}
+        scopes = list(traverse_scope(select_expression))
+        if not scopes:
+            return []
+        return self._scope_output_columns(scopes[-1], state, output_cache)
+
+    def _parameter_identifier(self, parameter) -> str:
+        if isinstance(parameter, exp.Parameter) and getattr(parameter, "this", None) is not None:
+            inner = parameter.this
+            if hasattr(inner, "name") and inner.name:
+                return f"@{inner.name}"
+            if hasattr(inner, "this") and inner.this:
+                return f"@{inner.this}"
+        return ""
+
+    def _table_is_temporary(self, table_expression) -> bool:
+        if not isinstance(table_expression, exp.Table):
+            return False
+        table_this = table_expression.this
+        if isinstance(table_this, exp.Parameter):
+            return False
+        args = getattr(table_this, "args", {})
+        return bool(args.get("temporary") or args.get("global_"))
+
+    def _table_identifier_from_expression(self, table_expression) -> str:
+        if not isinstance(table_expression, exp.Table):
+            return ""
+
+        table_this = table_expression.this
+        if isinstance(table_this, exp.Parameter):
+            variable_name = self._parameter_identifier(table_this)
+            return variable_name
+
+        name = str(getattr(table_expression, "name", "") or "")
+        if not name:
+            return ""
+
+        args = getattr(table_this, "args", {})
+        if args.get("global_"):
+            return f"##{name}"
+        if args.get("temporary"):
+            return f"#{name}"
+
+        parts = [part for part in (table_expression.catalog, table_expression.db, name) if part]
+        return ".".join(parts)
+
+    def _relation_lookup_names(self, identifier: str) -> Set[str]:
+        lookup_names = {self._normalize_relation_key(identifier)}
+        clean_identifier = identifier
+        if identifier.startswith("##"):
+            clean_identifier = identifier[2:]
+        elif identifier.startswith("#"):
+            clean_identifier = identifier[1:]
+        lookup_names.add(self._normalize_relation_key(clean_identifier))
+        return {name for name in lookup_names if name}
+
+    def _relation_from_table_expression(
+        self,
+        table_expression,
+        alias_name: str,
+        script_state: dict[str, Any],
+    ) -> Optional[dict[str, Any]]:
+        relation_identifier = self._table_identifier_from_expression(table_expression)
+        lookup_names = self._relation_lookup_names(relation_identifier)
+        if table_expression.db:
+            lookup_names.add(self._normalize_relation_key(f"{table_expression.db}.{table_expression.name}"))
+        if table_expression.name:
+            lookup_names.add(self._normalize_relation_key(table_expression.name))
+        if alias_name:
+            lookup_names.add(self._normalize_relation_key(alias_name))
+
+        for lookup_name in lookup_names:
+            scripted_relation = script_state["relation_lookup"].get(lookup_name)
+            if scripted_relation is not None:
+                return self._clone_relation(
+                    scripted_relation,
+                    preferred_qualifier=alias_name or scripted_relation.get("preferred_qualifier", ""),
+                    extra_lookup_names=lookup_names,
+                )
+
+        entry = self._find_schema_entry(table_expression.name, table_expression.db, table_expression.catalog)
+        if entry is None:
+            return None
+
+        relation = self._make_relation(
+            entry["detail"],
+            entry.get("columns", []),
+            "table",
+            f'{entry["type"]} - {entry["detail"]}',
+            preferred_qualifier=alias_name or entry["name"],
+            lookup_names=set(entry.get("lookup_names", set())) | lookup_names,
+        )
+        return relation
+
+    def _find_schema_entry(self, table_name: str, schema_name: str = "", catalog_name: str = "") -> Optional[dict[str, Any]]:
+        lookup_candidates = []
+        if catalog_name and schema_name:
+            lookup_candidates.append(self._normalize_relation_key(f"{catalog_name}.{schema_name}.{table_name}"))
+        if schema_name:
+            lookup_candidates.append(self._normalize_relation_key(f"{schema_name}.{table_name}"))
+        lookup_candidates.append(self._normalize_relation_key(table_name))
+
+        candidates: List[dict[str, Any]] = []
+        for lookup_name in lookup_candidates:
+            candidates.extend(self._table_lookup.get(lookup_name, []))
+
+        if not candidates:
+            return None
+
+        normalized_schema = self._normalize_name(schema_name)
+
+        def sort_key(entry: dict[str, Any]) -> Tuple[int, int, str]:
+            entry_schema = self._normalize_name(entry.get("schema", ""))
+            if normalized_schema and entry_schema == normalized_schema:
+                return (0, 0, entry["detail"])
+            if entry_schema in DEFAULT_SCHEMA_PRIORITY:
+                return (1, DEFAULT_SCHEMA_PRIORITY.index(entry_schema), entry["detail"])
+            if not entry_schema:
+                return (2, 0, entry["detail"])
+            return (3, 0, entry["detail"])
+
+        return sorted(candidates, key=sort_key)[0]
+
+    def _fallback_scope_relations(
+        self,
+        statement_sql: str,
+        script_state: dict[str, Any],
+    ) -> Tuple[List[dict[str, Any]], dict[str, dict[str, Any]]]:
+        relations: List[dict[str, Any]] = []
+        lookup: dict[str, dict[str, Any]] = {}
+        aliases = self._fallback_resolve_aliases(statement_sql)
+
+        for alias_name, target_name in aliases.items():
+            scripted_relation = script_state["relation_lookup"].get(self._normalize_relation_key(target_name))
+            if scripted_relation is not None:
+                self._append_relation(
+                    relations,
+                    lookup,
+                    self._clone_relation(
+                        scripted_relation,
+                        preferred_qualifier=alias_name if alias_name != target_name else scripted_relation.get("preferred_qualifier", ""),
+                        extra_lookup_names={self._normalize_relation_key(alias_name)},
+                    ),
+                )
+                continue
+
+            entry = self._find_schema_entry(target_name)
+            if entry is None:
+                continue
+            relation = self._make_relation(
+                entry["detail"],
+                entry.get("columns", []),
+                "table",
+                f'{entry["type"]} - {entry["detail"]}',
+                preferred_qualifier=alias_name,
+                lookup_names=set(entry.get("lookup_names", set())) | {self._normalize_relation_key(alias_name)},
+            )
+            self._append_relation(relations, lookup, relation)
+
+        return relations, lookup
+
+    def _fallback_resolve_aliases(self, sql: str) -> Dict[str, str]:
+        result: Dict[str, str] = {}
+        for match in _RE_TABLE_REF.finditer(sql):
+            schema_name = self._strip_identifier_quotes(match.group(1) or "")
+            table_name = self._strip_identifier_quotes(match.group(2) or "")
+            alias_name = self._strip_identifier_quotes(match.group(3) or "")
+            if not table_name:
+                continue
+            bare_table = table_name
+            full_table = f"{schema_name}.{table_name}" if schema_name else table_name
+            result[bare_table.lower()] = bare_table
+            if alias_name and alias_name.upper() not in {kw.upper() for kw in SQL_KEYWORDS}:
+                result[alias_name.lower()] = bare_table
+            if schema_name:
+                result[full_table.lower()] = bare_table
+        return result
+
+    def _build_completions(
+        self,
+        context: str,
+        context_arg: Optional[str],
+        analysis: dict[str, Any],
+    ) -> List[Tuple[str, str, str]]:
+        if context == CTX_DOT:
+            return self._dot_completions(context_arg or "", analysis)
         if context == CTX_TABLE:
-            return self._table_completions()
-
+            return self._table_completions(analysis)
         if context == CTX_COLUMN:
-            return self._column_completions(full_text)
-
+            return self._column_completions(analysis)
         if context == CTX_DATABASE:
             return self._database_completions()
+        if context == CTX_ROUTINE:
+            return self._routine_completions()
+        return (
+            self._keyword_completions()
+            + self._table_completions(analysis)
+            + self._variable_completions(analysis)
+            + self._routine_completions()
+        )
 
-        # CTX_DEFAULT: keywords + tables
-        return self._keyword_completions() + self._table_completions()
+    def _routine_completions(self) -> List[Tuple[str, str, str]]:
+        """Return procedure/function completions from the schema routines list."""
+        result: List[Tuple[str, str, str]] = []
+        seen: Set[str] = set()
+        for routine in self._schema.get("routines", []) or []:
+            name = str(routine.get("name", "") or "")
+            if not name:
+                continue
+            normalized = self._normalize_name(name)
+            if normalized in seen:
+                continue
+            seen.add(normalized)
+            routine_type = str(routine.get("type", "PROCEDURE") or "PROCEDURE").upper()
+            schema_name = str(routine.get("schema", "") or "")
+            detail = f"{routine_type} - {schema_name}.{name}" if schema_name else f"{routine_type} - {name}"
+            result.append((name, CAT_ROUTINE, detail))
+        return result
 
     def _keyword_completions(self) -> List[Tuple[str, str, str]]:
         """Return SQL keyword completions (both UPPER and lower case)."""
@@ -466,214 +1502,217 @@ class SqlAutoCompleteService:
             upper = kw.upper()
             if upper not in seen:
                 seen.add(upper)
-                cat = CAT_FUNCTION if upper in func_set else CAT_KEYWORD
-                result.append((upper, cat, ""))
-                result.append((upper.lower(), cat, ""))
+                category = CAT_FUNCTION if upper in func_set else CAT_KEYWORD
+                result.append((upper, category, ""))
+                result.append((upper.lower(), category, ""))
         return result
 
-    def _table_completions(self) -> List[Tuple[str, str, str]]:
-        """Return table name completions from schema."""
-        tables = self._schema.get("tables", [])
-        result = []
-        for t in tables:
-            name = t["name"] if isinstance(t, dict) else str(t)
-            schema_name = t.get("schema", "") if isinstance(t, dict) else ""
-            ttype = t.get("type", "TABLE") if isinstance(t, dict) else "TABLE"
-            detail = f"{schema_name}.{name}" if schema_name else name
-            result.append((name, CAT_TABLE, f"{ttype} - {detail}"))
-        return result
+    def _table_completions(self, analysis: Optional[dict[str, Any]] = None) -> List[Tuple[str, str, str]]:
+        """Return table-like completions from schema, CTEs, temp tables and table variables."""
+        result: List[Tuple[str, str, str]] = []
+        seen: Set[str] = set()
 
-    def _column_completions(self, full_text: str) -> List[Tuple[str, str, str]]:
-        """Return column completions from tables mentioned in FROM/JOIN clauses."""
-        columns = self._schema.get("columns", {})
-        result = []
-        seen = set()
+        def append_table(label: str, detail: str) -> None:
+            normalized_label = self._normalize_name(label)
+            if not normalized_label or normalized_label in seen:
+                return
+            seen.add(normalized_label)
+            result.append((label, CAT_TABLE, detail))
 
-        # Extract tables from FROM/JOIN clauses
-        tables_in_query = self._extract_tables_from_query(full_text)
-        
-        # Also resolve aliases to get real table names
-        aliases = self._resolve_aliases(full_text)
-        
-        # Build set of table names to include
-        relevant_tables = set()
-        for t in tables_in_query:
-            relevant_tables.add(t.lower())
-            # If it's an alias, add the real table too
-            real_table = aliases.get(t.lower())
-            if real_table and real_table not in ("__cte__", "__subquery__"):
-                relevant_tables.add(real_table.lower())
-        
-        # Add real table names from aliases
-        for alias, table in aliases.items():
-            if table not in ("__cte__", "__subquery__"):
-                relevant_tables.add(table.lower())
-        
-        # If no tables found, maybe user is still typing - show all columns
-        if not relevant_tables:
-            return self._all_columns_flat()
-        
-        # Get columns only from relevant tables
-        for table_name, cols in columns.items():
-            if table_name.lower() not in relevant_tables:
-                continue
-                
-            for col in cols:
-                cname = col["name"] if isinstance(col, dict) else str(col)
-                ctype = col.get("type", "") if isinstance(col, dict) else ""
+        if analysis:
+            for relation in analysis.get("cte_sources", []):
+                label = relation["display_name"]
+                append_table(label, relation.get("detail", "CTE"))
 
-                key = cname.lower()
-                if key not in seen:
-                    seen.add(key)
-                    detail = f"{table_name}.{cname} ({ctype})" if ctype else f"{table_name}.{cname}"
-                    result.append((cname, CAT_COLUMN, detail))
+            script_state = analysis.get("script_state", {})
+            for relation in script_state.get("relation_sources", []):
+                label = relation["display_name"]
+                append_table(label, relation.get("detail", ""))
 
-        # Also suggest qualified table.column for tables in query
-        for table_name, cols in columns.items():
-            if table_name.lower() not in relevant_tables:
-                continue
-            for col in cols:
-                cname = col["name"] if isinstance(col, dict) else str(col)
-                ctype = col.get("type", "") if isinstance(col, dict) else ""
-                qualified = f"{table_name}.{cname}"
-                if qualified.lower() not in seen:
-                    result.append((qualified, CAT_COLUMN, ctype))
+        for entry in self._table_entries:
+            append_table(entry["name"], f'{entry["type"]} - {entry["detail"]}')
 
         return result
 
-    def _extract_tables_from_query(self, text: str) -> List[str]:
-        """Extract table names from FROM and JOIN clauses."""
-        tables = []
-        
-        # Clean the text
-        cleaned = self._strip_noise(text.upper())
-        
-        # Pattern: FROM table_name [AS alias] or FROM table_name alias
-        from_pattern = r'\bFROM\s+(\w+)'
-        for match in re.finditer(from_pattern, cleaned, re.IGNORECASE):
-            tables.append(match.group(1))
-        
-        # Pattern: JOIN table_name [AS alias]
-        join_pattern = r'\bJOIN\s+(\w+)'
-        for match in re.finditer(join_pattern, cleaned, re.IGNORECASE):
-            tables.append(match.group(1))
-        
-        # Pattern: UPDATE table_name
-        update_pattern = r'\bUPDATE\s+(\w+)'
-        for match in re.finditer(update_pattern, cleaned, re.IGNORECASE):
-            tables.append(match.group(1))
-        
-        # Pattern: INSERT INTO table_name
-        insert_pattern = r'\bINTO\s+(\w+)'
-        for match in re.finditer(insert_pattern, cleaned, re.IGNORECASE):
-            tables.append(match.group(1))
-        
-        return tables
+    def _column_completions(self, analysis: dict[str, Any]) -> List[Tuple[str, str, str]]:
+        """Return column completions from the visible scope, plus variables."""
+        scope_sources = analysis.get("scope_sources", [])
+        if not scope_sources:
+            return self._all_columns_flat() + self._variable_completions(analysis)
 
-    def _dot_completions(
-        self, prefix: str, full_text: str
-    ) -> List[Tuple[str, str, str]]:
-        """
-        Return columns for the table/alias/CTE/subquery before the dot.
+        result: List[Tuple[str, str, str]] = []
+        seen_names: Set[str] = set()
+        seen_qualified: Set[str] = set()
 
-        Args:
-            prefix: The identifier before the dot (table name, alias, CTE, or subquery).
-            full_text: Complete SQL text for alias resolution.
-        """
-        columns = self._schema.get("columns", {})
-        prefix_lower = prefix.lower()
+        for relation in scope_sources:
+            qualifier = relation.get("preferred_qualifier") or relation.get("display_name")
+            for column in relation.get("columns", []):
+                column_name = str(column.get("name", "") or "")
+                if not column_name:
+                    continue
+                detail_name = relation.get("display_name", qualifier)
+                display_type = str(column.get("display_type") or column.get("type") or "")
+                unqualified_key = self._normalize_name(column_name)
+                qualified_label = f"{qualifier}.{column_name}" if qualifier else column_name
+                qualified_key = self._normalize_relation_key(qualified_label)
 
-        # First resolve aliases (including CTEs and subqueries)
-        aliases = self._resolve_aliases(full_text)
-        real_target = aliases.get(prefix_lower)
+                if unqualified_key and unqualified_key not in seen_names:
+                    seen_names.add(unqualified_key)
+                    detail = f"{detail_name}.{column_name}"
+                    if display_type:
+                        detail = f"{detail} ({display_type})"
+                    result.append((column_name, CAT_COLUMN, detail))
 
-        # Check if it's a CTE
-        if real_target == "__cte__":
-            cte_cols = self._context_parser.get_cte_columns(prefix_lower)
-            if cte_cols:
-                return [(col, CAT_COLUMN, "CTE column") for col in cte_cols]
-            # CTE with unknown columns - return empty (no fallback to all columns)
+                if qualifier and qualified_key not in seen_qualified:
+                    seen_qualified.add(qualified_key)
+                    result.append((qualified_label, CAT_COLUMN, display_type))
+
+        return result + self._variable_completions(analysis)
+
+    def _dot_completions(self, prefix: str, analysis: dict[str, Any]) -> List[Tuple[str, str, str]]:
+        """Return columns for the table, alias, CTE, subquery or temp relation before the dot."""
+        normalized_prefix = self._normalize_relation_key(prefix)
+
+        relation = analysis.get("scope_lookup", {}).get(normalized_prefix)
+        if relation is None:
+            relation = analysis.get("cte_lookup", {}).get(normalized_prefix)
+        if relation is None:
+            relation = analysis.get("script_state", {}).get("relation_lookup", {}).get(normalized_prefix)
+        if relation is None:
+            entry = self._find_schema_entry(prefix)
+            if entry is not None:
+                relation = self._make_relation(
+                    entry["detail"],
+                    entry.get("columns", []),
+                    "table",
+                    f'{entry["type"]} - {entry["detail"]}',
+                    preferred_qualifier=prefix,
+                    lookup_names=set(entry.get("lookup_names", set())),
+                )
+
+        if relation is None:
+            logger.debug("No columns found for prefix: %s", prefix)
             return []
 
-        # Check if it's a subquery alias
-        if real_target == "__subquery__":
-            subq_cols = self._context_parser.get_subquery_columns(prefix_lower)
-            if subq_cols:
-                return [(col, CAT_COLUMN, "Subquery column") for col in subq_cols]
-            # Subquery with unknown columns - return empty
-            return []
-
-        # Direct match: prefix is a table name
-        if prefix in columns:
-            return self._columns_of(prefix)
-
-        # Case-insensitive match for table name
-        for table_name in columns:
-            if table_name.lower() == prefix_lower:
-                return self._columns_of(table_name)
-
-        # Alias points to a real table
-        if real_target and real_target in columns:
-            return self._columns_of(real_target)
-
-        # Case-insensitive alias->table
-        if real_target:
-            for table_name in columns:
-                if table_name.lower() == real_target.lower():
-                    return self._columns_of(table_name)
-
-        # No match - return empty list (don't flood with all columns)
-        logger.debug(f"No columns found for prefix: {prefix}")
-        return []
-
-    def _columns_of(self, table_name: str) -> List[Tuple[str, str, str]]:
-        """Return columns of a specific table."""
-        columns = self._schema.get("columns", {})
-        cols = columns.get(table_name, [])
         result = []
-        for col in cols:
-            cname = col["name"] if isinstance(col, dict) else str(col)
-            ctype = col.get("type", "") if isinstance(col, dict) else ""
-            result.append((cname, CAT_COLUMN, ctype))
+        for column in relation.get("columns", []):
+            column_name = str(column.get("name", "") or "")
+            if not column_name:
+                continue
+            display_type = str(column.get("display_type") or column.get("type") or "")
+            detail = display_type or relation.get("detail", "")
+            result.append((column_name, CAT_COLUMN, detail))
         return result
 
     def _all_columns_flat(self) -> List[Tuple[str, str, str]]:
         """Return all columns from all tables plus table names (fallback for SELECT without FROM)."""
-        columns = self._schema.get("columns", {})
-        tables = self._schema.get("tables", [])
-        result = []
-        seen = set()
-        
-        # Include table names for qualification (e.g., SELECT users.id)
-        for t in tables:
-            name = t["name"] if isinstance(t, dict) else str(t)
-            if name.lower() not in seen:
-                seen.add(name.lower())
-                result.append((name, CAT_TABLE, ""))
-        
-        # Include all columns
-        for table_name, cols in columns.items():
-            for col in cols:
-                cname = col["name"] if isinstance(col, dict) else str(col)
-                ctype = col.get("type", "") if isinstance(col, dict) else ""
-                key = cname.lower()
-                if key not in seen:
-                    seen.add(key)
-                    detail = f"{ctype} ({table_name})" if ctype else table_name
-                    result.append((cname, CAT_COLUMN, detail))
+        result: List[Tuple[str, str, str]] = []
+        seen: Set[str] = set()
+
+        for entry in self._table_entries:
+            normalized_name = self._normalize_name(entry["name"])
+            if normalized_name in seen:
+                continue
+            seen.add(normalized_name)
+            result.append((entry["name"], CAT_TABLE, f'{entry["type"]} - {entry["detail"]}'))
+
+        for entry in self._table_entries:
+            for column in entry.get("columns", []):
+                column_name = str(column.get("name", "") or "")
+                normalized_column = self._normalize_name(column_name)
+                if not normalized_column or normalized_column in seen:
+                    continue
+                seen.add(normalized_column)
+                display_type = str(column.get("display_type") or column.get("type") or "")
+                detail = entry["detail"]
+                if display_type:
+                    detail = f"{detail} ({display_type})"
+                result.append((column_name, CAT_COLUMN, detail))
+
         return result
+
+    def _variable_completions(self, analysis: Optional[dict[str, Any]]) -> List[Tuple[str, str, str]]:
+        """Return declared SQL variables visible before the cursor."""
+        if not analysis:
+            return []
+        variables = analysis.get("script_state", {}).get("variables", {})
+        return [
+            (name, CAT_VARIABLE, detail)
+            for name, detail in sorted(variables.items(), key=lambda item: item[0])
+        ]
 
     def _database_completions(self) -> List[Tuple[str, str, str]]:
         """Return database name completions."""
         databases = self._schema.get("databases", [])
         return [(db, CAT_DATABASE, "") for db in databases]
 
-    def _resolve_aliases(self, text: str) -> Dict[str, str]:
-        """
-        Parse SQL to build alias->table_name mapping including CTEs and subqueries.
+    def _extract_tables_from_query(self, text: str) -> List[str]:
+        """Extract visible table-like names from the current statement."""
+        aliases = self._resolve_aliases(text)
+        table_names = []
+        for target in aliases.values():
+            if target in {"__cte__", "__subquery__"}:
+                continue
+            if target not in table_names:
+                table_names.append(target)
+        return table_names
 
-        Returns:
-            Dict mapping alias/CTE name (lowercase) -> real table name or '__cte__'/'__subquery__'.
-        """
-        schema_columns = self._schema.get("columns", {})
-        return self._context_parser.parse(text, schema_columns)
+    def _columns_of(self, table_name: str) -> List[Tuple[str, str, str]]:
+        """Return columns of a specific table or temp relation."""
+        relation = None
+        entry = self._find_schema_entry(table_name)
+        if entry is not None:
+            relation = self._make_relation(
+                entry["detail"],
+                entry.get("columns", []),
+                "table",
+                f'{entry["type"]} - {entry["detail"]}',
+                preferred_qualifier=table_name,
+            )
+
+        if relation is None:
+            return []
+
+        return [
+            (str(column.get("name", "") or ""), CAT_COLUMN, str(column.get("display_type") or column.get("type") or ""))
+            for column in relation.get("columns", [])
+            if column.get("name")
+        ]
+
+    def _resolve_aliases(self, text: str) -> Dict[str, str]:
+        """Parse SQL and build alias mappings for tables, CTEs and subqueries."""
+        result: Dict[str, str] = {}
+
+        for statement in self._split_sql_statements(text):
+            parsed = self._parse_statement(statement)
+            if parsed is None or not HAS_SQLGLOT:
+                continue
+
+            scopes = list(traverse_scope(parsed))
+            for scope in scopes:
+                cte_names = {
+                    self._normalize_name(cte.alias)
+                    for cte in getattr(scope, "ctes", [])
+                    if getattr(cte, "alias", "")
+                }
+                for cte_name in cte_names:
+                    result[cte_name] = "__cte__"
+
+                for alias_name, selected in getattr(scope, "selected_sources", {}).items():
+                    source_expression, source_object = selected
+                    normalized_alias = self._normalize_name(alias_name)
+                    if isinstance(source_object, exp.Table):
+                        bare_name = self._table_identifier_from_expression(source_object) or source_object.name
+                        if bare_name:
+                            result[normalized_alias] = bare_name
+                            if source_object.name:
+                                result[self._normalize_name(source_object.name)] = source_object.name
+                    elif hasattr(source_object, "expression"):
+                        source_name = ""
+                        if isinstance(source_expression, exp.Table):
+                            source_name = source_expression.name
+                        result[normalized_alias] = "__cte__" if self._normalize_name(source_name) in cte_names else "__subquery__"
+
+        if result:
+            return result
+        return self._fallback_resolve_aliases(text)

--- a/source/src/ui/components/copilot_chat_panel.py
+++ b/source/src/ui/components/copilot_chat_panel.py
@@ -27,11 +27,12 @@ from PyQt6.QtWidgets import (
     QStyleOptionViewItem,
     QStyle,
 )
-from PyQt6.QtCore import Qt, pyqtSignal, pyqtSlot, QUrl, QTimer, QSettings, QByteArray, QObject, QRect, QSize, QThread
+from PyQt6.QtCore import Qt, pyqtSignal, pyqtSlot, QUrl, QTimer, QSettings, QByteArray, QObject, QRect, QSize, QThread, QEvent
 from PyQt6.QtGui import QFont, QDesktopServices, QKeyEvent, QIcon, QPixmap, QPainter, QPen, QColor, QFontMetrics
 from PyQt6.QtSvg import QSvgRenderer
 from PyQt6.QtWebEngineWidgets import QWebEngineView
 from PyQt6.QtWebEngineCore import QWebEnginePage
+from PyQt6 import sip
 import sys
 from PyQt6.QtWebChannel import QWebChannel
 from pathlib import Path
@@ -472,7 +473,11 @@ class CopilotChatPanel(QWidget):
         self._is_thinking = False  # Tracks collapsible thinking block state
         self._settings = QSettings("DataPyn", "CopilotChat")
         self._current_session_id = None
+        self._current_tab_id = None
+        self._current_tab_name = ""
+        self._active_tool_target_id = None
         self._gh_install_worker = None
+        self._cleaned_up = False
         self._setup_ui()
         self._connect_signals()
         # Restore last session on startup
@@ -1117,6 +1122,10 @@ class CopilotChatPanel(QWidget):
         """Handle stop button - cancel current operation."""
         if self._copilot_client:
             self._copilot_client.cancel()
+        self._cancel_active_tool_target()
+        if self._mcp_server and hasattr(self._mcp_server, "tool_registry"):
+            self._mcp_server.tool_registry.unpin_session()
+        self._active_tool_target_id = None
         self._set_loading(False)
         self._hide_thinking_indicator()
         # Mark any widgets as complete
@@ -1143,20 +1152,29 @@ class CopilotChatPanel(QWidget):
         # Show loading state
         self._set_loading(True)
 
-        # Build system prompt with context
+        # Build static system prompt and lightweight per-turn context.
         system_prompt = self._build_system_prompt()
+        context_section = self._build_request_context_section()
+
+        from src.services.copilot.system_prompt import build_request_prompt
+        request_prompt = build_request_prompt(text, context_section)
 
         # Prepare messages for API
         api_messages = [{"role": "system", "content": system_prompt}]
-        for msg in self._messages:
+        for msg in self._messages[:-1]:
             api_messages.append({"role": msg["role"], "content": msg["content"]})
+        api_messages.append({"role": "user", "content": request_prompt})
 
         # Send to Copilot
         if self._copilot_client:
+            if hasattr(self._copilot_client, "system_message"):
+                self._copilot_client.system_message = system_prompt
+
             # Pin MCP tools to the current tab so tools target it even if user switches tabs
             if self._mcp_server and hasattr(self._mcp_server, "tool_registry"):
-                tab_id = getattr(self, "_current_tab_id", None)
+                tab_id = self._resolve_current_tab_id()
                 if tab_id:
+                    self._active_tool_target_id = tab_id
                     self._mcp_server.tool_registry.pin_session(tab_id)
 
             # Clear any previous assistant widget to ensure fresh response
@@ -1172,9 +1190,9 @@ class CopilotChatPanel(QWidget):
         self.message_sent.emit(text)
 
     def _build_system_prompt(self) -> str:
-        """Build system prompt with current editor context and available tools."""
+        """Build stable system prompt with behavior rules and available tools."""
         from src.services.copilot.system_prompt import (
-            SYSTEM_PROMPT_TEMPLATE, build_tools_list, build_context_section,
+            SYSTEM_PROMPT_TEMPLATE, build_tools_list,
         )
 
         # Build tools list
@@ -1186,30 +1204,192 @@ class CopilotChatPanel(QWidget):
             except Exception as e:
                 logger.debug(f"Error listing tools: {e}")
 
-        # Build context section
-        context_json = ""
-        schema_text = ""
-        if self._mcp_server:
-            try:
-                context_result = self._mcp_server.tool_registry.execute("get_context", {})
-                if "content" in context_result:
-                    context_json = context_result["content"][0].get("text", "")
-            except Exception as e:
-                logger.debug(f"Error getting editor context: {e}")
-
-            try:
-                schema_result = self._mcp_server.tool_registry.execute("read_schema", {})
-                if "content" in schema_result:
-                    schema_text = schema_result["content"][0].get("text", "")
-            except Exception as e:
-                logger.debug(f"Error getting schema: {e}")
-
-        context_section = build_context_section(context_json, schema_text)
-
         return SYSTEM_PROMPT_TEMPLATE.format(
             tools_list=tools_list,
-            context_section=context_section,
         )
+
+    def _build_request_context_section(self) -> str:
+        """Build a lightweight context snapshot for a single chat turn."""
+        from src.services.copilot.system_prompt import build_context_section
+
+        try:
+            context_json = json.dumps(self._build_context_snapshot(), indent=2, ensure_ascii=False)
+        except Exception as e:
+            logger.debug(f"Error building editor context snapshot: {e}")
+            context_json = "{}"
+        return build_context_section(context_json, "")
+
+    def _build_context_snapshot(self) -> dict:
+        """Return bounded editor state without triggering live database work."""
+        context = {
+            "chat_scope": "workspace_global",
+            "target_session_id": self._resolve_current_tab_id() or "",
+            "target_tab_name": self._current_tab_name or "",
+            "visible_artifact_policy": (
+                "Use silent tools for exploration. Edit existing blocks when possible. "
+                "Create at most one final visible tab/block for a user-facing deliverable."
+            ),
+        }
+
+        mw = self._get_registry_main_window()
+        session_widget = self._get_context_session_widget(mw, context["target_session_id"])
+        session = getattr(session_widget, "session", None) if session_widget else None
+        if session:
+            context["session"] = {
+                "id": getattr(session, "session_id", ""),
+                "title": getattr(session, "title", ""),
+                "connection_name": getattr(session, "connection_name", "") or "",
+                "is_connected": bool(getattr(session, "is_connected", False)),
+            }
+
+        block_editor = getattr(session_widget, "editor", None) if session_widget else None
+        if block_editor:
+            blocks = list(getattr(block_editor, "blocks", []) or [])
+            focused_block = getattr(block_editor, "focused_block", None)
+            block_infos = []
+            for index, block in enumerate(blocks[:20]):
+                try:
+                    code = block.get_code() if hasattr(block, "get_code") else ""
+                    name = block.get_block_name() if hasattr(block, "get_block_name") else f"block{index + 1}"
+                    language = block.get_language() if hasattr(block, "get_language") else "unknown"
+                    preview = code[:600] + "..." if len(code) > 600 else code
+                    block_infos.append({
+                        "index": index,
+                        "name": name,
+                        "language": language,
+                        "focused": block is focused_block,
+                        "lines": len(code.splitlines()) if code else 0,
+                        "code_preview": preview,
+                    })
+                except Exception as e:
+                    logger.debug(f"Error reading block context: {e}")
+            context["blocks"] = block_infos
+            context["total_blocks"] = len(blocks)
+            if len(blocks) > len(block_infos):
+                context["blocks_truncated"] = len(blocks) - len(block_infos)
+            if block_infos:
+                context["block_map"] = {b["name"]: b["index"] for b in block_infos}
+
+        connection_name = context.get("session", {}).get("connection_name", "")
+        schema_summary = self._build_cached_schema_summary(mw, connection_name, context["target_session_id"])
+        if schema_summary:
+            context["cached_schema"] = schema_summary
+
+        variables = self._build_namespace_summary(session_widget, session)
+        if variables:
+            context["variables"] = variables
+
+        return context
+
+    def _get_registry_main_window(self):
+        if not self._mcp_server or not hasattr(self._mcp_server, "tool_registry"):
+            return None
+        return getattr(self._mcp_server.tool_registry, "_main_window", None)
+
+    def _resolve_current_tab_id(self):
+        if self._current_tab_id:
+            return self._current_tab_id
+        mw = self._get_registry_main_window()
+        widget = self._get_context_session_widget(mw, "")
+        session = getattr(widget, "session", None) if widget else None
+        return getattr(session, "session_id", None)
+
+    def _get_context_session_widget(self, mw, session_id: str):
+        if not mw:
+            return None
+        if session_id and hasattr(mw, "_session_widgets"):
+            widget = mw._session_widgets.get(session_id)
+            if widget:
+                return widget
+        if hasattr(mw, "session_tabs") and mw.session_tabs:
+            idx = mw.session_tabs.currentIndex()
+            return mw.session_tabs.widget(idx) if idx >= 0 else None
+        return None
+
+    def _build_cached_schema_summary(self, mw, connection_name: str, session_id: str) -> dict:
+        if not mw or not connection_name:
+            return {}
+        schema_service = getattr(mw, "_schema_service", None)
+        if not schema_service or not hasattr(schema_service, "get_cached_schema"):
+            return {}
+        try:
+            cached = schema_service.get_cached_schema(connection_name, session_id=session_id or "")
+        except TypeError:
+            cached = schema_service.get_cached_schema(connection_name)
+        except Exception as e:
+            logger.debug(f"Error reading cached schema: {e}")
+            return {}
+        if not cached:
+            return {}
+
+        tables = cached.get("tables", []) or []
+        columns = cached.get("columns", {}) or {}
+        table_summaries = []
+        for table in tables[:50]:
+            table_name = table.get("name", "") if isinstance(table, dict) else str(table)
+            table_columns = columns.get(table_name, []) if isinstance(columns, dict) else []
+            column_names = []
+            for column in table_columns[:20]:
+                if isinstance(column, dict):
+                    column_names.append(column.get("name", ""))
+                else:
+                    column_names.append(str(column))
+            table_summaries.append({"name": table_name, "columns": column_names})
+
+        return {
+            "connection_name": connection_name,
+            "database": cached.get("database", ""),
+            "total_tables": len(tables),
+            "tables": table_summaries,
+            "tables_truncated": max(0, len(tables) - len(table_summaries)),
+        }
+
+    def _build_namespace_summary(self, session_widget, session) -> dict:
+        namespace = getattr(session_widget, "namespace", None) if session_widget else None
+        if namespace is None:
+            namespace = getattr(session_widget, "_namespace", None) if session_widget else None
+        if namespace is None:
+            namespace = getattr(session, "namespace", None) if session else None
+        if not namespace:
+            return {}
+
+        variables = {}
+        for name, value in list(namespace.items())[:80]:
+            if name.startswith("_") or name in ("pd", "np", "plt") or callable(value) or isinstance(value, type):
+                continue
+            try:
+                type_name = type(value).__name__
+                if hasattr(value, "shape"):
+                    variables[name] = f"{type_name}{value.shape}"
+                elif hasattr(value, "__len__") and not isinstance(value, (str, bytes)):
+                    variables[name] = f"{type_name}(len={len(value)})"
+                else:
+                    variables[name] = type_name
+            except Exception:
+                variables[name] = "unknown"
+            if len(variables) >= 30:
+                break
+        return variables
+
+    def _cancel_active_tool_target(self):
+        """Cancel visible execution for the chat target if one is active."""
+        if not self._mcp_server or not hasattr(self._mcp_server, "tool_registry"):
+            return
+        registry = self._mcp_server.tool_registry
+        session_widget = registry._get_active_session_widget() if hasattr(registry, "_get_active_session_widget") else None
+        editor = getattr(session_widget, "editor", None) if session_widget else None
+        if editor and hasattr(editor, "cancel_all_executions"):
+            try:
+                editor.cancel_all_executions()
+            except Exception as e:
+                logger.debug(f"Error cancelling active Copilot execution: {e}")
+        session = getattr(session_widget, "session", None) if session_widget else None
+        connector = getattr(session, "connector", None) if session else None
+        if connector and hasattr(connector, "cancel_query"):
+            try:
+                connector.cancel_query()
+            except Exception as e:
+                logger.debug(f"Error cancelling active Copilot query: {e}")
 
     def _add_message(self, role: str, content: str):
         """Add a message to the chat."""
@@ -1259,6 +1439,7 @@ class CopilotChatPanel(QWidget):
         # Unpin MCP tools session (response is complete)
         if self._mcp_server and hasattr(self._mcp_server, "tool_registry"):
             self._mcp_server.tool_registry.unpin_session()
+        self._active_tool_target_id = None
         
         # End collapsible thinking block
         if self._is_thinking:
@@ -1301,6 +1482,7 @@ class CopilotChatPanel(QWidget):
         # Unpin MCP tools session (stream ended with error)
         if self._mcp_server and hasattr(self._mcp_server, "tool_registry"):
             self._mcp_server.tool_registry.unpin_session()
+        self._active_tool_target_id = None
         
         # End collapsible thinking block
         if self._is_thinking:
@@ -1620,6 +1802,62 @@ class CopilotChatPanel(QWidget):
         # Update models if available
         self._update_models_from_client()
 
+    def cleanup(self):
+        """Release background work and WebEngine resources."""
+        if self._cleaned_up:
+            return
+
+        self._cleaned_up = True
+
+        try:
+            self._on_stop()
+        except RuntimeError:
+            pass
+
+        try:
+            self.set_copilot_client(None)
+        except RuntimeError:
+            pass
+
+        webview = getattr(self, "_chat_webview", None)
+        if webview is not None and not sip.isdeleted(webview):
+            try:
+                webview.stop()
+                page = webview.page()
+                if page is not None and not sip.isdeleted(page):
+                    try:
+                        page.setWebChannel(None)
+                    except (RuntimeError, TypeError):
+                        pass
+                    replacement_page = QWebEnginePage(webview)
+                    webview.setPage(replacement_page)
+                    sip.delete(page)
+                webview.close()
+            except RuntimeError:
+                pass
+            try:
+                sip.delete(webview)
+            except RuntimeError:
+                pass
+
+        self._chat_webview = None
+        self._external_link_page = None
+        self._chat_channel = None
+        self._chat_bridge = None
+
+    def closeEvent(self, event):
+        self.cleanup()
+        super().closeEvent(event)
+
+    def deleteLater(self):
+        self.cleanup()
+        super().deleteLater()
+
+    def event(self, event):
+        if event.type() == QEvent.Type.DeferredDelete:
+            self.cleanup()
+        return super().event(event)
+
     def _on_auth_service_chat_logged_out(self):
         """Handle chat logout from auth service (e.g., logout via Settings)."""
         self._update_auth_state()
@@ -1672,58 +1910,9 @@ class CopilotChatPanel(QWidget):
     # === Per-Tab Chat Context ===
 
     def switch_tab_context(self, tab_id: str, tab_name: str = ""):
-        """Switch chat context to a different tab.
-        
-        Saves current messages for the previous tab and restores messages
-        for the new tab. If no messages exist for the new tab, starts fresh.
-        
-        Args:
-            tab_id: Unique identifier for the tab (e.g. session_id).
-            tab_name: Display name for the tab (shown in header).
-        """
-        if not hasattr(self, "_tab_contexts"):
-            self._tab_contexts: dict = {}  # tab_id -> {messages, session_id, stream_id}
-        
-        current_tab = getattr(self, "_current_tab_id", None)
-        
-        # Save current context
-        if current_tab and current_tab != tab_id:
-            self._tab_contexts[current_tab] = {
-                "messages": self._messages.copy(),
-                "session_id": self._current_session_id,
-                "stream_id": self._current_stream_id,
-            }
-        
+        """Update the active DataPyn target while keeping chat history global."""
         self._current_tab_id = tab_id
-        
-        # Restore context for new tab if it exists
-        if tab_id in self._tab_contexts:
-            ctx = self._tab_contexts[tab_id]
-            self._messages = ctx["messages"]
-            self._current_session_id = ctx["session_id"]
-            self._current_stream_id = ctx["stream_id"]
-        else:
-            # Fresh context
-            self._messages = []
-            self._current_session_id = None
-            self._current_stream_id = None
-        
-        # End any active thinking/tool states
-        self._is_thinking = False
-        self._active_tool_calls.clear()
-        
-        # Rebuild WebView with restored messages
-        self._run_chat_js("clearMessages()")
-        if self._messages:
-            for msg in self._messages:
-                role = msg["role"]
-                content = msg["content"]
-                role_js = "error" if role == "assistant" and content.startswith("Error:") else role
-                content_escaped = json.dumps(content)
-                msg_id = json.dumps(f"restored_{id(msg) % 10000}")
-                self._run_chat_js(f"addMessage({json.dumps(role_js)}, {content_escaped}, {msg_id})")
-        
-        # Update tab name in header if provided
+        self._current_tab_name = tab_name or ""
         if tab_name:
             self._update_tab_badge(tab_name)
     
@@ -1806,6 +1995,9 @@ class CopilotChatPanel(QWidget):
 
     def _restore_last_session(self):
         """Restore the last chat session on startup."""
+        if self._cleaned_up:
+            return
+
         last_id = self._settings.value("last_session_id", "")
         if last_id:
             self._restore_session(last_id)

--- a/source/src/ui/components/object_explorer_panel.py
+++ b/source/src/ui/components/object_explorer_panel.py
@@ -546,6 +546,112 @@ class ObjectExplorerPanel(QWidget):
         
         return ".".join(quoted_parts)
 
+    def _get_column_display_type(self, column_info: dict) -> str:
+        return str(
+            column_info.get("display_type")
+            or column_info.get("data_type")
+            or column_info.get("type")
+            or ""
+        )
+
+    def _format_column_label(self, column_info: dict) -> str:
+        col_name = column_info.get("name", "")
+        col_type = self._get_column_display_type(column_info)
+        nullable = str(column_info.get("nullable", "YES"))
+
+        display = f"{col_name}  ({col_type})" if col_type else str(col_name)
+        if nullable.upper() == "NO":
+            display += f"  {S.object_explorer.not_null}"
+        return display
+
+    def _get_item_qualified_name(self, data: dict) -> str:
+        catalog = data.get("catalog", "")
+        schema_name = data.get("schema", "")
+        name = data.get("name", "")
+
+        if catalog and schema_name:
+            return f"{catalog}.{schema_name}.{name}"
+        if schema_name:
+            return f"{schema_name}.{name}"
+        return str(name)
+
+    def _get_cached_columns_for_table(self, table_data: dict) -> list:
+        if not self._current_schema:
+            return []
+
+        columns = self._current_schema.get("columns", {})
+        table_key = table_data.get("key", "")
+        schema_name = table_data.get("schema", "")
+        table_name = table_data.get("name", "")
+
+        lookup_keys = [key for key in (
+            table_key,
+            f"{schema_name}.{table_name}" if schema_name else "",
+            table_name,
+        ) if key]
+
+        for lookup_key in lookup_keys:
+            if lookup_key in columns:
+                return columns.get(lookup_key, [])
+        return []
+
+    def _get_column_metadata_for_table(self, table_item: QTreeWidgetItem) -> list:
+        table_data = table_item.data(0, Qt.ItemDataRole.UserRole) or {}
+        cached_columns = self._get_cached_columns_for_table(table_data)
+        if cached_columns:
+            return cached_columns
+
+        columns = []
+        for index in range(table_item.childCount()):
+            child = table_item.child(index)
+            child_data = child.data(0, Qt.ItemDataRole.UserRole)
+            if child_data and child_data.get("type") == "column":
+                columns.append(
+                    {
+                        "name": child_data.get("name", ""),
+                        "display_type": child_data.get("display_type", ""),
+                        "type": child_data.get("data_type", ""),
+                        "nullable": child_data.get("nullable", "YES"),
+                    }
+                )
+        return columns
+
+    def _build_create_table_script(self, table_item: QTreeWidgetItem) -> str:
+        table_data = table_item.data(0, Qt.ItemDataRole.UserRole) or {}
+        qualified_name = self._get_item_qualified_name(table_data)
+        quoted_name = self._quote_identifier(qualified_name)
+        columns = self._get_column_metadata_for_table(table_item)
+
+        if columns:
+            column_lines = []
+            for column in columns:
+                col_name = column.get("name", "")
+                col_type = self._get_column_display_type(column)
+                nullable = "NOT NULL" if str(column.get("nullable", "YES")).upper() == "NO" else "NULL"
+                column_lines.append(
+                    f"    {self._quote_identifier(col_name)} {col_type} {nullable}".rstrip()
+                )
+            body = ",\n".join(column_lines)
+        else:
+            body = "    -- Expand the table to load column metadata and regenerate this script."
+
+        return f"CREATE TABLE {quoted_name} (\n{body}\n);"
+
+    def _build_drop_and_create_script(self, table_item: QTreeWidgetItem) -> str:
+        table_data = table_item.data(0, Qt.ItemDataRole.UserRole) or {}
+        qualified_name = self._get_item_qualified_name(table_data)
+        quoted_name = self._quote_identifier(qualified_name)
+
+        if self._db_type in ("mssql", "sqlserver", ""):
+            drop_statement = (
+                f"IF OBJECT_ID(N'{qualified_name}', N'U') IS NOT NULL\n"
+                f"    DROP TABLE {quoted_name};"
+            )
+        else:
+            drop_statement = f"DROP TABLE IF EXISTS {quoted_name};"
+
+        return f"{drop_statement}\n\n{self._build_create_table_script(table_item)}"
+
     def _build_tree(self, schema: dict):
         """Build tree from schema.
 
@@ -884,35 +990,20 @@ class ObjectExplorerPanel(QWidget):
 
                 for col in table_columns:
                     col_name = col.get("name", "")
-                    col_type = col.get("type", "")
-                    nullable = col.get("nullable", "YES")
+                    col_type = self._get_column_display_type(col)
 
                     # Quando filtro ativo, filtrar colunas individualmente
                     if filter_text and filter_text not in col_name.lower() and filter_text not in col_type.lower():
                         continue
 
-                    display = f"{col_name}  ({col_type})"
-                    if nullable.upper() == "NO":
-                        display += "  NOT NULL"
-
-                    col_item = QTreeWidgetItem(table_item, [display])
-                    col_item.setData(
-                        0, Qt.ItemDataRole.UserRole,
-                        {
-                            "type": "column",
-                            "name": col_name,
-                            "data_type": col_type,
-                            "nullable": nullable,
-                            "table": table_name,
-                            "table_key": table_key,
-                            "schema": table_schema,
-                        },
+                    self._add_column_item(
+                        table_item,
+                        col,
+                        table_name=table_name,
+                        table_key=table_key,
+                        table_schema=table_schema,
+                        catalog=catalog,
                     )
-
-                    if HAS_QTAWESOME:
-                        col_item.setIcon(0, qta.icon("mdi.table-column", color="#888888"))
-
-                    col_item.setForeground(0, QColor("#b0b0b0"))
 
                 # Expandir tabela se filtro ativo e ha match
                 if filter_text:
@@ -942,6 +1033,42 @@ class ObjectExplorerPanel(QWidget):
         placeholder.setForeground(0, QColor("#808080"))
         if HAS_QTAWESOME:
             placeholder.setIcon(0, qta.icon("mdi.loading", color="#808080"))
+
+    def _add_column_item(
+        self,
+        table_item: QTreeWidgetItem,
+        column_info: dict,
+        table_name: str,
+        table_key: str = "",
+        table_schema: str = "",
+        catalog: str = "",
+    ):
+        col_name = column_info.get("name", "")
+        col_type = column_info.get("type", "")
+        display_type = self._get_column_display_type(column_info)
+        nullable = column_info.get("nullable", "YES")
+
+        col_item = QTreeWidgetItem(table_item, [self._format_column_label(column_info)])
+        col_item.setData(
+            0,
+            Qt.ItemDataRole.UserRole,
+            {
+                "type": "column",
+                "name": col_name,
+                "data_type": col_type,
+                "display_type": display_type,
+                "nullable": nullable,
+                "table": table_name,
+                "table_key": table_key,
+                "schema": table_schema,
+                "catalog": catalog,
+            },
+        )
+
+        if HAS_QTAWESOME:
+            col_item.setIcon(0, qta.icon("mdi.table-column", color="#888888"))
+
+        col_item.setForeground(0, QColor("#b0b0b0"))
 
     def _has_placeholder_child(self, item: QTreeWidgetItem) -> bool:
         """Check if item has a placeholder child (needs lazy loading)."""
@@ -1110,25 +1237,14 @@ class ObjectExplorerPanel(QWidget):
             if table_item:
                 self._remove_placeholder_children(table_item)
                 for col in columns:
-                    col_name = col.get("name", "")
-                    col_type = col.get("type", "")
-                    nullable = col.get("nullable", "YES")
-
-                    display = f"{col_name}  ({col_type})"
-                    if nullable.upper() == "NO":
-                        display += "  NOT NULL"
-
-                    col_item = QTreeWidgetItem(table_item, [display])
-                    col_item.setData(0, Qt.ItemDataRole.UserRole, {
-                        "type": "column",
-                        "name": col_name,
-                        "data_type": col_type,
-                        "table": table_name,
-                    })
-
-                    if HAS_QTAWESOME:
-                        col_item.setIcon(0, qta.icon("mdi.table-column", color="#9cdcfe"))
-                    col_item.setForeground(0, QColor("#b0b0b0"))
+                    self._add_column_item(
+                        table_item,
+                        col,
+                        table_name=table_name,
+                        table_key=f"{schema_name}.{table_name}" if schema_name else table_name,
+                        table_schema=schema_name,
+                        catalog=catalog_name,
+                    )
                 return
 
     def _on_double_click(self, item: QTreeWidgetItem, column: int):
@@ -1259,17 +1375,10 @@ class ObjectExplorerPanel(QWidget):
             """)
 
         if item_type == "table":
-            # Build qualified name
-            # For Databricks, use full namespace: catalog.schema.table
             catalog_name = data.get("catalog", "")
-            if catalog_name and schema_name:
-                # Databricks: catalog.schema.table
-                qualified = f"{catalog_name}.{schema_name}.{name}"
-            elif schema_name:
-                qualified = f"{schema_name}.{name}"
-            else:
-                qualified = name
+            qualified = self._get_item_qualified_name(data)
             quoted = self._quote_identifier(qualified)
+            is_view = "VIEW" in str(data.get("table_type", "")).upper()
             
             # Build query based on database type
             if self._db_type in ("mysql", "mariadb", "postgres", "postgresql", "sqlite", "databricks"):
@@ -1302,6 +1411,21 @@ class ObjectExplorerPanel(QWidget):
 
             menu.addSeparator()
 
+            if not is_view:
+                commands_menu = menu.addMenu(S.object_explorer.ctx_commands_menu)
+
+                act_create = commands_menu.addAction(S.object_explorer.ctx_command_create_table)
+                act_create.triggered.connect(
+                    lambda _, script=self._build_create_table_script(item): self.insert_text_requested.emit(script)
+                )
+
+                act_drop_create = commands_menu.addAction(S.object_explorer.ctx_command_drop_create)
+                act_drop_create.triggered.connect(
+                    lambda _, script=self._build_drop_and_create_script(item): self.insert_text_requested.emit(script)
+                )
+
+                menu.addSeparator()
+
             # COUNT(*)
             count_query = f"SELECT COUNT(*) FROM {quoted}"
             act_count = menu.addAction(S.object_explorer.ctx_count_rows)
@@ -1324,7 +1448,7 @@ class ObjectExplorerPanel(QWidget):
 
         elif item_type == "column":
             table_name = data.get("table", "")
-            col_type = data.get("data_type", "")
+            col_type = data.get("display_type") or data.get("data_type", "")
 
             # Insert name in editor
             act_insert = menu.addAction(S.object_explorer.ctx_insert_name)

--- a/source/src/ui/components/session_widget.py
+++ b/source/src/ui/components/session_widget.py
@@ -1195,7 +1195,7 @@ class SessionWidget(QWidget):
         tpl_vars = {
             "rows": f"{self._queue_last_rows:,}",
             "blocks": str(self._queue_blocks_done),
-            "tab_name": self.session.title or "",
+            "tab_name": getattr(self.session, "title", "") or "",
             "block_name": self._queue_last_block_name or "",
             "connection": self._queue_last_connection or "",
             "database": self._queue_last_database or "",
@@ -1725,6 +1725,9 @@ class SessionWidget(QWidget):
         """Clean resources"""
         # Stop periodic timer if running
         self.stop_periodic()
+
+        if hasattr(self, "editor") and self.editor:
+            self.editor.cleanup()
 
         try:
             if self._sql_thread and self._sql_thread.isRunning():

--- a/source/src/ui/dialogs/__init__.py
+++ b/source/src/ui/dialogs/__init__.py
@@ -9,6 +9,7 @@ from .connections_manager_dialog import ConnectionsManagerDialog
 from .settings_dialog import SettingsDialog
 from .package_manager_dialog import PackageManagerDialog
 from .copilot_download_dialog import CopilotDownloadDialog
+from .entity_info_dialog import EntityInfoDialog
 
 __all__ = [
     "ConnectionEditDialog",
@@ -16,4 +17,5 @@ __all__ = [
     "SettingsDialog",
     "PackageManagerDialog",
     "CopilotDownloadDialog",
+    "EntityInfoDialog",
 ]

--- a/source/src/ui/dialogs/entity_info_dialog.py
+++ b/source/src/ui/dialogs/entity_info_dialog.py
@@ -1,0 +1,450 @@
+"""
+Entity information dialog.
+
+Shows relation metadata gathered in the background from the active database.
+"""
+
+from __future__ import annotations
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import (
+    QDialog,
+    QFrame,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+    QHeaderView,
+)
+
+from src.design_system.tokens import get_colors, RADIUS
+from src.language import S
+
+try:
+    import qtawesome as qta
+
+    HAS_QTAWESOME = True
+except ImportError:
+    HAS_QTAWESOME = False
+
+
+class EntityInfoDialog(QDialog):
+    """Displays database metadata for a table, view, procedure, function, or trigger."""
+
+    def __init__(self, entity_name: str, parent=None):
+        super().__init__(parent)
+        self._entity_name = entity_name
+        self._summary_cards: dict[str, QLabel] = {}
+        self._setup_ui()
+
+    def _setup_ui(self):
+        colors = get_colors()
+        self.setWindowTitle(S.entity_info.dialog_title)
+        self.setWindowFlags(
+            Qt.WindowType.Dialog
+            | Qt.WindowType.WindowTitleHint
+            | Qt.WindowType.WindowSystemMenuHint
+            | Qt.WindowType.WindowCloseButtonHint
+        )
+        self.resize(860, 790)
+        self.setMinimumSize(680, 630)
+        self.setStyleSheet(
+            f"""
+            QDialog {{
+                background-color: {colors.bg_primary};
+                color: {colors.text_primary};
+            }}
+            """
+        )
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(18, 18, 18, 18)
+        layout.setSpacing(14)
+
+        header = QWidget()
+        header_layout = QVBoxLayout(header)
+        header_layout.setContentsMargins(0, 0, 0, 0)
+        header_layout.setSpacing(4)
+
+        title_row = QHBoxLayout()
+        title_row.setContentsMargins(0, 0, 0, 0)
+        title_row.setSpacing(8)
+
+        self._title_label = QLabel(self._entity_name)
+        self._title_label.setStyleSheet(
+            f"color: {colors.text_primary}; font-size: 22px; font-weight: 700;"
+        )
+        title_row.addWidget(self._title_label)
+
+        if HAS_QTAWESOME:
+            icon_label = QLabel()
+            icon_label.setPixmap(qta.icon("mdi.database-search", color=colors.interactive_primary).pixmap(20, 20))
+            title_row.insertWidget(0, icon_label)
+
+        title_row.addStretch()
+        header_layout.addLayout(title_row)
+
+        self._path_label = QLabel()
+        self._path_label.setStyleSheet(
+            f"color: {colors.text_secondary}; font-size: 12px; font-family: monospace;"
+        )
+        self._path_label.hide()
+        header_layout.addWidget(self._path_label)
+
+        self._subtitle_label = QLabel(S.entity_info.loading)
+        self._subtitle_label.setStyleSheet(
+            f"color: {colors.text_secondary}; font-size: 12px;"
+        )
+        header_layout.addWidget(self._subtitle_label)
+        layout.addWidget(header)
+
+        self._message_banner = QLabel()
+        self._message_banner.setWordWrap(True)
+        self._message_banner.hide()
+        layout.addWidget(self._message_banner)
+
+        summary_widget = QWidget()
+        self._summary_layout = QGridLayout(summary_widget)
+        self._summary_layout.setContentsMargins(0, 0, 0, 0)
+        self._summary_layout.setHorizontalSpacing(12)
+        self._summary_layout.setVerticalSpacing(12)
+
+        summary_fields = [
+            ("entity_type", S.entity_info.field_type),
+            ("database", S.entity_info.field_database),
+            ("catalog", S.entity_info.field_catalog),
+            ("schema", S.entity_info.field_schema),
+            ("row_count", S.entity_info.field_rows),
+            ("size", S.entity_info.field_size),
+        ]
+        for index, (field_key, label_text) in enumerate(summary_fields):
+            card = self._create_summary_card(label_text)
+            self._summary_layout.addWidget(card, index // 3, index % 3)
+            self._summary_cards[field_key] = card.findChild(QLabel, "value")
+        layout.addWidget(summary_widget)
+
+        self._columns_header = QLabel(S.entity_info.section_columns)
+        self._columns_header.setStyleSheet(
+            f"color: {colors.text_secondary}; font-size: 12px; font-weight: 600;"
+        )
+        layout.addWidget(self._columns_header)
+
+        self._columns_table = self._create_table(
+            [
+                S.entity_info.columns_name,
+                S.entity_info.columns_type,
+                S.entity_info.columns_nullable,
+                S.entity_info.columns_default,
+            ]
+        )
+        layout.addWidget(self._columns_table, 1)
+
+        self._indexes_header = QLabel(S.entity_info.section_indexes)
+        self._indexes_header.setStyleSheet(
+            f"color: {colors.text_secondary}; font-size: 12px; font-weight: 600;"
+        )
+        layout.addWidget(self._indexes_header)
+
+        self._indexes_table = self._create_table(
+            [
+                S.entity_info.indexes_name,
+                S.entity_info.indexes_type,
+                S.entity_info.indexes_columns,
+            ]
+        )
+        layout.addWidget(self._indexes_table, 1)
+
+        button_row = QHBoxLayout()
+        button_row.addStretch()
+
+        close_button = QPushButton(S.entity_info.button_close)
+        close_button.setStyleSheet(
+            f"""
+            QPushButton {{
+                background-color: {colors.bg_elevated};
+                color: {colors.text_primary};
+                border: 1px solid {colors.border_default};
+                border-radius: {RADIUS.radius_sm}px;
+                padding: 7px 16px;
+            }}
+            QPushButton:hover {{
+                background-color: {colors.bg_secondary};
+            }}
+            """
+        )
+        close_button.clicked.connect(self.close)
+        button_row.addWidget(close_button)
+        layout.addLayout(button_row)
+
+        self.set_loading()
+
+    def _create_summary_card(self, label_text: str) -> QFrame:
+        colors = get_colors()
+        card = QFrame()
+        card.setStyleSheet(
+            f"""
+            QFrame {{
+                background-color: {colors.bg_secondary};
+                border: 1px solid {colors.border_default};
+                border-radius: {RADIUS.radius_sm}px;
+            }}
+            """
+        )
+        card_layout = QVBoxLayout(card)
+        card_layout.setContentsMargins(12, 10, 12, 10)
+        card_layout.setSpacing(4)
+
+        label = QLabel(label_text)
+        label.setStyleSheet(
+            f"color: {colors.text_tertiary}; font-size: 11px; font-weight: 600;"
+        )
+        card_layout.addWidget(label)
+
+        value = QLabel(S.entity_info.not_available)
+        value.setObjectName("value")
+        value.setWordWrap(True)
+        value.setStyleSheet(
+            f"color: {colors.text_primary}; font-size: 13px; font-weight: 600;"
+        )
+        card_layout.addWidget(value)
+        return card
+
+    def _create_table(self, headers: list[str]) -> QTableWidget:
+        colors = get_colors()
+        table = QTableWidget()
+        table.setColumnCount(len(headers))
+        table.setHorizontalHeaderLabels(headers)
+        table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        table.setSelectionMode(QTableWidget.SelectionMode.NoSelection)
+        table.setAlternatingRowColors(True)
+        table.verticalHeader().setVisible(False)
+        table.horizontalHeader().setStretchLastSection(True)
+        table.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
+        table.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
+        table.setStyleSheet(
+            f"""
+            QTableWidget {{
+                background-color: {colors.bg_secondary};
+                color: {colors.text_primary};
+                border: 1px solid {colors.border_default};
+                border-radius: {RADIUS.radius_sm}px;
+                gridline-color: {colors.border_default};
+                font-size: 11px;
+            }}
+            QHeaderView::section {{
+                background-color: {colors.bg_tertiary};
+                color: {colors.text_secondary};
+                border: none;
+                border-bottom: 1px solid {colors.border_default};
+                padding: 8px;
+                font-weight: 600;
+            }}
+            QTableWidget::item {{
+                padding: 6px 8px;
+            }}
+            """
+        )
+        return table
+
+    def set_loading(self):
+        self._subtitle_label.setText(S.entity_info.loading)
+        self._show_banner(S.entity_info.loading, "info")
+        self._set_empty_table(self._columns_table, S.entity_info.loading)
+        self._indexes_header.show()
+        self._indexes_table.show()
+        self._set_empty_table(self._indexes_table, S.entity_info.loading)
+
+    def set_error(self, message: str):
+        self._subtitle_label.setText(S.entity_info.error_subtitle)
+        self._show_banner(message, "error")
+        self._set_empty_table(self._columns_table, message)
+        self._indexes_header.show()
+        self._indexes_table.show()
+        self._set_empty_table(self._indexes_table, message)
+
+    def populate(self, metadata: dict, connection_name: str):
+        entity_label = metadata.get("entity_name") or self._entity_name
+        self._title_label.setText(entity_label)
+        self._subtitle_label.setText(
+            S.entity_info.subtitle_ready.format(connection=connection_name, db_type=metadata.get("db_type", ""))
+        )
+        self._show_banner(
+            S.entity_info.header_connection.format(connection=connection_name),
+            "success",
+        )
+
+        qualified = metadata.get("qualified_name") or ""
+        if qualified:
+            self._path_label.setText(qualified)
+            self._path_label.show()
+        else:
+            self._path_label.hide()
+
+        summary_values = {
+            "entity_type": metadata.get("entity_type") or S.entity_info.not_available,
+            "database": metadata.get("database") or S.entity_info.not_available,
+            "catalog": metadata.get("catalog") or S.entity_info.not_available,
+            "schema": metadata.get("schema") or S.entity_info.not_available,
+            "row_count": self._format_row_count(metadata.get("row_count")),
+            "size": metadata.get("size_pretty") or S.entity_info.not_available,
+        }
+        for field_key, label in self._summary_cards.items():
+            label.setText(str(summary_values.get(field_key, S.entity_info.not_available)))
+
+        section_type = metadata.get("section_type", "table")
+
+        if section_type == "routine":
+            self._columns_header.setText(S.entity_info.section_parameters)
+            self._columns_table.setHorizontalHeaderLabels([
+                S.entity_info.columns_name,
+                S.entity_info.columns_type,
+                S.entity_info.columns_direction,
+                S.entity_info.columns_default,
+            ])
+            params = metadata.get("parameters", [])
+            self._populate_parameters(params)
+            self._indexes_header.hide()
+            self._indexes_table.hide()
+        elif section_type == "trigger":
+            self._columns_header.setText(S.entity_info.section_trigger_info)
+            self._columns_table.setHorizontalHeaderLabels([
+                S.entity_info.columns_name,
+                S.entity_info.columns_type,
+                S.entity_info.columns_default,
+                S.entity_info.columns_nullable,
+            ])
+            trigger_cols = metadata.get("parameters", [])
+            self._populate_trigger_info(trigger_cols)
+            self._indexes_header.hide()
+            self._indexes_table.hide()
+        else:
+            self._columns_header.setText(S.entity_info.section_columns)
+            self._columns_table.setHorizontalHeaderLabels([
+                S.entity_info.columns_name,
+                S.entity_info.columns_type,
+                S.entity_info.columns_nullable,
+                S.entity_info.columns_default,
+            ])
+            self._indexes_header.show()
+            self._indexes_table.show()
+            self._populate_columns(metadata.get("columns", []))
+            self._populate_indexes(metadata.get("indexes", []), metadata.get("indexes_supported", True))
+
+    def _populate_parameters(self, parameters: list[dict]):
+        if not parameters:
+            self._set_empty_table(self._columns_table, S.entity_info.no_parameters)
+            return
+        self._columns_table.setRowCount(len(parameters))
+        for row_index, param in enumerate(sorted(parameters, key=lambda p: p.get("ordinal_position", 0))):
+            values = [
+                str(param.get("name", "")),
+                str(param.get("display_type", "")),
+                str(param.get("direction", "IN")),
+                str(param.get("default", "")),
+            ]
+            for col_index, value in enumerate(values):
+                self._columns_table.setItem(row_index, col_index, QTableWidgetItem(value))
+        self._columns_table.resizeRowsToContents()
+
+    def _populate_trigger_info(self, trigger_cols: list[dict]):
+        if not trigger_cols:
+            self._set_empty_table(self._columns_table, S.entity_info.not_available)
+            return
+        self._columns_table.setRowCount(len(trigger_cols))
+        for row_index, item in enumerate(sorted(trigger_cols, key=lambda p: p.get("ordinal_position", 0))):
+            values = [
+                str(item.get("name", "")),
+                str(item.get("display_type", "")),
+                "",
+                "",
+            ]
+            for col_index, value in enumerate(values):
+                self._columns_table.setItem(row_index, col_index, QTableWidgetItem(value))
+        self._columns_table.resizeRowsToContents()
+
+    def _populate_columns(self, columns: list[dict]):
+        if not columns:
+            self._set_empty_table(self._columns_table, S.entity_info.no_columns)
+            return
+
+        self._columns_table.setRowCount(len(columns))
+        for row_index, column in enumerate(columns):
+            values = [
+                str(column.get("name", "")),
+                str(column.get("display_type", "")),
+                self._format_nullable(column.get("nullable")),
+                str(column.get("default", "")),
+            ]
+            for column_index, value in enumerate(values):
+                item = QTableWidgetItem(value)
+                if column_index == 0:
+                    item.setTextAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+                self._columns_table.setItem(row_index, column_index, item)
+        self._columns_table.resizeRowsToContents()
+
+    def _populate_indexes(self, indexes: list[dict], indexes_supported: bool):
+        if not indexes_supported:
+            self._set_empty_table(self._indexes_table, S.entity_info.indexes_not_supported)
+            return
+        if not indexes:
+            self._set_empty_table(self._indexes_table, S.entity_info.no_indexes)
+            return
+
+        self._indexes_table.setRowCount(len(indexes))
+        for row_index, index_info in enumerate(indexes):
+            values = [
+                str(index_info.get("name", "")),
+                str(index_info.get("type", "")),
+                str(index_info.get("columns", "")),
+            ]
+            for column_index, value in enumerate(values):
+                self._indexes_table.setItem(row_index, column_index, QTableWidgetItem(value))
+        self._indexes_table.resizeRowsToContents()
+
+    def _set_empty_table(self, table: QTableWidget, message: str):
+        table.clearContents()
+        table.setRowCount(1)
+        table.setItem(0, 0, QTableWidgetItem(message))
+        for column_index in range(1, table.columnCount()):
+            table.setItem(0, column_index, QTableWidgetItem(""))
+        table.resizeRowsToContents()
+
+    def _show_banner(self, message: str, variant: str):
+        colors = get_colors()
+        palette = {
+            "info": (colors.info, f"{colors.info}20"),
+            "success": (colors.success, f"{colors.success}20"),
+            "error": (colors.danger, f"{colors.danger}20"),
+        }
+        border_color, background_color = palette.get(variant, palette["info"])
+        self._message_banner.setText(message)
+        self._message_banner.setStyleSheet(
+            f"""
+            QLabel {{
+                background-color: {background_color};
+                color: {border_color};
+                border: 1px solid {border_color};
+                border-radius: {RADIUS.radius_sm}px;
+                padding: 8px 10px;
+                font-size: 11px;
+            }}
+            """
+        )
+        self._message_banner.show()
+
+    def _format_row_count(self, row_count) -> str:
+        if row_count is None:
+            return S.entity_info.not_available
+        try:
+            return f"{int(row_count):,}"
+        except (TypeError, ValueError):
+            return str(row_count)
+
+    def _format_nullable(self, value) -> str:
+        if str(value).strip().upper() == "NO":
+            return S.entity_info.nullable_no
+        return S.entity_info.nullable_yes

--- a/source/src/ui/dialogs/settings_dialog.py
+++ b/source/src/ui/dialogs/settings_dialog.py
@@ -1432,47 +1432,48 @@ class SettingsDialog(QDialog):
         # Friendly descriptions for ALL shortcuts
         descriptions = {
             # Execution
-            "execute_sql": "Run Current Block",
-            "execute_all": "Run All Blocks",
-            "execute_block_advance": "Run Block & Advance",
-            "clear_results": "Clear Results",
+            "execute_sql": S.settings.shortcut_actions.execute_sql,
+            "execute_all": S.settings.shortcut_actions.execute_all,
+            "execute_block_advance": S.settings.shortcut_actions.execute_block_advance,
+            "clear_results": S.settings.shortcut_actions.clear_results,
             # File
-            "open_file": "Open File",
-            "save_file": "Save File",
-            "save_as": "Save As...",
-            "export_script": "Export as Script",
+            "open_file": S.settings.shortcut_actions.open_file,
+            "save_file": S.settings.shortcut_actions.save_file,
+            "save_as": S.settings.shortcut_actions.save_as,
+            "export_script": S.settings.shortcut_actions.export_script,
             # Sessions
-            "new_tab": "New Tab",
-            "new_session": "New Session",
-            "close_tab": "Close Tab",
-            "add_block": "Add Block",
+            "new_tab": S.settings.shortcut_actions.new_tab,
+            "new_session": S.settings.shortcut_actions.new_session,
+            "close_tab": S.settings.shortcut_actions.close_tab,
+            "add_block": S.settings.shortcut_actions.add_block,
             # Editing
-            "find": "Find",
-            "replace": "Replace",
-            "format_code": "Format Code",
+            "find": S.settings.shortcut_actions.find,
+            "replace": S.settings.shortcut_actions.replace,
+            "format_code": S.settings.shortcut_actions.format_code,
+            "show_entity_info": S.settings.shortcut_actions.show_entity_info,
             # Autocomplete
-            "force_autocomplete": "Force Autocomplete",
+            "force_autocomplete": S.settings.shortcut_actions.force_autocomplete,
             # Connections
-            "manage_connections": "Manage Connections",
-            "new_connection": "New Connection",
+            "manage_connections": S.settings.shortcut_actions.manage_connections,
+            "new_connection": S.settings.shortcut_actions.new_connection,
             # Schema
-            "reload_schema": "Reload SQL Schema",
+            "reload_schema": S.settings.shortcut_actions.reload_schema,
             # Tools
-            "settings": "Settings",
+            "settings": S.settings.shortcut_actions.settings,
             # Results grid
-            "copy_with_headers": "Copy with Headers (Grid)",
+            "copy_with_headers": S.settings.shortcut_actions.copy_with_headers,
             # View / Layout
-            "exit_app": "Exit Application",
-            "restore_view": "Restore Default View",
-            "reset_layout": "Reset Layout Completely",
+            "exit_app": S.settings.shortcut_actions.exit_app,
+            "restore_view": S.settings.shortcut_actions.restore_view,
+            "reset_layout": S.settings.shortcut_actions.reset_layout,
             # Editor (QScintilla)
-            "editor_newline": "[Editor] Newline (Shift+Enter)",
-            "editor_duplicate_line": "[Editor] Duplicate Line/Selection",
-            "editor_cut_line": "[Editor] Cut Line",
-            "editor_transpose_line": "[Editor] Transpose Lines",
-            "editor_lowercase": "[Editor] Lowercase",
-            "editor_uppercase": "[Editor] Uppercase",
-            "editor_delete_line": "[Editor] Delete Line",
+            "editor_newline": S.settings.shortcut_actions.editor_newline,
+            "editor_duplicate_line": S.settings.shortcut_actions.editor_duplicate_line,
+            "editor_cut_line": S.settings.shortcut_actions.editor_cut_line,
+            "editor_transpose_line": S.settings.shortcut_actions.editor_transpose_line,
+            "editor_lowercase": S.settings.shortcut_actions.editor_lowercase,
+            "editor_uppercase": S.settings.shortcut_actions.editor_uppercase,
+            "editor_delete_line": S.settings.shortcut_actions.editor_delete_line,
         }
 
         # Show ALL shortcuts

--- a/source/src/ui/main_window/_connections.py
+++ b/source/src/ui/main_window/_connections.py
@@ -118,8 +118,8 @@ class ConnectionsMixin:
 
         # Update only this block's database panel
         if block and hasattr(block, "db_panel"):
-            block._database_name = display_name
-            block.db_panel.set_database(display_name)
+            block._database_name = database_name
+            block.db_panel.set_database(database_name)
 
         # Get session_id for per-session cache
         sid = ""
@@ -203,8 +203,8 @@ class ConnectionsMixin:
                     # Only update blocks using the session connection (no custom connection)
                     block_conn = block.get_connection_name() if hasattr(block, "get_connection_name") else None
                     if not block_conn:
-                        block._database_name = display_name
-                        block.db_panel.set_database(display_name)
+                        block._database_name = database_name
+                        block.db_panel.set_database(database_name)
 
     def _get_effective_connector_info(self):
         """Return (connector, connection_name) for the effective connection.

--- a/source/src/ui/main_window/_file_io.py
+++ b/source/src/ui/main_window/_file_io.py
@@ -412,6 +412,13 @@ class FileIOMixin:
         """Sync global _original_file_path/_original_file_type from the current widget.
         This ensures the global always matches the active tab."""
         current_widget = self._get_current_session_widget()
+        if (
+            current_widget
+            and hasattr(current_widget, "session")
+            and current_widget.session.session_id not in self._session_widgets
+        ):
+            current_widget = None
+
         if current_widget and hasattr(current_widget, "file_path") and current_widget.file_path:
             self._original_file_path = current_widget.file_path
             self._original_file_type = getattr(current_widget, "_original_file_type", None)
@@ -433,6 +440,9 @@ class FileIOMixin:
             # No current widget - use original type or fallback
             if self._original_file_type in ["sql", "python"]:
                 return self._original_file_type
+            return "workspace"
+
+        if not getattr(current_widget, "file_path", None) and self._original_file_type == "workspace":
             return "workspace"
 
         blocks = current_widget.editor.get_blocks()
@@ -508,6 +518,8 @@ class FileIOMixin:
         # Per-tab source of truth for file path
         current_widget = self._get_current_session_widget()
         widget_file_path = getattr(current_widget, "file_path", None) if current_widget else None
+        if not widget_file_path and self._original_file_path:
+            widget_file_path = self._original_file_path
 
         if context in ["sql", "python"]:
             # Contexto de arquivo unico
@@ -765,6 +777,13 @@ class FileIOMixin:
             if session_widget.session.connection_name:
                 conn_name = session_widget.session.connection_name
                 config = self.connection_manager.get_connection_config(conn_name)
+                if not config:
+                    connector = getattr(session_widget.session, "connector", None)
+                    connector_params = getattr(connector, "connection_params", None)
+                    if isinstance(connector_params, dict) and connector_params:
+                        config = dict(connector_params)
+                        config.setdefault('db_type', getattr(connector, "db_type", "mysql") or "mysql")
+
                 if config:
                     db_type = config.get('db_type', 'mysql')
                     host = config.get('host', 'localhost')
@@ -802,6 +821,11 @@ class FileIOMixin:
 
                     lines.append('')
                     lines.append('# Create connection engine')
+                    lines.append('engine = create_engine(connection_string)')
+                    lines.append('')
+                else:
+                    lines.append(f"# Connection config not found for: {conn_name}")
+                    lines.append("connection_string = ''  # Configure your connection string")
                     lines.append('engine = create_engine(connection_string)')
                     lines.append('')
             else:

--- a/source/src/ui/main_window/_layout.py
+++ b/source/src/ui/main_window/_layout.py
@@ -149,6 +149,9 @@ class LayoutMixin:
         self.results_dock.hide()
         self.variables_dock.hide()
 
+        if getattr(self, "_empty_state_widget", None):
+            self._show_empty_state()
+
     def _create_session_panels(self, session_id: str):
         """Creates panels (Results, Output, Variables) for a session and adds to stacks."""
         results = ResultsViewer(theme_manager=self.theme_manager)
@@ -381,11 +384,16 @@ class LayoutMixin:
                 if dock.isFloating() and dock.isVisible():
                     dock.setFloating(False)
 
+            if getattr(self, "_empty_state_widget", None):
+                self._show_empty_state()
+
             # Sync view menu after a short delay (docks need to settle)
             QTimer.singleShot(300, self._finish_layout_restore)
 
         except Exception:
             self._setup_default_layout()
+            if getattr(self, "_empty_state_widget", None):
+                self._show_empty_state()
             self._restoring_layout = False
 
     def _finish_layout_restore(self):

--- a/source/src/ui/main_window/_main.py
+++ b/source/src/ui/main_window/_main.py
@@ -189,6 +189,7 @@ class MainWindow(
         self._original_file_path = None  # Original opened file path (sql/py/dpw)
         self._original_file_type = None  # Tipo: 'sql', 'python', 'workspace'
         self._current_context = "workspace"  # Contexto atual: 'sql', 'python', 'workspace'
+        self._is_closing = False
 
         # Icons
         self.icons = self._setup_icons()
@@ -517,6 +518,10 @@ class MainWindow(
                 if hasattr(widget, "_cancel_requested"):
                     widget._cancel_requested = True
 
+        self._is_closing = True
+        if hasattr(self, "_sessions_to_load"):
+            self._sessions_to_load.clear()
+
         # Save sessions before closing
         self._save_sessions()
 
@@ -528,6 +533,27 @@ class MainWindow(
         if hasattr(self, '_layout_save_timer') and self._layout_save_timer:
             self._layout_save_timer.stop()
 
+        if hasattr(self, "auto_update_service") and self.auto_update_service:
+            self.auto_update_service.cleanup()
+
+        for thread_attr in ("_entity_info_threads", "_connection_threads"):
+            active_threads = list(getattr(self, thread_attr, []))
+            for thread, worker in active_threads:
+                try:
+                    if hasattr(worker, "cancel"):
+                        worker.cancel()
+                except RuntimeError:
+                    pass
+                try:
+                    if thread and thread.isRunning():
+                        thread.quit()
+                        if not thread.wait(3000):
+                            thread.terminate()
+                            thread.wait(1000)
+                except RuntimeError:
+                    pass
+            setattr(self, thread_attr, [])
+
         # Save dock layout before closing
         self._save_dock_layout()
 
@@ -535,14 +561,25 @@ class MainWindow(
         for widget in self._session_widgets.values():
             widget.cleanup()
 
+        # Limpar schema service
+        if hasattr(self, "_schema_service"):
+            self._schema_service.cleanup()
+
+        if hasattr(self, "_copilot_chat_panel") and self._copilot_chat_panel:
+            self._copilot_chat_panel.cleanup()
+
+        # Cleanup Copilot auth/LSP before widgets and connections disappear
+        if hasattr(self, "_copilot_auth_service") and self._copilot_auth_service:
+            self._copilot_auth_service.cleanup()
+
+        if hasattr(self, "_lsp_client") and self._lsp_client:
+            self._lsp_client.cleanup()
+            self._lsp_client = None
+
         self.session_manager.cleanup_all()
 
         # Close connections
         self.connection_manager.close_all()
-
-        # Limpar schema service
-        if hasattr(self, "_schema_service"):
-            self._schema_service.cleanup()
 
         # Cleanup Copilot client
         if hasattr(self, "_copilot_client") and self._copilot_client:
@@ -553,3 +590,8 @@ class MainWindow(
             self.docking_manager.cleanup()
 
         event.accept()
+
+    def deleteLater(self):
+        if hasattr(self, "_copilot_chat_panel") and self._copilot_chat_panel:
+            self._copilot_chat_panel.cleanup()
+        super().deleteLater()

--- a/source/src/ui/main_window/_sessions.py
+++ b/source/src/ui/main_window/_sessions.py
@@ -392,22 +392,40 @@ class SessionsMixin:
                     self.finished.emit(False)
 
         def on_connected(success):
+            if getattr(self, "_is_closing", False):
+                return
+
             if success and color:
                 idx = self.session_tabs.indexOf(widget)
                 if idx >= 0:
                     self.session_tabs.set_tab_connection_color(idx, color)
-            # Cleanup thread
-            thread.quit()
-            thread.wait()
-            thread.deleteLater()
-            worker.deleteLater()
 
         # Create and start background thread
         thread = QThread()
         worker = ConnectionWorker(session, connection_name)
+
+        def cleanup_connection_thread(active_thread=thread, active_worker=worker):
+            if not hasattr(self, "_connection_threads"):
+                return
+            self._connection_threads = [
+                (stored_thread, stored_worker)
+                for stored_thread, stored_worker in self._connection_threads
+                if stored_thread is not active_thread
+            ]
+            try:
+                active_worker.deleteLater()
+            except RuntimeError:
+                pass
+            try:
+                active_thread.deleteLater()
+            except RuntimeError:
+                pass
+
         worker.moveToThread(thread)
         thread.started.connect(worker.run)
         worker.finished.connect(on_connected)
+        worker.finished.connect(thread.quit)
+        thread.finished.connect(cleanup_connection_thread)
         thread.start()
 
         # Store reference to prevent garbage collection
@@ -493,9 +511,6 @@ class SessionsMixin:
 
     def _show_empty_state(self):
         """Shows empty state when there are no sessions, hiding panels"""
-        if hasattr(self, "_empty_state_widget") and self._empty_state_widget:
-            return  # Ja esta mostrando
-
         # Esconder paineis inferiores (sem sessao, nao faz sentido mostralos)
         if hasattr(self, "results_dock"):
             self.results_dock.hide()
@@ -503,6 +518,9 @@ class SessionsMixin:
             self.output_dock.hide()
         if hasattr(self, "variables_dock"):
             self.variables_dock.hide()
+
+        if hasattr(self, "_empty_state_widget") and self._empty_state_widget:
+            return  # Ja esta mostrando
 
         # Criar widget de estado vazio com suporte a drag-and-drop
         from PyQt6.QtWidgets import QLabel, QPushButton
@@ -642,6 +660,9 @@ class SessionsMixin:
 
     def _create_session_widget(self, session):
         """Creates widget for a session and adds it to a tab"""
+        if hasattr(self, "_empty_state_widget") and self._empty_state_widget:
+            self._hide_empty_state()
+
         widget = SessionWidget(session, theme_manager=self.theme_manager)
         
         # Pass Copilot client to BlockEditor for inline completions (Monaco)
@@ -850,6 +871,7 @@ class SessionsMixin:
                 del self._session_widgets[session_id]
 
             self.session_tabs.removeTab(index)
+            widget.deleteLater()
             self._save_sessions()
 
             # Verificar se nao ha mais sessoes REAIS (ignorar aba do botao +)
@@ -1169,6 +1191,9 @@ class SessionsMixin:
 
     def _load_next_session(self):
         """Loads the next session from the queue"""
+        if getattr(self, "_is_closing", False):
+            return
+
         if not self._sessions_to_load:
             # Focus on active session
             focused = self.session_manager.focused_session

--- a/source/src/ui/main_window/_sessions.py
+++ b/source/src/ui/main_window/_sessions.py
@@ -215,6 +215,95 @@ class SessionsMixin:
         else:
             self.action_label.setText(S.status.code_already_formatted.format(lang=lang.upper()))
 
+    def _show_selected_entity_info(self):
+        """Open the entity information dialog for the selected SQL relation."""
+        widget = self._get_current_session_widget()
+        if not widget or not widget.editor:
+            return
+
+        block = widget.editor.get_focused_block()
+        if not block:
+            self.statusBar().showMessage(S.entity_info.no_active_sql_block, 4000)
+            return
+
+        if getattr(block, "get_language", lambda: "")() != "sql":
+            self.statusBar().showMessage(S.entity_info.no_active_sql_block, 4000)
+            return
+
+        selected_text = (block.get_selected_text() or "").strip().strip(";").strip()
+        if not selected_text:
+            self.statusBar().showMessage(S.entity_info.no_selection, 4000)
+            return
+
+        session = getattr(widget, "session", None)
+        block_connection_name = block.get_connection_name() if hasattr(block, "get_connection_name") else ""
+        connection_name = block_connection_name or getattr(session, "connection_name", "")
+        if not connection_name:
+            self.statusBar().showMessage(S.entity_info.no_connection, 4000)
+            return
+
+        database_override = block.get_database_name() if hasattr(block, "get_database_name") else ""
+        session_connector = getattr(session, "connector", None)
+        existing_connector = None
+        if block_connection_name:
+            candidate = self.connection_manager.get_connection(connection_name)
+            if candidate and self._connector_is_connected(candidate):
+                existing_connector = candidate
+        elif session_connector and self._connector_is_connected(session_connector):
+            existing_connector = session_connector
+
+        connection_config = self.connection_manager.get_connection_config(connection_name)
+        connector = None if connection_config else existing_connector
+
+        if connector is None and connection_config is None and existing_connector is None:
+            self.statusBar().showMessage(S.entity_info.no_connection, 4000)
+            return
+
+        from src.services.entity_metadata_service import EntityMetadataWorker
+        from src.ui.dialogs.entity_info_dialog import EntityInfoDialog
+
+        dialog = EntityInfoDialog(selected_text, self)
+        dialog.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose, True)
+        dialog.show()
+        dialog.raise_()
+        dialog.activateWindow()
+
+        thread = QThread()
+        worker = EntityMetadataWorker(
+            entity_name=selected_text,
+            connector=connector,
+            fallback_connector=existing_connector if connection_config else None,
+            connection_config=connection_config,
+            database_override=database_override,
+        )
+        worker.moveToThread(thread)
+
+        def on_loaded(metadata: dict, dlg=dialog, active_connection=connection_name):
+            try:
+                dlg.populate(metadata, active_connection)
+            except RuntimeError:
+                pass
+
+        def on_error(error_text: str, dlg=dialog):
+            try:
+                dlg.set_error(S.entity_info.load_error.format(error=error_text))
+            except RuntimeError:
+                pass
+            self.statusBar().showMessage(S.entity_info.load_error_status.format(error=error_text), 6000)
+
+        thread.started.connect(worker.run)
+        worker.loaded.connect(on_loaded)
+        worker.error.connect(on_error)
+        worker.finished.connect(thread.quit)
+        thread.finished.connect(worker.deleteLater)
+        thread.finished.connect(thread.deleteLater)
+        thread.finished.connect(lambda current_thread=thread: self._cleanup_entity_info_thread(current_thread))
+
+        if not hasattr(self, "_entity_info_threads"):
+            self._entity_info_threads = []
+        self._entity_info_threads.append((thread, worker))
+        thread.start()
+
     def _force_autocomplete(self):
         """Force trigger autocomplete in current block (Ctrl+. shortcut)."""
         widget = self._get_current_session_widget()
@@ -226,6 +315,15 @@ class SessionsMixin:
         if isinstance(widget.editor, BlockEditor):
             widget.editor.force_autocomplete_focused_block()
             logging.info("[MAIN] Force autocomplete triggered via Ctrl+.")
+
+    def _cleanup_entity_info_thread(self, thread):
+        if not hasattr(self, "_entity_info_threads"):
+            return
+        self._entity_info_threads = [
+            (active_thread, worker)
+            for active_thread, worker in self._entity_info_threads
+            if active_thread is not thread
+        ]
 
     def _add_block_to_current_session(self):
         """Adds a new code block in the current session"""

--- a/source/src/ui/main_window/_ui_setup.py
+++ b/source/src/ui/main_window/_ui_setup.py
@@ -749,6 +749,7 @@ class UISetupMixin:
             "find": self._find_in_editor,
             "replace": self._replace_in_editor,
             "format_code": self._format_current_block,
+            "show_entity_info": self._show_selected_entity_info,
             # Autocompletar
             "force_autocomplete": self._force_autocomplete,
             # Conexoes
@@ -803,6 +804,7 @@ class UISetupMixin:
             "find": self._find_in_editor,
             "replace": self._replace_in_editor,
             "format_code": self._format_current_block,
+            "show_entity_info": self._show_selected_entity_info,
             # Autocompletar
             "force_autocomplete": self._force_autocomplete,
             # Conexoes

--- a/source/src/ui/main_window/_ui_setup.py
+++ b/source/src/ui/main_window/_ui_setup.py
@@ -1139,6 +1139,9 @@ class UISetupMixin:
 
     def _check_for_updates_silent(self):
         """Silently checks for updates on startup"""
+        if getattr(self, "_is_closing", False):
+            return
+
         if not self.auto_update_service.is_auto_update_enabled():
             return
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -227,6 +227,59 @@ def clear_layout_settings():
         s.sync()
 
 
+@pytest.fixture(autouse=True)
+def reset_workspace_state_between_tests(isolate_workspace_for_tests):
+    """Remove persisted tab/workspace state so tests do not inherit sessions."""
+    state_files = (
+        isolate_workspace_for_tests / "sessions.json",
+        isolate_workspace_for_tests / "workspace.json",
+    )
+
+    for state_file in state_files:
+        state_file.unlink(missing_ok=True)
+
+    yield
+
+    for state_file in state_files:
+        state_file.unlink(missing_ok=True)
+
+
+@pytest.fixture(autouse=True)
+def cleanup_qt_windows_after_test(qapp):
+    """Close Qt top-level windows left open by tests."""
+    yield
+
+    try:
+        from PyQt6 import sip
+        from PyQt6.QtCore import QCoreApplication, QEvent
+        from PyQt6.QtWidgets import QApplication
+
+        app = QApplication.instance()
+        if app is None:
+            return
+
+        for widget in list(app.topLevelWidgets()):
+            try:
+                if sip.isdeleted(widget):
+                    continue
+                cleanup = getattr(widget, "cleanup", None)
+                if callable(cleanup):
+                    cleanup()
+                if hasattr(widget, "_save_sessions"):
+                    widget._save_sessions = lambda: None
+                widget.close()
+                widget.deleteLater()
+            except RuntimeError:
+                pass
+
+        for _ in range(3):
+            app.processEvents()
+            QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)
+            app.processEvents()
+    except Exception:
+        pass
+
+
 # ==================== TESTES COM QSCINTILLA ====================
 # Removido sistema de parametrizacao - agora usa apenas QScintilla
 

--- a/tests/test_block_database.py
+++ b/tests/test_block_database.py
@@ -56,6 +56,14 @@ class TestBlockDatabasePanel:
         assert panel.get_database_name() == "testdb"
         assert panel.name_label.text() == "testdb"
 
+    def test_panel_preserves_databricks_override_token(self, qapp):
+        """Databricks prefixes devem ser preservados internamente e limpos na UI."""
+        panel = BlockDatabasePanel()
+        panel.set_database("SCHEMA:analytics")
+
+        assert panel.get_database_name() == "SCHEMA:analytics"
+        assert panel.name_label.text() == "analytics"
+
     def test_panel_set_database_none_resets(self, qapp):
         """set_database(None) should return to default"""
         panel = BlockDatabasePanel()

--- a/tests/test_copilot_integration.py
+++ b/tests/test_copilot_integration.py
@@ -5,7 +5,7 @@ Tests for Copilot MCP tools, MCP server, and CopilotClient.
 import pytest
 import json
 from unittest.mock import MagicMock, patch
-from PyQt6.QtCore import QSettings
+from PyQt6.QtCore import QObject, QSettings, pyqtSignal
 
 # Shared test data
 MOCK_SCHEMA = {
@@ -76,6 +76,20 @@ class TestMCPToolRegistry:
         assert "Test Tab" in result["content"][0]["text"]
         mock_mw.session_manager.create_session.assert_called_once_with(title="Test Tab")
 
+    def test_create_tab_pins_new_session_for_followup_tools(self):
+        """After creating a tab, later tools in the same turn should target it."""
+        mock_session = MagicMock()
+        mock_session.title = "Produtos"
+        mock_session.session_id = "new-session-id"
+
+        mock_mw = MagicMock()
+        mock_mw.session_manager.create_session.return_value = mock_session
+
+        self.registry.set_main_window(mock_mw)
+        self.registry.execute("create_tab", {"title": "Produtos"})
+
+        assert self.registry._pinned_session_id == "new-session-id"
+
     def test_create_block_without_session_returns_error(self):
         """create_block without active session should return an error."""
         mock_mw = MagicMock()
@@ -107,6 +121,31 @@ class TestMCPToolRegistry:
         assert "sql" in result["content"][0]["text"]
         mock_editor.add_block.assert_called_once_with(language="sql")
         mock_block.set_code.assert_called_once_with("SELECT 1")
+
+    def test_create_block_updates_existing_named_block(self):
+        """create_block should update a named block instead of duplicating it."""
+        mock_block = MagicMock()
+        mock_block.get_block_name.return_value = "produtos"
+        mock_editor = MagicMock(spec=["add_block", "blocks"])
+        mock_editor.blocks = [mock_block]
+
+        mock_widget = MagicMock(spec=["editor"])
+        mock_widget.editor = mock_editor
+
+        mock_mw = MagicMock()
+        mock_mw.session_tabs.currentIndex.return_value = 0
+        mock_mw.session_tabs.widget.return_value = mock_widget
+
+        self.registry.set_main_window(mock_mw)
+        result = self.registry.execute("create_block", {
+            "language": "sql",
+            "code": "SELECT * FROM produtos",
+            "name": "produtos",
+        })
+
+        assert "content" in result
+        mock_editor.add_block.assert_not_called()
+        mock_block.set_code.assert_called_once_with("SELECT * FROM produtos")
 
     def test_edit_block_with_index(self):
         """edit_block should update the specified block's code."""
@@ -852,6 +891,60 @@ class TestCopilotClient:
 class TestCopilotChatPanel:
     """Tests for the CopilotChatPanel UI component."""
 
+    class FakeCopilotClient(QObject):
+        chat_response_chunk = pyqtSignal(str)
+        chat_response_complete = pyqtSignal(str)
+        chat_error = pyqtSignal(str)
+        authenticated = pyqtSignal(str)
+        auth_failed = pyqtSignal(str)
+        auth_started = pyqtSignal(str)
+        gh_not_found = pyqtSignal()
+        license_warning = pyqtSignal(str)
+        tool_called = pyqtSignal(str, dict, str)
+        tool_result = pyqtSignal(str, str)
+        thinking = pyqtSignal(str)
+        models_changed = pyqtSignal(list)
+
+        def __init__(self):
+            super().__init__()
+            self.system_message = ""
+            self.is_authenticated = True
+            self.sent_messages = None
+            self.cancel_called = False
+
+        def send_chat(self, messages):
+            self.sent_messages = messages
+
+        def cancel(self):
+            self.cancel_called = True
+
+        def available_models(self):
+            return []
+
+        @property
+        def model(self):
+            return "gpt-4o"
+
+        @model.setter
+        def model(self, value):
+            self._model = value
+
+    def _make_panel_with_fake_client(self, qtbot):
+        from src.ui.components.copilot_chat_panel import CopilotChatPanel
+
+        client = self.FakeCopilotClient()
+        panel = CopilotChatPanel()
+        qtbot.addWidget(panel)
+        panel.set_copilot_client(client)
+
+        registry = MagicMock()
+        registry.list_tools.return_value = []
+        registry._main_window = None
+        server = MagicMock()
+        server.tool_registry = registry
+        panel.set_mcp_server(server)
+        return panel, client, registry
+
     def test_panel_creates(self, qtbot):
         """Panel should be created without errors."""
         from src.ui.components.copilot_chat_panel import CopilotChatPanel
@@ -941,6 +1034,54 @@ class TestCopilotChatPanel:
         panel._input.clear()
         panel._on_send()
         assert len(panel._messages) == 0
+
+    def test_send_passes_static_system_and_contextual_user_prompt(self, qtbot):
+        """Sending should pass static rules separately from hidden turn context."""
+        panel, client, _ = self._make_panel_with_fake_client(qtbot)
+        panel._current_tab_id = "tab_green"
+        panel._current_tab_name = "Green"
+
+        panel._input.setPlainText("lista os produtos da base green")
+        with patch.object(panel, '_run_chat_js'):
+            panel._on_send()
+
+        assert client.sent_messages is not None
+        assert client.sent_messages[0]["role"] == "system"
+        assert "SILENT vs VISIBLE" in client.system_message
+        assert "lista os produtos da base green" in client.sent_messages[-1]["content"]
+        assert '"target_session_id": "tab_green"' in client.sent_messages[-1]["content"]
+        assert panel._messages[-1]["content"] == "lista os produtos da base green"
+
+    def test_send_pins_active_tab_at_submit_time(self, qtbot):
+        """Tool calls should target the tab active when the user sends the prompt."""
+        panel, _, registry = self._make_panel_with_fake_client(qtbot)
+        panel._current_tab_id = "tab_a"
+
+        panel._input.setPlainText("crie a analise")
+        with patch.object(panel, '_run_chat_js'):
+            panel._on_send()
+
+        registry.pin_session.assert_called_once_with("tab_a")
+        assert panel._active_tool_target_id == "tab_a"
+
+    def test_stop_cancels_client_and_unpins_target(self, qtbot):
+        """Stop should cancel the client and clear the pinned tool target."""
+        panel, client, registry = self._make_panel_with_fake_client(qtbot)
+        panel._active_tool_target_id = "tab_a"
+        editor = MagicMock()
+        connector = MagicMock()
+        widget = MagicMock()
+        widget.editor = editor
+        widget.session.connector = connector
+        registry._get_active_session_widget.return_value = widget
+
+        panel._on_stop()
+
+        assert client.cancel_called is True
+        editor.cancel_all_executions.assert_called_once()
+        connector.cancel_query.assert_called_once()
+        registry.unpin_session.assert_called_once()
+        assert panel._active_tool_target_id is None
 
     def test_model_change_updates_client(self, qtbot):
         """Changing the model combo should update the client."""

--- a/tests/test_copilot_ux.py
+++ b/tests/test_copilot_ux.py
@@ -357,38 +357,34 @@ class TestPerTabChatContext:
             panel = CopilotChatPanel()
         return panel
 
-    def test_switch_to_new_tab_clears(self, panel):
-        """Switching to a new tab should give empty messages."""
+    def test_switch_to_new_tab_keeps_global_messages(self, panel):
+        """Switching tabs should keep the global chat history."""
         with patch.object(panel, '_run_chat_js'):
             panel._messages = [{"role": "user", "content": "hello"}]
             panel.switch_tab_context("tab_2", "Tab 2")
-            assert panel._messages == []
+            assert panel._messages == [{"role": "user", "content": "hello"}]
+            assert panel._current_tab_id == "tab_2"
 
-    def test_switch_back_restores(self, panel):
-        """Switching back to a previous tab should restore messages."""
+    def test_switch_back_does_not_restore_per_tab_history(self, panel):
+        """Chat history should remain global instead of per-tab isolated."""
         with patch.object(panel, '_run_chat_js'):
-            # Start on tab_1 with messages
             panel._messages = [{"role": "user", "content": "hello from tab 1"}]
             panel._current_tab_id = "tab_1"
-            
-            # Switch to tab_2
-            panel.switch_tab_context("tab_2", "Tab 2")
-            assert panel._messages == []
-            
-            # Add message on tab_2
-            panel._messages.append({"role": "user", "content": "hello from tab 2"})
-            
-            # Switch back to tab_1
-            panel.switch_tab_context("tab_1", "Tab 1")
-            assert len(panel._messages) == 1
-            assert panel._messages[0]["content"] == "hello from tab 1"
 
-    def test_switch_resets_thinking_state(self, panel):
-        """Switching tabs should reset thinking state."""
+            panel.switch_tab_context("tab_2", "Tab 2")
+            panel._messages.append({"role": "user", "content": "hello from tab 2"})
+
+            panel.switch_tab_context("tab_1", "Tab 1")
+            assert len(panel._messages) == 2
+            assert panel._messages[0]["content"] == "hello from tab 1"
+            assert panel._messages[1]["content"] == "hello from tab 2"
+
+    def test_switch_keeps_thinking_state(self, panel):
+        """Switching target tabs should not interrupt global chat thinking state."""
         with patch.object(panel, '_run_chat_js'):
             panel._is_thinking = True
             panel.switch_tab_context("tab_new", "New Tab")
-            assert panel._is_thinking is False
+            assert panel._is_thinking is True
 
     def test_tab_badge_updated(self, panel):
         """Switching tabs should update the tab badge label."""
@@ -401,12 +397,12 @@ class TestPerTabChatContext:
         """Tab badge should be hidden initially."""
         assert panel._tab_badge.isHidden()
 
-    def test_webview_cleared_on_switch(self, panel):
-        """Switching tabs should call clearMessages in WebView."""
+    def test_webview_not_cleared_on_switch(self, panel):
+        """Switching tabs should not clear global chat messages in WebView."""
         with patch.object(panel, '_run_chat_js') as mock_js:
             panel.switch_tab_context("tab_1", "Tab 1")
             calls = [c[0][0] for c in mock_js.call_args_list]
-            assert any("clearMessages" in c for c in calls)
+            assert not any("clearMessages" in c for c in calls)
 
 
 # ===== i18n Labels =====
@@ -726,8 +722,13 @@ class TestMCPToolExecuteBlock:
         new_block._is_running = False
         new_block.get_block_name.return_value = "analysis"
         new_block.status_label.text.return_value = "0.2s"
-        block_editor.add_block.return_value = new_block
-        block_editor.blocks = [block, new_block]
+        block_editor.blocks = [block]
+
+        def add_block(language="python"):
+            block_editor.blocks.append(new_block)
+            return new_block
+
+        block_editor.add_block.side_effect = add_block
 
         result = registry._write_and_run({
             "language": "python",
@@ -739,6 +740,21 @@ class TestMCPToolExecuteBlock:
         new_block.set_block_name.assert_called_once_with("analysis")
         new_block.set_code.assert_called_once_with("print('hello')")
         block_editor.execute_block.assert_called_once_with(new_block)
+        assert "content" in result
+
+    def test_write_and_run_updates_existing_named_block(self, qapp):
+        """write_and_run should update/run an existing named block instead of duplicating it."""
+        registry, block, block_editor = self._make_registry_with_session()
+
+        result = registry._write_and_run({
+            "language": "python",
+            "code": "print('updated')",
+            "name": "test_block",
+        })
+
+        block_editor.add_block.assert_not_called()
+        block.set_code.assert_called_once_with("print('updated')")
+        block_editor.execute_block.assert_called_once_with(block)
         assert "content" in result
 
     def test_fix_and_run_updates_and_executes(self, qapp):

--- a/tests/test_database_connector.py
+++ b/tests/test_database_connector.py
@@ -249,29 +249,87 @@ class TestDatabaseConnectorMocked:
         assert connector.engine is not None
         assert connector.db_type == "mysql"
 
-    @patch("database.database_connector.create_engine")
-    def test_execute_query_returns_dataframe(self, mock_create_engine):
-        """execute_query deve retornar DataFrame"""
+    def test_execute_query_returns_dataframe(self):
+        """execute_query deve retornar DataFrame preservando strings numericas."""
         from database.database_connector import DatabaseConnector
 
-        # Setup mock
         mock_engine = MagicMock()
         mock_connection = MagicMock()
         mock_engine.connect.return_value.__enter__ = lambda s: mock_connection
         mock_engine.connect.return_value.__exit__ = lambda s, *args: None
-        mock_create_engine.return_value = mock_engine
 
         connector = DatabaseConnector()
-        connector.connect("mysql", "localhost", 3306, "testdb", "user", "pass")
+        connector.engine = mock_engine
+        connector.db_type = "mysql"
 
-        # Mock pd.read_sql
-        with patch("pandas.read_sql") as mock_read_sql:
-            mock_read_sql.return_value = pd.DataFrame({"col": [1, 2, 3]})
+        mock_result = MagicMock()
+        mock_result.keys.return_value = ["col"]
+        mock_result.fetchall.return_value = [("001",), ("002",), ("003",)]
+        mock_connection.execute.return_value = mock_result
 
-            result = connector.execute_query("SELECT * FROM test")
+        result = connector.execute_query("SELECT * FROM test")
 
-            assert isinstance(result, pd.DataFrame)
-            assert len(result) == 3
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 3
+        assert result["col"].tolist() == ["001", "002", "003"]
+        assert all(isinstance(value, str) for value in result["col"])
+
+    def test_execute_query_preserves_text_columns_with_nulls(self):
+        """SELECT generico nao deve converter texto numerico em inteiro mesmo com NULL."""
+        from database.database_connector import DatabaseConnector
+
+        mock_engine = MagicMock()
+        mock_connection = MagicMock()
+        mock_engine.connect.return_value.__enter__ = lambda s: mock_connection
+        mock_engine.connect.return_value.__exit__ = lambda s, *args: None
+
+        connector = DatabaseConnector()
+        connector.engine = mock_engine
+        connector.db_type = "postgresql"
+
+        mock_result = MagicMock()
+        mock_result.keys.return_value = ["external_id"]
+        mock_result.fetchall.return_value = [("123",), (None,), ("045",)]
+        mock_connection.execute.return_value = mock_result
+
+        result = connector.execute_query("SELECT external_id FROM customer")
+
+        assert result["external_id"].iloc[0] == "123"
+        assert pd.isna(result["external_id"].iloc[1])
+        assert result["external_id"].iloc[2] == "045"
+        assert all(isinstance(value, str) for value in result["external_id"].dropna())
+
+    def test_execute_query_multiple_selects_preserve_driver_values(self):
+        """Multiplos SELECTs devem retornar DataFrames sem passar por inferencia do pandas.read_sql."""
+        from database.database_connector import DatabaseConnector
+
+        mock_engine = MagicMock()
+        mock_connection = MagicMock()
+        mock_engine.connect.return_value.__enter__ = lambda s: mock_connection
+        mock_engine.connect.return_value.__exit__ = lambda s, *args: None
+
+        connector = DatabaseConnector()
+        connector.engine = mock_engine
+        connector.db_type = "mariadb"
+
+        first_result = MagicMock()
+        first_result.keys.return_value = ["code"]
+        first_result.fetchall.return_value = [("0007",)]
+
+        second_result = MagicMock()
+        second_result.keys.return_value = ["reference"]
+        second_result.fetchall.return_value = [("9001",)]
+
+        mock_connection.execute.side_effect = [first_result, second_result]
+
+        result = connector.execute_query("SELECT code FROM first_table; SELECT reference FROM second_table;")
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["code"].tolist() == ["0007"]
+        assert result[1]["reference"].tolist() == ["9001"]
+        assert all(isinstance(value, str) for value in result[0]["code"])
+        assert all(isinstance(value, str) for value in result[1]["reference"])
 
 
 class TestDatabaseConnectorEdgeCases:

--- a/tests/test_entity_metadata_service.py
+++ b/tests/test_entity_metadata_service.py
@@ -1,0 +1,419 @@
+"""
+Tests for entity metadata introspection helpers.
+"""
+
+import pandas as pd
+
+from src.services.entity_metadata_service import (
+    EntityMetadataService,
+    build_display_data_type,
+    split_qualified_name,
+)
+
+
+class FakeConnector:
+    def __init__(self):
+        self.db_type = "mysql"
+        self.queries = []
+
+    def get_current_database(self):
+        return "analytics"
+
+    def execute_query(self, query: str):
+        self.queries.append(query)
+        compact_query = " ".join(query.split())
+
+        if "FROM INFORMATION_SCHEMA.TABLES" in compact_query:
+            return pd.DataFrame(
+                [
+                    {
+                        "schema_name": "analytics",
+                        "entity_name": "orders",
+                        "entity_type": "BASE TABLE",
+                        "table_rows": 9876543210,
+                        "size_bytes": 8192,
+                    }
+                ]
+            )
+        if "FROM INFORMATION_SCHEMA.COLUMNS" in compact_query:
+            return pd.DataFrame(
+                [
+                    {
+                        "column_name": "id",
+                        "data_type": "decimal",
+                        "numeric_precision": 20,
+                        "numeric_scale": 12,
+                        "is_nullable": "NO",
+                        "column_default": "",
+                        "ordinal_position": 1,
+                    },
+                    {
+                        "column_name": "customer_name",
+                        "data_type": "varchar",
+                        "character_maximum_length": 50,
+                        "is_nullable": "YES",
+                        "column_default": None,
+                        "ordinal_position": 2,
+                    },
+                ]
+            )
+        if "FROM INFORMATION_SCHEMA.STATISTICS" in compact_query:
+            return pd.DataFrame(
+                [
+                    {
+                        "index_name": "PRIMARY",
+                        "non_unique": 0,
+                        "column_name": "id",
+                        "seq_in_index": 1,
+                    },
+                    {
+                        "index_name": "idx_customer_name",
+                        "non_unique": 1,
+                        "column_name": "customer_name",
+                        "seq_in_index": 1,
+                    },
+                ]
+            )
+        raise AssertionError(f"Unexpected query: {query}")
+
+
+class FakeSqlServerConnector:
+    def __init__(
+        self,
+        *,
+        entity_type: str = "TABLE",
+        deny_row_count: bool = False,
+        deny_size: bool = False,
+        deny_indexes: bool = False,
+    ):
+        self.db_type = "sqlserver"
+        self.queries = []
+        self.entity_type = entity_type
+        self.deny_row_count = deny_row_count
+        self.deny_size = deny_size
+        self.deny_indexes = deny_indexes
+
+    def get_current_database(self):
+        return "Gecon"
+
+    def execute_query(self, query: str):
+        self.queries.append(query)
+        compact_query = " ".join(query.split())
+
+        if "FROM sys.objects o" in compact_query and "WHERE o.type IN ('U', 'V', 'P', 'FN', 'IF', 'TF', 'TR')" in compact_query:
+            return pd.DataFrame(
+                [
+                    {
+                        "schema_name": "dbo",
+                        "entity_name": "orders",
+                        "entity_type": self.entity_type,
+                        "object_type_code": "U" if self.entity_type == "TABLE" else "V",
+                    }
+                ]
+            )
+        if "FROM sys.tables t JOIN sys.schemas s ON s.schema_id = t.schema_id JOIN sys.partitions p" in compact_query:
+            if self.deny_row_count:
+                raise Exception("VIEW DATABASE PERFORMANCE STATE permission denied")
+            return pd.DataFrame([[9876543210123]])
+        if "FROM sys.tables t JOIN sys.schemas s ON s.schema_id = t.schema_id JOIN sys.indexes i ON i.object_id = t.object_id" in compact_query:
+            if self.deny_size:
+                raise Exception("The SELECT permission was denied on the object")
+            return pd.DataFrame([[16384]])
+        if "FROM INFORMATION_SCHEMA.COLUMNS" in compact_query:
+            return pd.DataFrame(
+                [
+                    {
+                        "column_name": "id",
+                        "data_type": "bigint",
+                        "is_nullable": "NO",
+                        "column_default": None,
+                        "ordinal_position": 1,
+                    },
+                    {
+                        "column_name": "customer_name",
+                        "data_type": "varchar",
+                        "character_maximum_length": 50,
+                        "is_nullable": "YES",
+                        "column_default": None,
+                        "ordinal_position": 2,
+                    },
+                ]
+            )
+        if "FROM sys.indexes i" in compact_query and "JOIN sys.index_columns ic" in compact_query:
+            if self.deny_indexes:
+                raise Exception("The user does not have permission to perform this action")
+            return pd.DataFrame(
+                [
+                    {
+                        "index_name": "PK_orders",
+                        "type_desc": "CLUSTERED",
+                        "is_unique": 1,
+                        "is_primary_key": 1,
+                        "column_name": "id",
+                        "key_ordinal": 1,
+                    }
+                ]
+            )
+
+        raise AssertionError(f"Unexpected query: {query}")
+
+
+def test_build_display_data_type_formats_lengths_and_scale():
+    assert build_display_data_type(
+        {"data_type": "decimal", "numeric_precision": 20, "numeric_scale": 12},
+        "mysql",
+    ) == "decimal(20,12)"
+    assert build_display_data_type(
+        {"data_type": "varchar", "character_maximum_length": 50},
+        "mysql",
+    ) == "varchar(50)"
+    assert build_display_data_type(
+        {"data_type": "string", "character_maximum_length": 50},
+        "databricks",
+    ) == "string(50)"
+
+
+def test_split_qualified_name_strips_quotes():
+    assert split_qualified_name('[dbo]."orders"') == ["dbo", "orders"]
+    assert split_qualified_name("`main`.`sales`.`orders`") == ["main", "sales", "orders"]
+
+
+def test_mysql_metadata_service_returns_columns_rows_and_indexes():
+    connector = FakeConnector()
+
+    metadata = EntityMetadataService().fetch_entity_info(connector, "orders")
+
+    assert metadata["entity_name"] == "orders"
+    assert metadata["schema"] == "analytics"
+    assert metadata["row_count"] == 9876543210
+    assert metadata["size_pretty"] == "8.00 KB"
+    assert metadata["columns"][0]["display_type"] == "decimal(20,12)"
+    assert metadata["columns"][1]["display_type"] == "varchar(50)"
+    assert metadata["indexes"][0]["type"] == "PRIMARY KEY"
+    assert metadata["indexes"][0]["columns"] == "id"
+    assert metadata["indexes"][1]["name"] == "idx_customer_name"
+    assert not any("COUNT(*)" in query for query in connector.queries)
+
+
+def test_mysql_metadata_row_count_supports_values_above_int32():
+    connector = FakeConnector()
+
+    metadata = EntityMetadataService().fetch_entity_info(connector, "orders")
+
+    assert metadata["row_count"] > 2_147_483_647
+    assert isinstance(metadata["row_count"], int)
+
+
+def test_mysql_view_metadata_skips_row_count():
+    connector = FakeConnector()
+
+    original_execute = connector.execute_query
+
+    def execute_view(query: str):
+        compact_query = " ".join(query.split())
+        if "FROM INFORMATION_SCHEMA.TABLES" in compact_query:
+            return pd.DataFrame(
+                [
+                    {
+                        "schema_name": "analytics",
+                        "entity_name": "orders_view",
+                        "entity_type": "VIEW",
+                        "table_rows": 1234567890123,
+                        "size_bytes": 4096,
+                    }
+                ]
+            )
+        return original_execute(query)
+
+    connector.execute_query = execute_view
+
+    metadata = EntityMetadataService().fetch_entity_info(connector, "orders_view")
+
+    assert metadata["entity_type"] == "VIEW"
+    assert metadata["row_count"] is None
+
+
+def test_sqlserver_metadata_uses_catalog_queries_and_large_row_count():
+    connector = FakeSqlServerConnector()
+
+    metadata = EntityMetadataService().fetch_entity_info(connector, "orders")
+
+    assert metadata["entity_name"] == "orders"
+    assert metadata["schema"] == "dbo"
+    assert metadata["row_count"] == 9876543210123
+    assert metadata["size_pretty"] == "16.00 KB"
+    assert metadata["indexes_supported"] is True
+    assert metadata["indexes"][0]["type"] == "PRIMARY KEY"
+    assert any("sys.partitions" in query for query in connector.queries)
+    assert any("sys.allocation_units" in query for query in connector.queries)
+    assert not any("dm_db_partition_stats" in query for query in connector.queries)
+
+
+def test_sqlserver_metadata_permission_fallback_keeps_window_data():
+    connector = FakeSqlServerConnector(
+        deny_row_count=True,
+        deny_size=True,
+        deny_indexes=True,
+    )
+
+    metadata = EntityMetadataService().fetch_entity_info(connector, "orders")
+
+    assert metadata["entity_name"] == "orders"
+    assert metadata["row_count"] is None
+    assert metadata["size_bytes"] is None
+    assert metadata["size_pretty"] == ""
+    assert metadata["indexes"] == []
+    assert metadata["indexes_supported"] is False
+    assert metadata["columns"][0]["name"] == "id"
+    assert metadata["columns"][1]["display_type"] == "varchar(50)"
+
+
+def test_sqlserver_view_metadata_skips_catalog_row_count():
+    connector = FakeSqlServerConnector(entity_type="VIEW")
+
+    metadata = EntityMetadataService().fetch_entity_info(connector, "orders")
+
+    assert metadata["entity_type"] == "VIEW"
+    assert metadata["row_count"] is None
+    assert metadata["size_bytes"] is None
+    assert not any("SUM(p.rows)" in query for query in connector.queries)
+
+
+class FakeSqlServerProcedureConnector:
+    """Fake connector returning SQL Server procedure metadata."""
+
+    def __init__(self, entity_type: str = "PROCEDURE"):
+        self.db_type = "sqlserver"
+        self.queries = []
+        self.entity_type = entity_type
+
+    def get_current_database(self):
+        return "AppDB"
+
+    def execute_query(self, query: str):
+        self.queries.append(query)
+        compact_query = " ".join(query.split())
+
+        if "FROM sys.objects o" in compact_query and "WHERE o.type IN ('U', 'V', 'P', 'FN', 'IF', 'TF', 'TR')" in compact_query:
+            type_code = "P" if self.entity_type == "PROCEDURE" else "FN"
+            return pd.DataFrame(
+                [
+                    {
+                        "schema_name": "dbo",
+                        "entity_name": "usp_GetOrders",
+                        "entity_type": self.entity_type,
+                        "object_type_code": type_code,
+                    }
+                ]
+            )
+        if "FROM INFORMATION_SCHEMA.PARAMETERS" in compact_query:
+            return pd.DataFrame(
+                [
+                    {
+                        "parameter_name": "@CustomerId",
+                        "data_type": "int",
+                        "parameter_mode": "IN",
+                        "character_maximum_length": None,
+                        "numeric_precision": 10,
+                        "numeric_scale": 0,
+                        "ordinal_position": 1,
+                    },
+                    {
+                        "parameter_name": "@MaxRows",
+                        "data_type": "int",
+                        "parameter_mode": "IN",
+                        "character_maximum_length": None,
+                        "numeric_precision": 10,
+                        "numeric_scale": 0,
+                        "ordinal_position": 2,
+                    },
+                ]
+            )
+
+        raise AssertionError(f"Unexpected query: {query}")
+
+
+class FakeSqlServerTriggerConnector:
+    """Fake connector returning SQL Server trigger metadata."""
+
+    def __init__(self):
+        self.db_type = "sqlserver"
+        self.queries = []
+
+    def get_current_database(self):
+        return "AppDB"
+
+    def execute_query(self, query: str):
+        self.queries.append(query)
+        compact_query = " ".join(query.split())
+
+        if "FROM sys.objects o" in compact_query and "WHERE o.type IN ('U', 'V', 'P', 'FN', 'IF', 'TF', 'TR')" in compact_query:
+            return pd.DataFrame(
+                [
+                    {
+                        "schema_name": "dbo",
+                        "entity_name": "trg_OrderAudit",
+                        "entity_type": "TRIGGER",
+                        "object_type_code": "TR",
+                    }
+                ]
+            )
+        if "FROM sys.triggers t" in compact_query:
+            return pd.DataFrame(
+                [
+                    {
+                        "trigger_name": "trg_OrderAudit",
+                        "parent_table": "orders",
+                        "parent_schema": "dbo",
+                        "timing": "AFTER",
+                        "events": "INSERT UPDATE",
+                        "status": "Enabled",
+                    }
+                ]
+            )
+
+        raise AssertionError(f"Unexpected query: {query}")
+
+
+def test_sqlserver_procedure_metadata_returns_parameters_and_section_type():
+    connector = FakeSqlServerProcedureConnector(entity_type="PROCEDURE")
+
+    metadata = EntityMetadataService().fetch_entity_info(connector, "usp_GetOrders")
+
+    assert metadata["entity_name"] == "usp_GetOrders"
+    assert metadata["entity_type"] == "PROCEDURE"
+    assert metadata["section_type"] == "routine"
+    assert metadata["row_count"] is None
+    assert metadata["size_bytes"] is None
+    assert len(metadata["parameters"]) == 2
+    assert metadata["parameters"][0]["name"] == "@CustomerId"
+    assert metadata["parameters"][0]["display_type"].startswith("int")
+    assert metadata["parameters"][0]["direction"] == "IN"
+    assert metadata["columns"] == []
+    assert metadata["indexes"] == []
+    assert metadata["indexes_supported"] is False
+
+
+def test_sqlserver_function_metadata_returns_parameters_and_section_type():
+    connector = FakeSqlServerProcedureConnector(entity_type="FUNCTION")
+
+    metadata = EntityMetadataService().fetch_entity_info(connector, "usp_GetOrders")
+
+    assert metadata["entity_type"] == "FUNCTION"
+    assert metadata["section_type"] == "routine"
+    assert len(metadata["parameters"]) == 2
+
+
+def test_sqlserver_trigger_metadata_returns_trigger_info():
+    connector = FakeSqlServerTriggerConnector()
+
+    metadata = EntityMetadataService().fetch_entity_info(connector, "trg_OrderAudit")
+
+    assert metadata["entity_name"] == "trg_OrderAudit"
+    assert metadata["entity_type"] == "TRIGGER"
+    assert metadata["section_type"] == "trigger"
+    assert metadata["row_count"] is None
+    assert len(metadata["parameters"]) >= 1
+    parent_row = next((p for p in metadata["parameters"] if p["name"] == "Parent Table"), None)
+    assert parent_row is not None
+    assert "orders" in parent_row["display_type"]

--- a/tests/test_export_script.py
+++ b/tests/test_export_script.py
@@ -29,9 +29,11 @@ def main_window(qapp, qtbot, tmp_path):
 
     with (
         patch("src.ui.main_window.ConnectionManager") as MockConnManager,
+        patch("src.ui.main_window._main.ConnectionManager") as MockMainConnManager,
         patch("src.core.session_manager.Path.home", return_value=tmp_path),
     ):
         mock_conn_manager = MockConnManager.return_value
+        MockMainConnManager.return_value = mock_conn_manager
         mock_conn_manager.get_saved_connections.return_value = ["Test Connection"]
         mock_conn_manager.get_connection_config.return_value = {
             "db_type": "mysql",

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -36,7 +36,7 @@ def qapp():
     """QApplication singleton para todos os testes"""
     app = QApplication.instance()
     if not app:
-        app = QApplication([])
+        app = QApplication(["datapyn-tests"])
     yield app
 
 

--- a/tests/test_monaco_editor.py
+++ b/tests/test_monaco_editor.py
@@ -399,3 +399,43 @@ class TestMonacoCompletionIntegration:
         qtbot.addWidget(editor)
         
         assert callable(getattr(editor, "provide_completion", None))
+
+
+class TestMonacoSqlAutocompleteIntegration:
+    """Tests for Monaco SQL autocomplete bridge behavior."""
+
+    def test_sql_completion_uses_zero_based_service_coordinates(self, qtbot):
+        from src.editors.monaco.monaco_editor import MonacoEditor
+
+        editor = MonacoEditor()
+        qtbot.addWidget(editor)
+        editor._run_js_when_ready = Mock()
+
+        with patch("src.services.sql_autocomplete_service.SqlAutoCompleteService") as service_cls:
+            service = service_cls.return_value
+            service.get_completions.return_value = [("total", "column", "decimal(18,2)")]
+
+            editor._on_sql_completion_requested("SELECT o.", 2, 9)
+
+            service.get_completions.assert_called_once_with("SELECT o.", 1, 8)
+            emitted = editor._run_js_when_ready.call_args[0][0]
+            assert '"label": "total"' in emitted
+            assert '"kind": "field"' in emitted
+
+    def test_sql_context_completion_preserves_variable_kind(self, qtbot):
+        from src.editors.monaco.monaco_editor import MonacoEditor
+
+        editor = MonacoEditor()
+        qtbot.addWidget(editor)
+        editor._run_js_when_ready = Mock()
+
+        with patch("src.services.sql_autocomplete_service.SqlAutoCompleteService") as service_cls:
+            service = service_cls.return_value
+            service.get_completions.return_value = [("@status", "variable", "VARCHAR(20)")]
+
+            editor._on_sql_context_requested("SELECT @", "@", 1, 8)
+
+            service.get_completions.assert_called_once_with("SELECT @", 0, 7)
+            emitted = editor._run_js_when_ready.call_args[0][0]
+            assert '"label": "@status"' in emitted
+            assert '"kind": "variable"' in emitted

--- a/tests/test_object_explorer.py
+++ b/tests/test_object_explorer.py
@@ -1863,6 +1863,48 @@ class TestObjectExplorerEnhancedContextMenu:
         assert "WHERE" in expected
         assert "id" in expected
 
+    def test_create_table_script_uses_detailed_types(self, explorer):
+        """Create Table script usa o tipo detalhado das colunas."""
+        schema = {
+            "database": "testdb",
+            "tables": [{"name": "orders", "schema": "dbo", "type": "BASE TABLE", "key": "dbo.orders"}],
+            "columns": {
+                "dbo.orders": [
+                    {"name": "amount", "type": "decimal", "display_type": "decimal(20,12)", "nullable": "NO"},
+                    {"name": "customer_name", "type": "varchar", "display_type": "varchar(50)", "nullable": "YES"},
+                ]
+            },
+        }
+        explorer.set_schema(schema, "conn1", db_type="mssql")
+
+        orders_item = self._find_table_item(explorer, "orders")
+        assert orders_item is not None
+
+        script = explorer._build_create_table_script(orders_item)
+        assert "CREATE TABLE [dbo].[orders]" in script
+        assert "[amount] decimal(20,12) NOT NULL" in script
+        assert "[customer_name] varchar(50) NULL" in script
+
+    def test_drop_and_create_script_includes_drop_statement(self, explorer):
+        """Drop and Create gera DROP seguido do CREATE TABLE."""
+        schema = {
+            "database": "testdb",
+            "tables": [{"name": "users", "schema": "dbo", "type": "BASE TABLE", "key": "dbo.users"}],
+            "columns": {
+                "dbo.users": [
+                    {"name": "id", "type": "int", "display_type": "int", "nullable": "NO"},
+                ]
+            },
+        }
+        explorer.set_schema(schema, "conn1", db_type="mssql")
+
+        users_item = self._find_table_item(explorer, "users")
+        assert users_item is not None
+
+        script = explorer._build_drop_and_create_script(users_item)
+        assert "DROP TABLE [dbo].[users];" in script
+        assert script.count("CREATE TABLE") == 1
+
     def test_column_group_by(self, explorer, sample_schema):
         """Coluna gera GROUP BY correto"""
         explorer.set_schema(sample_schema, "conn1")

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -21,6 +21,7 @@ def mock_shortcut_manager():
         "execute_sql": "F5",
         "execute_all": "Shift+F5",
         "new_tab": "Ctrl+T",
+        "show_entity_info": "Alt+F1",
     }
     return manager
 
@@ -37,6 +38,14 @@ def test_settings_dialog_has_shortcuts_table(qapp, mock_shortcut_manager):
     """Testa que o dialog tem uma tabela de atalhos"""
     dialog = SettingsDialog(mock_shortcut_manager)
     assert dialog.table.columnCount() >= 2
+    dialog.close()
+
+
+def test_settings_dialog_lists_entity_info_shortcut(qapp, mock_shortcut_manager):
+    """O atalho de informacoes da entidade aparece na tabela."""
+    dialog = SettingsDialog(mock_shortcut_manager)
+    shortcut_values = [dialog.table.item(row, 1).text() for row in range(dialog.table.rowCount())]
+    assert "Alt+F1" in shortcut_values
     dialog.close()
 
 

--- a/tests/test_shortcut_manager.py
+++ b/tests/test_shortcut_manager.py
@@ -19,12 +19,14 @@ class TestShortcutManager:
         assert "save_file" in shortcuts
         assert "open_file" in shortcuts
         assert "new_tab" in shortcuts
+        assert "show_entity_info" in shortcuts
 
     def test_default_shortcut_values(self, shortcut_manager):
         """Atalhos padrão devem ter valores corretos"""
         assert shortcut_manager.get_shortcut("execute_sql") == "F5"
         assert shortcut_manager.get_shortcut("execute_all") == "Ctrl+F5"
         assert shortcut_manager.get_shortcut("new_tab") == "Ctrl+T"
+        assert shortcut_manager.get_shortcut("show_entity_info") == "Alt+F1"
 
     def test_set_shortcut(self, shortcut_manager):
         """Deve permitir alterar atalho"""
@@ -192,6 +194,7 @@ class TestNoDuplicateDefaults:
         assert "exit_app" in shortcuts
         assert "restore_view" in shortcuts
         assert "reset_layout" in shortcuts
+        assert "show_entity_info" in shortcuts
 
     def test_copy_with_headers_default(self, shortcut_manager):
         """copy_with_headers should default to Ctrl+Shift+C."""

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -199,6 +199,7 @@ def test_all_shortcuts_registered(main_window):
         "add_block",
         # Edição - find/replace gerenciados pelos editores
         # 'find', 'replace' removidos - cada editor tem seus próprios
+        "show_entity_info",
         # Conexões
         "manage_connections",
         "new_connection",

--- a/tests/test_sql_autocomplete.py
+++ b/tests/test_sql_autocomplete.py
@@ -17,11 +17,14 @@ from source.src.services.sql_autocomplete_service import (
     CAT_COLUMN,
     CAT_DATABASE,
     CAT_FUNCTION,
+    CAT_VARIABLE,
+    CAT_ROUTINE,
     CTX_TABLE,
     CTX_COLUMN,
     CTX_DOT,
     CTX_DATABASE,
     CTX_DEFAULT,
+    CTX_ROUTINE,
 )
 
 
@@ -73,6 +76,44 @@ def service(schema):
 def empty_service():
     """SqlAutoCompleteService with no schema."""
     return SqlAutoCompleteService()
+
+
+@pytest.fixture
+def qualified_schema():
+    """Schema with schema-qualified column keys like SQL Server/PostgreSQL."""
+    return {
+        "db_type": "sqlserver",
+        "tables": [
+            {"name": "users", "schema": "dbo", "type": "TABLE"},
+            {"name": "orders", "schema": "sales", "type": "TABLE"},
+            {"name": "audit_log", "schema": "dbo", "type": "TABLE"},
+        ],
+        "columns": {
+            "dbo.users": [
+                {"name": "id", "type": "int", "display_type": "int"},
+                {"name": "name", "type": "varchar", "display_type": "varchar(80)"},
+                {"name": "email", "type": "varchar", "display_type": "varchar(120)"},
+            ],
+            "sales.orders": [
+                {"name": "id", "type": "bigint", "display_type": "bigint"},
+                {"name": "user_id", "type": "int", "display_type": "int"},
+                {"name": "total", "type": "decimal", "display_type": "decimal(18,2)"},
+            ],
+            "dbo.audit_log": [
+                {"name": "id", "type": "bigint", "display_type": "bigint"},
+                {"name": "payload", "type": "nvarchar", "display_type": "nvarchar(max)"},
+            ],
+        },
+        "database": "gecon",
+        "databases": ["gecon", "master"],
+    }
+
+
+@pytest.fixture
+def qualified_service(qualified_schema):
+    svc = SqlAutoCompleteService()
+    svc.set_schema(qualified_schema)
+    return svc
 
 
 # ---- Helper ----
@@ -571,3 +612,161 @@ class TestComplexQueries:
         n = names(result)
         assert "id" in n
         assert "name" in n
+
+
+class TestSchemaQualifiedAutocomplete:
+    """Coverage for SQL Server/PostgreSQL style schema-qualified schemas."""
+
+    def test_alias_resolution_uses_schema_qualified_columns(self, qualified_service):
+        sql = "SELECT u. FROM dbo.users u"
+        result = qualified_service.get_completions(sql, 0, 9)
+        n = names(result)
+        assert "id" in n
+        assert "name" in n
+        assert "email" in n
+
+    def test_where_context_merges_columns_from_visible_schema_qualified_sources(self, qualified_service):
+        sql = (
+            "SELECT *\n"
+            "FROM dbo.users u\n"
+            "JOIN sales.orders o ON u.id = o.user_id\n"
+            "WHERE "
+        )
+        result = qualified_service.get_completions(sql, 3, 6)
+        n = names(result)
+        assert "id" in n
+        assert "name" in n
+        assert "user_id" in n
+        assert "total" in n
+        assert "u.id" in n
+        assert "o.total" in n
+
+    def test_direct_schema_qualified_dot_lookup_works(self, qualified_service):
+        sql = "SELECT dbo.users."
+        result = qualified_service.get_completions(sql, 0, len(sql))
+        n = names(result)
+        assert "id" in n
+        assert "name" in n
+        assert "email" in n
+
+
+class TestDerivedAndTemporarySources:
+    """Coverage for CTEs, subqueries, temp tables and variables."""
+
+    def test_cte_alias_columns_are_suggested(self, qualified_service):
+        sql = (
+            "WITH recent_orders AS (\n"
+            "  SELECT o.user_id, o.total FROM sales.orders o\n"
+            ")\n"
+            "SELECT ro. FROM recent_orders ro"
+        )
+        result = qualified_service.get_completions(sql, 3, 10)
+        n = names(result)
+        assert "user_id" in n
+        assert "total" in n
+
+    def test_subquery_star_expands_inner_table_columns(self, qualified_service):
+        sql = "SELECT sq. FROM (SELECT u.* FROM dbo.users u) sq"
+        result = qualified_service.get_completions(sql, 0, 10)
+        n = names(result)
+        assert "id" in n
+        assert "name" in n
+        assert "email" in n
+
+    def test_create_temp_table_columns_are_suggested_later(self, qualified_service):
+        sql = (
+            "CREATE TABLE #tmp_users (id INT, name VARCHAR(80));\n"
+            "SELECT t. FROM #tmp_users t"
+        )
+        result = qualified_service.get_completions(sql, 1, 9)
+        n = names(result)
+        assert "id" in n
+        assert "name" in n
+
+    def test_select_into_temp_table_infers_projected_columns(self, qualified_service):
+        sql = (
+            "SELECT u.id, u.name INTO #tmp_users FROM dbo.users u;\n"
+            "SELECT t. FROM #tmp_users t"
+        )
+        result = qualified_service.get_completions(sql, 1, 9)
+        n = names(result)
+        assert "id" in n
+        assert "name" in n
+
+    def test_table_variable_columns_and_scalar_variables_are_suggested(self, qualified_service):
+        sql = (
+            "DECLARE @tmp TABLE (id INT, total DECIMAL(18,2));\n"
+            "DECLARE @status VARCHAR(20);\n"
+            "SELECT t. FROM @tmp t WHERE @"
+        )
+        dot_result = qualified_service.get_completions(sql, 2, 9)
+        dot_names = names(dot_result)
+        assert "id" in dot_names
+        assert "total" in dot_names
+
+        variable_result = qualified_service.get_completions(sql, 2, len("SELECT t. FROM @tmp t WHERE @"))
+        variable_names = names(variable_result)
+        variable_categories = categories(variable_result)
+        assert "@status" in variable_names
+        assert CAT_VARIABLE in variable_categories
+
+
+# ==============================================================
+# Routine (Procedures / Functions) Autocomplete
+# ==============================================================
+
+class TestRoutineAutocomplete:
+    """Tests for stored procedure and function autocomplete."""
+
+    @pytest.fixture
+    def routine_schema(self):
+        return {
+            "tables": [{"name": "orders", "schema": "dbo", "type": "TABLE"}],
+            "columns": {"orders": [{"name": "id", "type": "int"}, {"name": "status", "type": "varchar"}]},
+            "routines": [
+                {"name": "usp_GetOrders", "schema": "dbo", "type": "PROCEDURE"},
+                {"name": "usp_ProcessOrder", "schema": "dbo", "type": "PROCEDURE"},
+                {"name": "fn_FormatName", "schema": "dbo", "type": "FUNCTION"},
+            ],
+            "db_type": "sqlserver",
+        }
+
+    @pytest.fixture
+    def routine_service(self, routine_schema):
+        svc = SqlAutoCompleteService()
+        svc.set_schema(routine_schema)
+        return svc
+
+    def test_exec_context_returns_ctx_routine(self, routine_service):
+        ctx, arg = routine_service._detect_context("EXEC ")
+        assert ctx == CTX_ROUTINE
+
+    def test_execute_context_returns_ctx_routine(self, routine_service):
+        ctx, arg = routine_service._detect_context("EXECUTE ")
+        assert ctx == CTX_ROUTINE
+
+    def test_exec_completions_includes_procedures(self, routine_service):
+        result = routine_service.get_completions("EXEC ", 0, 5)
+        n = names(result)
+        c = categories(result)
+        assert "usp_GetOrders" in n
+        assert "usp_ProcessOrder" in n
+        assert CAT_ROUTINE in c
+
+    def test_exec_completions_includes_functions(self, routine_service):
+        result = routine_service.get_completions("EXEC ", 0, 5)
+        n = names(result)
+        assert "fn_FormatName" in n
+
+    def test_default_context_includes_routines(self, routine_service):
+        result = routine_service.get_completions("SELECT * FROM orders;\n", 1, 0)
+        n = names(result)
+        c = categories(result)
+        assert "usp_GetOrders" in n
+        assert CAT_ROUTINE in c
+
+    def test_no_routines_in_schema_returns_empty_routine_list(self, service):
+        result = service.get_completions("EXEC ", 0, 5)
+        routine_items = [(name, cat) for name, cat, *_ in result if cat == CAT_ROUTINE]
+        assert routine_items == []
+

--- a/uv.lock
+++ b/uv.lock
@@ -415,7 +415,7 @@ wheels = [
 
 [[package]]
 name = "datapyn"
-version = "1.24.0"
+version = "1.29.2"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary
- refine the Copilot chat flow with a stable system prompt, hidden contextual requests, active-tab pinning, better cancellation and named artifact updates
- harden Qt/WebEngine/LSP shutdown paths across the main window, Monaco editor, schema service and auto-update cleanup
- improve workspace/test isolation and expand Copilot, export and GUI regression coverage

## Testing
- .venv\Scripts\python.exe -m pytest tests\\ --tb=short -q
- Result: 1886 passed, 4 skipped