### PR TITLE
fix: stabilize object explorer lazy loading across databases

### DIFF
--- a/source/src/services/schema_service.py
+++ b/source/src/services/schema_service.py
@@ -28,6 +28,10 @@ def _quote_databricks_identifier(value: str) -> str:
     return f"`{str(value or '').replace('`', '``')}`"
 
 
+def _quote_sqlserver_identifier(value: str) -> str:
+    return f"[{str(value or '').replace(']', ']]')}]"
+
+
 def _databricks_relation_key(catalog: str, schema: str, table: str) -> str:
     return ".".join(part for part in (catalog, schema, table) if part)
 
@@ -634,10 +638,11 @@ class SchemaService(QObject):
             try:
                 db_type = getattr(connector, "db_type", "").lower()
                 tables = []
+                namespace_name = str(catalog_name or "")
+                schema_literal = _sql_literal(schema_name)
                 
                 if db_type == "databricks":
                     catalog_ident = _quote_databricks_identifier(catalog_name)
-                    schema_literal = _sql_literal(schema_name)
                     schema_ident = _quote_databricks_identifier(schema_name)
 
                     # Query the target catalog directly instead of changing connection context.
@@ -671,18 +676,25 @@ class SchemaService(QObject):
                                 "type": table_type or "TABLE",
                             })
                 elif db_type in ("mssql", "sqlserver"):
+                    query_source = "INFORMATION_SCHEMA.TABLES"
+                    if namespace_name:
+                        query_source = f"{_quote_sqlserver_identifier(namespace_name)}.INFORMATION_SCHEMA.TABLES"
+
                     query = f"""
-                        SELECT TABLE_NAME, TABLE_TYPE
-                        FROM INFORMATION_SCHEMA.TABLES
-                        WHERE TABLE_SCHEMA = '{schema_name}'
-                        ORDER BY TABLE_NAME
+                        SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE
+                        FROM {query_source}
                     """
+                    if schema_name:
+                        query += f"\n                        WHERE TABLE_SCHEMA = '{schema_literal}'"
+                    query += "\n                        ORDER BY TABLE_SCHEMA, TABLE_NAME\n                    "
                     df = connector.execute_query(query)
                     if df is not None:
                         for _, row in df.iterrows():
+                            table_schema = str(row.get("TABLE_SCHEMA", row.get("table_schema", row.iloc[0] if len(row) > 0 else "")))
                             tables.append({
-                                "name": str(row.get("TABLE_NAME", row.iloc[0])),
-                                "schema": schema_name,
+                                "name": str(row.get("TABLE_NAME", row.get("table_name", row.iloc[1] if len(row) > 1 else row.iloc[0]))),
+                                "schema": table_schema,
+                                "database": namespace_name,
                                 "type": str(row.get("TABLE_TYPE", "TABLE")),
                             })
                 elif db_type == "postgresql":
@@ -700,12 +712,13 @@ class SchemaService(QObject):
                                 "schema": schema_name,
                                 "type": str(row.get("table_type", "TABLE")),
                             })
-                else:
-                    # MySQL/MariaDB - schema = database
+                elif db_type in ("mysql", "mariadb"):
+                    target_database = namespace_name or schema_name
+                    database_literal = _sql_literal(target_database)
                     query = f"""
                         SELECT TABLE_NAME, TABLE_TYPE
                         FROM INFORMATION_SCHEMA.TABLES
-                        WHERE TABLE_SCHEMA = '{schema_name}'
+                        WHERE TABLE_SCHEMA = '{database_literal}'
                         ORDER BY TABLE_NAME
                     """
                     df = connector.execute_query(query)
@@ -713,9 +726,12 @@ class SchemaService(QObject):
                         for _, row in df.iterrows():
                             tables.append({
                                 "name": str(row.get("TABLE_NAME", row.iloc[0])),
-                                "schema": schema_name,
+                                "schema": target_database,
+                                "database": target_database,
                                 "type": str(row.get("TABLE_TYPE", "TABLE")),
                             })
+                else:
+                    return []
 
                 return tables
             except Exception as e:
@@ -745,13 +761,14 @@ class SchemaService(QObject):
             try:
                 db_type = getattr(connector, "db_type", "").lower()
                 columns = []
+                namespace_name = str(_catalog_name or "")
+                schema_literal = _sql_literal(_schema_name)
+                table_literal = _sql_literal(_table_name)
                 
                 if db_type == "databricks":
                     catalog_ident = _quote_databricks_identifier(_catalog_name)
                     schema_ident = _quote_databricks_identifier(_schema_name)
                     table_ident = _quote_databricks_identifier(_table_name)
-                    schema_literal = _sql_literal(_schema_name)
-                    table_literal = _sql_literal(_table_name)
 
                     # Query the target catalog directly instead of changing connection context.
                     try:
@@ -786,12 +803,15 @@ class SchemaService(QObject):
                                 "nullable": str(_row_value(row, "is_nullable", "IS_NULLABLE", default="YES")),
                             })
                 elif db_type in ("mssql", "sqlserver"):
+                    query_source = "INFORMATION_SCHEMA.COLUMNS"
+                    if namespace_name:
+                        query_source = f"{_quote_sqlserver_identifier(namespace_name)}.INFORMATION_SCHEMA.COLUMNS"
                     query = f"""
                         SELECT COLUMN_NAME, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH,
                                NUMERIC_PRECISION, NUMERIC_SCALE, DATETIME_PRECISION,
                                IS_NULLABLE
-                        FROM INFORMATION_SCHEMA.COLUMNS
-                        WHERE TABLE_SCHEMA = '{_schema_name}' AND TABLE_NAME = '{_table_name}'
+                        FROM {query_source}
+                        WHERE TABLE_SCHEMA = '{schema_literal}' AND TABLE_NAME = '{table_literal}'
                         ORDER BY ORDINAL_POSITION
                     """
                     df = connector.execute_query(query)
@@ -821,14 +841,15 @@ class SchemaService(QObject):
                                 "display_type": build_display_data_type(row, db_type),
                                 "nullable": str(row.get("is_nullable", "YES")),
                             })
-                else:
-                    # MySQL/MariaDB
+                elif db_type in ("mysql", "mariadb"):
+                    target_database = namespace_name or _schema_name
+                    database_literal = _sql_literal(target_database)
                     query = f"""
                         SELECT COLUMN_NAME, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH,
                                NUMERIC_PRECISION, NUMERIC_SCALE, DATETIME_PRECISION,
                                IS_NULLABLE
                         FROM INFORMATION_SCHEMA.COLUMNS
-                        WHERE TABLE_SCHEMA = '{_schema_name}' AND TABLE_NAME = '{_table_name}'
+                        WHERE TABLE_SCHEMA = '{database_literal}' AND TABLE_NAME = '{table_literal}'
                         ORDER BY ORDINAL_POSITION
                     """
                     df = connector.execute_query(query)
@@ -840,6 +861,8 @@ class SchemaService(QObject):
                                 "display_type": build_display_data_type(row, db_type),
                                 "nullable": str(row.get("IS_NULLABLE", "YES")),
                             })
+                else:
+                    return []
 
                 return columns
             except Exception as e:

--- a/source/src/ui/components/object_explorer_panel.py
+++ b/source/src/ui/components/object_explorer_panel.py
@@ -567,13 +567,18 @@ class ObjectExplorerPanel(QWidget):
 
     def _get_item_qualified_name(self, data: dict) -> str:
         catalog = data.get("catalog", "")
+        database_name = data.get("database", "")
         schema_name = data.get("schema", "")
         name = data.get("name", "")
 
         if catalog and schema_name:
             return f"{catalog}.{schema_name}.{name}"
+        if database_name and schema_name and database_name != schema_name:
+            return f"{database_name}.{schema_name}.{name}"
         if schema_name:
             return f"{schema_name}.{name}"
+        if database_name:
+            return f"{database_name}.{name}"
         return str(name)
 
     def _get_cached_columns_for_table(self, table_data: dict) -> list:
@@ -583,12 +588,15 @@ class ObjectExplorerPanel(QWidget):
         columns = self._current_schema.get("columns", {})
         table_key = table_data.get("key", "")
         catalog = table_data.get("catalog", "")
+        database_name = table_data.get("database", "")
         schema_name = table_data.get("schema", "")
         table_name = table_data.get("name", "")
 
         lookup_keys = [key for key in (
             table_key,
             f"{catalog}.{schema_name}.{table_name}" if catalog and schema_name else "",
+            f"{database_name}.{schema_name}.{table_name}" if database_name and schema_name and database_name != schema_name else "",
+            f"{database_name}.{table_name}" if database_name else "",
             f"{schema_name}.{table_name}" if schema_name else "",
             table_name,
         ) if key]
@@ -598,11 +606,15 @@ class ObjectExplorerPanel(QWidget):
                 return columns.get(lookup_key, [])
         return []
 
-    def _make_table_key(self, catalog: str, schema_name: str, table_name: str) -> str:
+    def _make_table_key(self, catalog: str, schema_name: str, table_name: str, database: str = "") -> str:
         if self._db_type == "databricks" and catalog and schema_name:
             return f"{catalog}.{schema_name}.{table_name}"
+        if database and schema_name and database != schema_name:
+            return f"{database}.{schema_name}.{table_name}"
         if schema_name:
             return f"{schema_name}.{table_name}"
+        if database:
+            return f"{database}.{table_name}"
         return str(table_name)
 
     def _schemas_for_catalog(self, catalog: str, tables: list) -> list:
@@ -653,22 +665,40 @@ class ObjectExplorerPanel(QWidget):
             if not table_name:
                 continue
             table_schema = str((table.get("schema") if isinstance(table, dict) else "") or schema_name)
-            table_catalog = str((table.get("catalog") if isinstance(table, dict) else "") or catalog_name)
-            table_key = str((table.get("key") if isinstance(table, dict) else "") or self._make_table_key(table_catalog, table_schema, table_name))
+            table_catalog = str((table.get("catalog") if isinstance(table, dict) else "") or (catalog_name if self._db_type == "databricks" else ""))
+            table_database = str((table.get("database") if isinstance(table, dict) else "") or (catalog_name if self._db_type != "databricks" else ""))
+            table_key = str(
+                (table.get("key") if isinstance(table, dict) else "")
+                or self._make_table_key(table_catalog, table_schema, table_name, database=table_database)
+            )
             normalized_tables.append({
                 "name": table_name,
                 "schema": table_schema,
                 "catalog": table_catalog,
+                "database": table_database,
                 "key": table_key,
                 "type": table_type,
             })
 
         existing_tables = self._current_schema.setdefault("tables", [])
-        replace_keys = {(table.get("catalog", ""), table.get("schema", ""), table.get("name", "")) for table in normalized_tables}
+        replace_keys = {
+            (
+                table.get("catalog", ""),
+                table.get("database", ""),
+                table.get("schema", ""),
+                table.get("name", ""),
+            )
+            for table in normalized_tables
+        }
         replace_table_keys = {table.get("key", "") for table in normalized_tables if table.get("key")}
         self._current_schema["tables"] = [
             table for table in existing_tables
-            if (table.get("catalog", ""), table.get("schema", ""), table.get("name", "")) not in replace_keys
+            if (
+                table.get("catalog", ""),
+                table.get("database", ""),
+                table.get("schema", ""),
+                table.get("name", ""),
+            ) not in replace_keys
             and table.get("key", "") not in replace_table_keys
         ]
         self._current_schema["tables"].extend(normalized_tables)
@@ -687,21 +717,39 @@ class ObjectExplorerPanel(QWidget):
             else:
                 normalized_columns.append({"name": str(column), "type": ""})
 
-        table_key = self._make_table_key(catalog_name, schema_name, table_name)
+        database_name = catalog_name if self._db_type != "databricks" else ""
+        table_key = self._make_table_key(catalog_name, schema_name, table_name, database=database_name)
         columns_map = self._current_schema.setdefault("columns", {})
         columns_map[table_key] = normalized_columns
         if self._db_type == "databricks" and schema_name:
             columns_map[f"{schema_name}.{table_name}"] = normalized_columns
-        elif table_name:
-            columns_map.setdefault(table_name, normalized_columns)
+        else:
+            if database_name and schema_name and database_name != schema_name:
+                columns_map[f"{database_name}.{schema_name}.{table_name}"] = normalized_columns
+            if database_name:
+                columns_map[f"{database_name}.{table_name}"] = normalized_columns
+            if schema_name:
+                columns_map[f"{schema_name}.{table_name}"] = normalized_columns
+            if table_name:
+                columns_map.setdefault(table_name, normalized_columns)
 
         if not any(
-            table.get("catalog", "") == catalog_name
+            table.get("catalog", "") == (catalog_name if self._db_type == "databricks" else "")
+            and table.get("database", "") == database_name
             and table.get("schema", "") == schema_name
             and table.get("name", "") == table_name
             for table in self._current_schema.setdefault("tables", [])
         ):
-            self._merge_tables_into_current_schema(catalog_name, schema_name, [{"name": table_name, "schema": schema_name, "catalog": catalog_name}])
+            self._merge_tables_into_current_schema(
+                catalog_name,
+                schema_name,
+                [{
+                    "name": table_name,
+                    "schema": schema_name,
+                    "catalog": catalog_name if self._db_type == "databricks" else "",
+                    "database": database_name,
+                }],
+            )
         self.schema_changed.emit(self._current_schema)
         return normalized_columns
 
@@ -1071,14 +1119,22 @@ class ObjectExplorerPanel(QWidget):
                 table_type = table.get("type", "TABLE")
                 table_schema = table.get("schema", "")
                 table_catalog = table.get("catalog", catalog)
+                table_database = table.get("database", "")
                 table_key = table.get("key") or (
-                    self._make_table_key(table_catalog, table_schema, table_name)
-                    if self._db_type == "databricks" and table_catalog else table_name
+                    self._make_table_key(
+                        table_catalog,
+                        table_schema,
+                        table_name,
+                        database=table_database,
+                    )
+                    if (table_catalog or table_database or table_schema) else table_name
                 )
 
-                # Columns use the composite key (schema.table) for lookup
+                # Columns use the composite key for lookup
                 table_columns = (
                     columns.get(table_key, [])
+                    or columns.get(f"{table_database}.{table_schema}.{table_name}", [])
+                    or columns.get(f"{table_database}.{table_name}", [])
                     or columns.get(f"{table_schema}.{table_name}", [])
                     or columns.get(table_name, [])
                 )
@@ -1104,6 +1160,7 @@ class ObjectExplorerPanel(QWidget):
                         "key": table_key,
                         "schema": table_schema,
                         "catalog": table_catalog,
+                        "database": table_database,
                         "table_type": table_type,
                     },
                 )
@@ -1129,6 +1186,7 @@ class ObjectExplorerPanel(QWidget):
                         table_key=table_key,
                         table_schema=table_schema,
                         catalog=table_catalog,
+                        database=table_database,
                     )
 
                 # Expandir tabela se filtro ativo e ha match
@@ -1168,6 +1226,7 @@ class ObjectExplorerPanel(QWidget):
         table_key: str = "",
         table_schema: str = "",
         catalog: str = "",
+        database: str = "",
     ):
         col_name = column_info.get("name", "")
         col_type = column_info.get("type", "")
@@ -1188,6 +1247,7 @@ class ObjectExplorerPanel(QWidget):
                 "table_key": table_key,
                 "schema": table_schema,
                 "catalog": catalog,
+                "database": database,
             },
         )
 
@@ -1231,6 +1291,7 @@ class ObjectExplorerPanel(QWidget):
         item_type = data.get("type", "")
         name = data.get("name", "")
         catalog = data.get("catalog", "")
+        database_name = data.get("database", "")
 
         if item_type == "catalog" and name:
             # Request schemas/tables for this catalog
@@ -1242,8 +1303,11 @@ class ObjectExplorerPanel(QWidget):
         elif item_type == "table" and name:
             # Request columns for this table
             schema_name = data.get("schema", "")
-            cat = catalog or self._current_schema.get("database", "") if self._current_schema else ""
-            self.columns_requested.emit(cat, schema_name, name)
+            if self._db_type == "databricks":
+                namespace_name = catalog or self._current_schema.get("database", "") if self._current_schema else ""
+            else:
+                namespace_name = database_name or catalog
+            self.columns_requested.emit(namespace_name, schema_name, name)
         elif item_type == "database" and name:
             # For non-Databricks, request tables for this database
             self.tables_requested.emit(name, "")
@@ -1292,12 +1356,12 @@ class ObjectExplorerPanel(QWidget):
             # For database items (non-Databricks)
             elif cat_type == "database" and cat_name == catalog_name:
                 self._remove_placeholder_children(cat_item)
-                self._add_table_items(cat_item, tables, "", "")
+                self._add_table_items(cat_item, tables, "", "", database=catalog_name)
                 return
 
     def _add_table_items(
         self, parent_item: QTreeWidgetItem, tables: list,
-        catalog: str = "", schema: str = "", with_column_placeholder: bool = True
+        catalog: str = "", schema: str = "", database: str = "", with_column_placeholder: bool = True
     ):
         """Add table items to a parent node.
         
@@ -1313,22 +1377,32 @@ class ObjectExplorerPanel(QWidget):
                 table_name = table.get("name", "")
                 table_type = table.get("type", "TABLE")
                 table_schema = table.get("schema", schema)
+                table_catalog = table.get("catalog", catalog)
+                table_database = table.get("database", database)
             else:
                 table_name = str(table)
                 table_type = "TABLE"
                 table_schema = schema
+                table_catalog = catalog
+                table_database = database
 
             is_view = "VIEW" in table_type.upper()
             label = f"{table_name} {S.object_explorer.view_suffix}" if is_view else table_name
 
             table_item = QTreeWidgetItem(parent_item, [label])
-            table_key = (table.get("key") if isinstance(table, dict) else "") or self._make_table_key(catalog, table_schema, table_name)
+            table_key = (table.get("key") if isinstance(table, dict) else "") or self._make_table_key(
+                table_catalog,
+                table_schema,
+                table_name,
+                database=table_database,
+            )
             table_item.setData(0, Qt.ItemDataRole.UserRole, {
                 "type": "table",
                 "name": table_name,
                 "key": table_key,
                 "schema": table_schema,
-                "catalog": catalog,
+                "catalog": table_catalog,
+                "database": table_database,
                 "table_type": table_type,
             })
 
@@ -1366,15 +1440,17 @@ class ObjectExplorerPanel(QWidget):
         for i in range(self.tree.topLevelItemCount()):
             table_item = find_table(self.tree.topLevelItem(i))
             if table_item:
+                table_data = table_item.data(0, Qt.ItemDataRole.UserRole) or {}
                 self._remove_placeholder_children(table_item)
                 for col in columns:
                     self._add_column_item(
                         table_item,
                         col,
                         table_name=table_name,
-                        table_key=f"{schema_name}.{table_name}" if schema_name else table_name,
-                        table_schema=schema_name,
-                        catalog=catalog_name,
+                        table_key=table_data.get("key", f"{schema_name}.{table_name}" if schema_name else table_name),
+                        table_schema=table_data.get("schema", schema_name),
+                        catalog=table_data.get("catalog", catalog_name if self._db_type == "databricks" else ""),
+                        database=table_data.get("database", catalog_name if self._db_type != "databricks" else ""),
                     )
                 return
 
@@ -1406,14 +1482,7 @@ class ObjectExplorerPanel(QWidget):
             return
 
         if item_type == "table":
-            catalog = data.get("catalog", "")
-            schema = data.get("schema", "")
-            if catalog and schema:
-                self.insert_text_requested.emit(f"{catalog}.{schema}.{name}")
-            elif schema:
-                self.insert_text_requested.emit(f"{schema}.{name}")
-            else:
-                self.insert_text_requested.emit(name)
+            self.insert_text_requested.emit(self._get_item_qualified_name(data))
         elif item_type == "column":
             self.insert_text_requested.emit(name)
         elif item_type == "schema":
@@ -1526,7 +1595,7 @@ class ObjectExplorerPanel(QWidget):
             menu.addSeparator()
 
             # Insert name in editor (full qualified for Databricks)
-            insert_name = qualified if catalog_name else name
+            insert_name = qualified if qualified != name else name
             act_insert = menu.addAction(S.object_explorer.ctx_insert_name)
             act_insert.triggered.connect(lambda _, n=insert_name: self.insert_text_requested.emit(n))
 

--- a/tests/test_object_explorer.py
+++ b/tests/test_object_explorer.py
@@ -264,6 +264,58 @@ class TestObjectExplorerMultipleDatabases:
         explorer.set_schema(multi_db_schema, "conn1")
         assert "3 databases" in explorer.info_label.text()
 
+    def test_multi_db_lazy_table_expansion_uses_target_database(self, explorer, multi_db_schema, qtbot):
+        """Tabela lazy de outro banco pede colunas usando o banco alvo."""
+        explorer.set_schema(multi_db_schema, "conn1", db_type="mysql")
+        explorer.add_tables_to_schema(
+            "production",
+            "",
+            [{"name": "orders", "schema": "production", "database": "production", "type": "BASE TABLE"}],
+        )
+
+        production_item = None
+        for i in range(explorer.tree.topLevelItemCount()):
+            item = explorer.tree.topLevelItem(i)
+            data = item.data(0, Qt.ItemDataRole.UserRole)
+            if data and data.get("name") == "production":
+                production_item = item
+                break
+
+        assert production_item is not None
+        table_item = production_item.child(0)
+        assert table_item is not None
+        assert table_item.data(0, Qt.ItemDataRole.UserRole)["database"] == "production"
+
+        with qtbot.waitSignal(explorer.columns_requested, timeout=1000) as blocker:
+            explorer._on_item_expanded(table_item)
+
+        assert blocker.args == ["production", "production", "orders"]
+
+    def test_multi_db_lazy_table_insert_uses_database_qualified_name(self, explorer, multi_db_schema, qtbot):
+        """Insercao de tabela lazy usa nome qualificado do banco alvo."""
+        explorer.set_schema(multi_db_schema, "conn1", db_type="mysql")
+        explorer.add_tables_to_schema(
+            "production",
+            "",
+            [{"name": "orders", "schema": "production", "database": "production", "type": "BASE TABLE"}],
+        )
+
+        production_item = None
+        for i in range(explorer.tree.topLevelItemCount()):
+            item = explorer.tree.topLevelItem(i)
+            data = item.data(0, Qt.ItemDataRole.UserRole)
+            if data and data.get("name") == "production":
+                production_item = item
+                break
+
+        assert production_item is not None
+        table_item = production_item.child(0)
+
+        with qtbot.waitSignal(explorer.insert_text_requested, timeout=1000) as blocker:
+            explorer._on_insert_clicked(table_item)
+
+        assert blocker.args == ["production.orders"]
+
 
 class TestObjectExplorerClear:
     """Testes de clear"""

--- a/tests/test_schema_service_multi_db.py
+++ b/tests/test_schema_service_multi_db.py
@@ -1,0 +1,121 @@
+import pandas as pd
+
+from src.services.schema_service import SchemaService
+
+
+class FakeMultiDbConnector:
+    def __init__(self, db_type: str, responses=None):
+        self.db_type = db_type
+        self.responses = responses or {}
+        self.queries = []
+
+    def execute_query(self, query: str):
+        compact_query = " ".join(query.split())
+        self.queries.append(compact_query)
+        for token, response in self.responses.items():
+            if token in compact_query:
+                return response
+        return pd.DataFrame()
+
+
+def run_schema_service_sync(service: SchemaService):
+    service._run_in_thread_with_signal = lambda func, callback: callback(func())
+
+
+def test_mysql_lazy_tables_use_requested_database(qapp):
+    service = SchemaService()
+    run_schema_service_sync(service)
+    connector = FakeMultiDbConnector(
+        "mysql",
+        responses={
+            "WHERE TABLE_SCHEMA = 'analytics'": pd.DataFrame([
+                {"TABLE_NAME": "orders", "TABLE_TYPE": "BASE TABLE"},
+                {"TABLE_NAME": "daily_metrics", "TABLE_TYPE": "VIEW"},
+            ])
+        },
+    )
+    captured = []
+    service.tables_loaded.connect(lambda database, schema, tables: captured.append((database, schema, tables)))
+
+    service.load_tables_for_schema(connector, "Conn", "analytics", "")
+
+    assert any("WHERE TABLE_SCHEMA = 'analytics'" in query for query in connector.queries)
+    assert captured[0][0:2] == ("analytics", "")
+    assert [table["name"] for table in captured[0][2]] == ["orders", "daily_metrics"]
+    assert captured[0][2][0]["schema"] == "analytics"
+    assert captured[0][2][0]["database"] == "analytics"
+
+
+def test_mysql_lazy_columns_use_requested_database(qapp):
+    service = SchemaService()
+    run_schema_service_sync(service)
+    connector = FakeMultiDbConnector(
+        "mysql",
+        responses={
+            "WHERE TABLE_SCHEMA = 'analytics' AND TABLE_NAME = 'orders'": pd.DataFrame([
+                {"COLUMN_NAME": "id", "DATA_TYPE": "bigint", "IS_NULLABLE": "NO"},
+                {"COLUMN_NAME": "total", "DATA_TYPE": "decimal", "IS_NULLABLE": "YES"},
+            ])
+        },
+    )
+    captured = []
+    service.columns_loaded.connect(
+        lambda database, schema, table, columns: captured.append((database, schema, table, columns))
+    )
+
+    service.load_columns_for_table(connector, "Conn", "analytics", "analytics", "orders")
+
+    assert any(
+        "WHERE TABLE_SCHEMA = 'analytics' AND TABLE_NAME = 'orders'" in query
+        for query in connector.queries
+    )
+    assert captured[0][0:3] == ("analytics", "analytics", "orders")
+    assert [column["name"] for column in captured[0][3]] == ["id", "total"]
+
+
+def test_sqlserver_lazy_tables_use_requested_database(qapp):
+    service = SchemaService()
+    run_schema_service_sync(service)
+    connector = FakeMultiDbConnector(
+        "sqlserver",
+        responses={
+            "FROM [warehouse].INFORMATION_SCHEMA.TABLES": pd.DataFrame([
+                {"TABLE_SCHEMA": "dbo", "TABLE_NAME": "users", "TABLE_TYPE": "BASE TABLE"},
+                {"TABLE_SCHEMA": "reporting", "TABLE_NAME": "totals", "TABLE_TYPE": "VIEW"},
+            ])
+        },
+    )
+    captured = []
+    service.tables_loaded.connect(lambda database, schema, tables: captured.append((database, schema, tables)))
+
+    service.load_tables_for_schema(connector, "Conn", "warehouse", "")
+
+    assert any("FROM [warehouse].INFORMATION_SCHEMA.TABLES" in query for query in connector.queries)
+    assert captured[0][0:2] == ("warehouse", "")
+    assert captured[0][2][0]["database"] == "warehouse"
+    assert captured[0][2][0]["schema"] == "dbo"
+
+
+def test_sqlserver_lazy_columns_use_requested_database(qapp):
+    service = SchemaService()
+    run_schema_service_sync(service)
+    connector = FakeMultiDbConnector(
+        "sqlserver",
+        responses={
+            "FROM [warehouse].INFORMATION_SCHEMA.COLUMNS": pd.DataFrame([
+                {"COLUMN_NAME": "id", "DATA_TYPE": "int", "IS_NULLABLE": "NO"},
+                {"COLUMN_NAME": "name", "DATA_TYPE": "nvarchar", "IS_NULLABLE": "YES"},
+            ])
+        },
+    )
+    captured = []
+    service.columns_loaded.connect(
+        lambda database, schema, table, columns: captured.append((database, schema, table, columns))
+    )
+
+    service.load_columns_for_table(connector, "Conn", "warehouse", "dbo", "users")
+
+    assert any("FROM [warehouse].INFORMATION_SCHEMA.COLUMNS" in query for query in connector.queries)
+    assert any("TABLE_SCHEMA = 'dbo' AND TABLE_NAME = 'users'" in query for query in connector.queries)
+    assert captured[0][0:3] == ("warehouse", "dbo", "users")
+    assert [column["name"] for column in captured[0][3]] == ["id", "name"]


### PR DESCRIPTION
## Summary
- preserve the target database/catalog context for lazy Object Explorer expansion
- use stable table keys when resolving lazy-loaded columns and insert actions
- add regressions for multi-database lazy loading in the Object Explorer and schema service

## Validation
- python -m pytest tests/test_object_explorer.py tests/test_schema_service_multi_db.py --tb=short -v
- python -m pytest tests/test_databricks_metadata.py --tb=short -v
- python -m pytest tests/test_file_operations.py --tb=short -v

## Notes
- full-suite runs in this environment still showed an unrelated Qt/gui flake in 	ests/test_gui.py::TestBlockExecutionGUI::test_execute_all_blocks_in_order
