### PR TITLE
Add Summarize dock panel for grid selection statistics

### DIFF
--- a/source/src/language/en-US.json
+++ b/source/src/language/en-US.json
@@ -25,6 +25,7 @@
     "view": "&View",
     "panels": "&Panels",
     "panel_results": "&Results",
+    "panel_summarize": "Su&mmarize",
     "panel_output": "&Output",
     "panel_variables": "&Variables",
     "panel_connections": "&Connections",
@@ -56,6 +57,7 @@
   "dock": {
     "connections": "Connections",
     "results": "Results",
+    "summarize": "Summarize",
     "output": "Output",
     "variables": "Variables",
     "object_explorer": "Object Explorer",
@@ -545,6 +547,41 @@
     "ctx_size_info": "Size: {n}",
     "ctx_size_chars": "Size: {n} chars",
     "ctx_remove_variable": "Remove variable"
+  },
+  "summarize_panel": {
+    "title": "Summarize",
+    "tab_summarize": "Summarize",
+    "tab_aggregate": "Aggregate",
+    "grand_total": "Selection total",
+    "format_column": "Column format",
+    "zoom_in": "Zoom in",
+    "zoom_out": "Zoom out",
+    "empty_hint": "Select cells in the results grid to see totals, averages, and counts.",
+    "no_data": "No data to summarize.",
+    "selection_subtitle": "{rows:,} rows · {cols} columns · {cells:,} cells selected",
+    "all_rows_subtitle": "All rows · {cols} columns ({rows:,} rows)",
+    "headers": {
+      "column": "Column",
+      "count": "Count",
+      "sum": "Sum",
+      "avg": "Avg",
+      "min": "Min",
+      "max": "Max",
+      "distinct": "Distinct",
+      "top": "Top value"
+    },
+    "aggregates": {
+      "rows": "Rows",
+      "cols": "Cols",
+      "count": "Count",
+      "count_numeric": "Count numeric",
+      "sum": "Sum",
+      "avg": "Avg",
+      "min": "Min",
+      "max": "Max",
+      "median": "Median",
+      "coefficient": "Coefficient of variation"
+    }
   },
   "output_panel": {
     "btn_clear": "Clear",

--- a/source/src/language/pt-BR.json
+++ b/source/src/language/pt-BR.json
@@ -25,6 +25,7 @@
     "view": "&Exibir",
     "panels": "&Paineis",
     "panel_results": "&Resultados",
+    "panel_summarize": "Res&umir",
     "panel_output": "&Saida",
     "panel_variables": "&Variaveis",
     "panel_connections": "&Conexoes",
@@ -56,6 +57,7 @@
   "dock": {
     "connections": "Conexoes",
     "results": "Resultados",
+    "summarize": "Resumir",
     "output": "Saida",
     "variables": "Variaveis",
     "object_explorer": "Explorador de Objetos",
@@ -545,6 +547,41 @@
     "ctx_size_info": "Tamanho: {n}",
     "ctx_size_chars": "Tamanho: {n} caracteres",
     "ctx_remove_variable": "Remover variavel"
+  },
+  "summarize_panel": {
+    "title": "Resumir",
+    "tab_summarize": "Resumir",
+    "tab_aggregate": "Agregados",
+    "grand_total": "Total da selecao",
+    "format_column": "Formato da coluna",
+    "zoom_in": "Aumentar zoom",
+    "zoom_out": "Diminuir zoom",
+    "empty_hint": "Selecione celulas no grid de resultados para ver totais, medias e contagens.",
+    "no_data": "Nenhum dado para resumir.",
+    "selection_subtitle": "{rows:,} linhas · {cols} colunas · {cells:,} celulas selecionadas",
+    "all_rows_subtitle": "Todas as linhas · {cols} colunas ({rows:,} linhas)",
+    "headers": {
+      "column": "Coluna",
+      "count": "Contagem",
+      "sum": "Soma",
+      "avg": "Media",
+      "min": "Min",
+      "max": "Max",
+      "distinct": "Distintos",
+      "top": "Valor top"
+    },
+    "aggregates": {
+      "rows": "Linhas",
+      "cols": "Colunas",
+      "count": "Contagem",
+      "count_numeric": "Contagem numerica",
+      "sum": "Soma",
+      "avg": "Media",
+      "min": "Min",
+      "max": "Max",
+      "median": "Mediana",
+      "coefficient": "Coeficiente de variacao"
+    }
   },
   "output_panel": {
     "btn_clear": "Limpar",

--- a/source/src/ui/components/__init__.py
+++ b/source/src/ui/components/__init__.py
@@ -53,6 +53,9 @@ from .editor_header import EditorHeader
 # Results Viewer
 from .results_viewer import ResultsViewer, CSVExportDialog, PandasModel
 
+# Summarize Panel
+from .summarize_panel import SummarizePanel
+
 # Session Widget
 from .session_widget import SessionWidget
 
@@ -93,6 +96,7 @@ __all__ = [
     "ResultsViewer",
     "CSVExportDialog",
     "PandasModel",
+    "SummarizePanel",
     "SessionWidget",
     "ObjectExplorerPanel",
 ]

--- a/source/src/ui/components/results_viewer.py
+++ b/source/src/ui/components/results_viewer.py
@@ -32,12 +32,14 @@ from PyQt6.QtWidgets import (
     QHeaderView,
     QFrame,
     QGridLayout,
+    QAbstractItemView,
 )
 from PyQt6.QtCore import Qt, QObject, QAbstractTableModel, QModelIndex, QVariant, QSettings, QTimer, QThread, pyqtSignal, QRect, QPoint, QSize, QSignalBlocker, QEvent
 from PyQt6.QtGui import QColor, QImage, QPixmap, QFont, QKeySequence, QShortcut, QAction, QDoubleValidator, QPainter, QPen
 import pandas as pd
 import io
 import json
+from dataclasses import dataclass
 from typing import Optional, Any
 import subprocess
 import os
@@ -47,6 +49,306 @@ from src.core.theme_manager import ThemeManager
 from src.language import S
 from src.design_system.tokens import SCROLLBAR_STYLE
 from src.workers import FileExportWorker
+
+GRID_ASYNC_ROW_THRESHOLD = 200
+GRID_COLUMN_RESIZE_SAMPLE_ROWS = 50
+GRID_COLUMN_MAX_WIDTH = 420
+
+
+@dataclass
+class PreparedGridData:
+    """Display-ready grid payload built off the UI thread."""
+
+    columns: list[str]
+    display_rows: list[list[str]]
+    null_mask: list[list[bool]]
+    numeric_column_indices: frozenset[int]
+    filtered_row_count: int
+    total_row_count: int
+    limited: bool
+
+
+@dataclass
+class GridPrepareResult:
+    """Full grid refresh result including the filtered export dataframe."""
+
+    prepared: PreparedGridData
+    filtered_df: pd.DataFrame
+
+
+def _grid_is_null_scalar(value) -> bool:
+    try:
+        if not pd.api.types.is_scalar(value):
+            return False
+        return bool(pd.isna(value))
+    except (TypeError, ValueError):
+        return False
+
+
+def _grid_column_is_numeric(series: pd.Series) -> bool:
+    """Detect numeric columns, including object columns with numeric strings."""
+    if series is None or series.empty:
+        return False
+    if pd.api.types.is_numeric_dtype(series):
+        return True
+    if pd.api.types.is_bool_dtype(series):
+        return False
+
+    non_null = series.dropna()
+    if non_null.empty:
+        return False
+
+    converted = pd.to_numeric(non_null, errors="coerce")
+    numeric_count = int(converted.notna().sum())
+    return numeric_count >= max(1, len(non_null) // 2)
+
+
+def _grid_coerce_numeric_series(series: pd.Series) -> pd.Series:
+    if pd.api.types.is_numeric_dtype(series):
+        return pd.to_numeric(series, errors="coerce")
+    return pd.to_numeric(series, errors="coerce")
+
+
+def _grid_normalize_format_config(format_config) -> dict:
+    if isinstance(format_config, dict):
+        normalized = dict(format_config)
+        normalized["type"] = str(normalized.get("type", "default") or "default")
+        return normalized
+    return {"type": str(format_config or "default")}
+
+
+def _grid_format_decimals(format_config: dict, default: int = 2) -> int:
+    try:
+        decimals = int(format_config.get("decimals", default))
+    except (TypeError, ValueError):
+        decimals = default
+    return max(0, min(decimals, 8))
+
+
+def _grid_format_display_value(value, format_config) -> str:
+    config = _grid_normalize_format_config(format_config)
+    format_name = config.get("type", "default")
+    if format_name == "default":
+        return str(value)
+    if format_name in {"number", "currency"}:
+        number = pd.to_numeric(value, errors="coerce")
+        if pd.isna(number):
+            return str(value)
+        decimals = _grid_format_decimals(config)
+        prefix = str(config.get("prefix", "$ " if format_name == "currency" else ""))
+        suffix = str(config.get("suffix", ""))
+        return f"{prefix}{float(number):,.{decimals}f}{suffix}"
+    if format_name == "percent":
+        number = pd.to_numeric(value, errors="coerce")
+        decimals = _grid_format_decimals(config)
+        return str(value) if pd.isna(number) else f"{float(number):.{decimals}%}"
+    if format_name in {"date", "datetime"}:
+        parsed = pd.to_datetime(value, errors="coerce")
+        if pd.isna(parsed):
+            return str(value)
+        return parsed.strftime("%Y-%m-%d" if format_name == "date" else "%Y-%m-%d %H:%M:%S")
+    return str(value)
+
+
+def _grid_normalize_filter_spec(value: Any) -> dict:
+    if isinstance(value, dict):
+        spec = dict(value)
+        spec["type"] = str(spec.get("type", "text") or "text")
+        return spec
+    return {"type": "text", "operator": "contains", "value": str(value or "")}
+
+
+def _grid_filter_spec_is_empty(spec: dict) -> bool:
+    filter_type = str(spec.get("type", "text"))
+    if filter_type == "number":
+        return not str(spec.get("min", "")).strip() and not str(spec.get("max", "")).strip()
+    if filter_type == "bool":
+        return spec.get("value") in (None, "", "any")
+    if filter_type == "date":
+        return not str(spec.get("start", "")).strip() and not str(spec.get("end", "")).strip()
+    return not str(spec.get("value", "")).strip()
+
+
+def _grid_parse_float(value: Any) -> Optional[float]:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        return float(text.replace(",", "."))
+    except ValueError:
+        return None
+
+
+def _grid_parse_bool_value(value: Any) -> Optional[bool]:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return None
+    text = str(value).strip().lower()
+    if text in {"1", "true", "t", "yes", "y", "sim", "s"}:
+        return True
+    if text in {"0", "false", "f", "no", "n", "nao"}:
+        return False
+    return None
+
+
+def _grid_column_filter_mask(df: pd.DataFrame, column, spec: dict):
+    filter_type = str(spec.get("type", "text"))
+    if filter_type == "number":
+        values = pd.to_numeric(df[column], errors="coerce")
+        mask = pd.Series(True, index=df.index)
+        min_value = _grid_parse_float(spec.get("min"))
+        max_value = _grid_parse_float(spec.get("max"))
+        if min_value is not None:
+            mask = mask & values.ge(min_value)
+        if max_value is not None:
+            mask = mask & values.le(max_value)
+        return mask.fillna(False)
+    if filter_type == "bool":
+        desired = _grid_parse_bool_value(spec.get("value"))
+        if desired is None:
+            return pd.Series(True, index=df.index)
+        values = df[column].map(_grid_parse_bool_value)
+        return values.eq(desired).fillna(False)
+    if filter_type == "date":
+        values = pd.to_datetime(df[column], errors="coerce")
+        mask = pd.Series(True, index=df.index)
+        start = pd.to_datetime(spec.get("start"), errors="coerce") if str(spec.get("start", "")).strip() else None
+        end = pd.to_datetime(spec.get("end"), errors="coerce") if str(spec.get("end", "")).strip() else None
+        if start is not None and not pd.isna(start):
+            mask = mask & values.ge(start)
+        if end is not None and not pd.isna(end):
+            mask = mask & values.le(end)
+        return mask.fillna(False)
+
+    value = str(spec.get("value", "")).strip()
+    operator = str(spec.get("operator", "contains") or "contains")
+    values = df[column].astype("string").fillna("")
+    if operator == "equals":
+        return values.str.lower().eq(value.lower())
+    if operator == "starts_with":
+        return values.str.lower().str.startswith(value.lower(), na=False)
+    if operator == "ends_with":
+        return values.str.lower().str.endswith(value.lower(), na=False)
+    return values.str.contains(value, case=False, regex=False, na=False)
+
+
+def filter_dataframe_with_specs(df: pd.DataFrame, column_filters: dict) -> pd.DataFrame:
+    """Filter a DataFrame using active column filter specs."""
+    if df is None:
+        return pd.DataFrame()
+    active_column_filters = [
+        (column, _grid_normalize_filter_spec(value))
+        for column, value in (column_filters or {}).items()
+        if column in df.columns and not _grid_filter_spec_is_empty(_grid_normalize_filter_spec(value))
+    ]
+    if not active_column_filters:
+        return df
+
+    mask = pd.Series(True, index=df.index)
+    for column, spec in active_column_filters:
+        mask = mask & _grid_column_filter_mask(df, column, spec)
+    return df.loc[mask]
+
+
+def prepare_grid_data(
+    source_df: pd.DataFrame,
+    column_filters: dict,
+    column_formats: dict,
+    limit: int,
+) -> GridPrepareResult:
+    """Build display-ready grid data. Safe to run off the UI thread."""
+    if source_df is None:
+        empty = pd.DataFrame()
+        prepared = PreparedGridData([], [], [], frozenset(), 0, 0, False)
+        return GridPrepareResult(prepared, empty)
+
+    total_rows = len(source_df)
+    filtered_df = filter_dataframe_with_specs(source_df, column_filters)
+    filtered_count = len(filtered_df)
+    limited = filtered_count > limit
+    display_df = filtered_df.head(limit) if limited else filtered_df
+
+    columns = [str(column) for column in display_df.columns]
+    row_count = len(display_df)
+    col_count = len(columns)
+    format_map = dict(column_formats or {})
+    numeric_indices = frozenset(
+        index
+        for index, column in enumerate(columns)
+        if column in display_df.columns and _grid_column_is_numeric(display_df[column])
+    )
+
+    display_rows: list[list[str]] = [[""] * col_count for _ in range(row_count)]
+    null_mask: list[list[bool]] = [[False] * col_count for _ in range(row_count)]
+
+    for col_index, column in enumerate(columns):
+        series = display_df[column]
+        format_config = format_map.get(column, format_map.get(str(column), "default"))
+        if _grid_column_is_numeric(series):
+            numeric_series = _grid_coerce_numeric_series(series)
+            nulls = numeric_series.isna().to_numpy()
+            values = numeric_series.to_numpy()
+            for row_index, value in enumerate(values):
+                is_null = bool(nulls[row_index])
+                null_mask[row_index][col_index] = is_null
+                display_rows[row_index][col_index] = (
+                    "NULL" if is_null else _grid_format_display_value(value, format_config)
+                )
+            continue
+
+        values = series.to_numpy()
+        for row_index, value in enumerate(values):
+            is_null = _grid_is_null_scalar(value)
+            null_mask[row_index][col_index] = is_null
+            display_rows[row_index][col_index] = (
+                "NULL" if is_null else _grid_format_display_value(value, format_config)
+            )
+
+    prepared = PreparedGridData(
+        columns=columns,
+        display_rows=display_rows,
+        null_mask=null_mask,
+        numeric_column_indices=numeric_indices,
+        filtered_row_count=filtered_count,
+        total_row_count=total_rows,
+        limited=limited,
+    )
+    return GridPrepareResult(prepared, filtered_df)
+
+
+class GridPrepareWorker(QObject):
+    """Prepare large grid payloads outside the UI thread."""
+
+    finished = pyqtSignal(int, object)
+    error = pyqtSignal(int, str)
+
+    def __init__(
+        self,
+        job_id: int,
+        source_df: pd.DataFrame,
+        column_filters: dict,
+        column_formats: dict,
+        limit: int,
+    ):
+        super().__init__()
+        self._job_id = job_id
+        self._source_df = source_df
+        self._column_filters = dict(column_filters or {})
+        self._column_formats = dict(column_formats or {})
+        self._limit = int(limit)
+
+    def run(self):
+        try:
+            result = prepare_grid_data(
+                self._source_df,
+                self._column_filters,
+                self._column_formats,
+                self._limit,
+            )
+            self.finished.emit(self._job_id, result)
+        except Exception as exc:
+            self.error.emit(self._job_id, str(exc))
 
 
 class ChartRenderWorker(QObject):
@@ -1006,6 +1308,7 @@ class PandasModel(QAbstractTableModel):
     def __init__(self, df: pd.DataFrame = None, theme_manager: ThemeManager = None):
         super().__init__()
         self._df = df if df is not None else pd.DataFrame()
+        self._prepared: Optional[PreparedGridData] = None
         self.theme_manager = theme_manager or ThemeManager()
         self._column_formats = {}
         self._update_colors()
@@ -1034,13 +1337,36 @@ class PandasModel(QAbstractTableModel):
         self.layoutChanged.emit()
 
     def rowCount(self, parent=QModelIndex()):
+        if self._prepared is not None:
+            return len(self._prepared.display_rows)
         return len(self._df)
 
     def columnCount(self, parent=QModelIndex()):
+        if self._prepared is not None:
+            return len(self._prepared.columns)
         return len(self._df.columns)
 
     def data(self, index, role=Qt.ItemDataRole.DisplayRole):
         if not index.isValid():
+            return QVariant()
+
+        if self._prepared is not None:
+            row = index.row()
+            col = index.column()
+            if role == Qt.ItemDataRole.DisplayRole:
+                return self._prepared.display_rows[row][col]
+            if role == Qt.ItemDataRole.BackgroundRole:
+                if self._prepared.null_mask[row][col]:
+                    return self._null_bg
+                return self._row_even if row % 2 == 0 else self._row_odd
+            if role == Qt.ItemDataRole.ForegroundRole:
+                if self._prepared.null_mask[row][col]:
+                    return self._null_text
+                return self._text_color
+            if role == Qt.ItemDataRole.TextAlignmentRole:
+                if col in self._prepared.numeric_column_indices:
+                    return Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
+                return Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
             return QVariant()
 
         if role == Qt.ItemDataRole.DisplayRole:
@@ -1055,11 +1381,9 @@ class PandasModel(QAbstractTableModel):
             value = self._df.iloc[index.row(), index.column()]
             if self._is_null_value(value):
                 return self._null_bg
-            # Alternar cores das linhas
             if index.row() % 2 == 0:
                 return self._row_even
-            else:
-                return self._row_odd
+            return self._row_odd
 
         if role == Qt.ItemDataRole.ForegroundRole:
             value = self._df.iloc[index.row(), index.column()]
@@ -1078,10 +1402,10 @@ class PandasModel(QAbstractTableModel):
     def headerData(self, section, orientation, role=Qt.ItemDataRole.DisplayRole):
         if role == Qt.ItemDataRole.DisplayRole:
             if orientation == Qt.Orientation.Horizontal:
-                # Manter case original do banco de dados
+                if self._prepared is not None:
+                    return self._prepared.columns[section]
                 return self._df.columns[section]
-            else:
-                return str(section + 1)
+            return str(section + 1)
 
         if role == Qt.ItemDataRole.BackgroundRole:
             return self._header_bg
@@ -1091,11 +1415,19 @@ class PandasModel(QAbstractTableModel):
 
         return QVariant()
 
-    def update_data(self, df: pd.DataFrame):
-        """Atualiza o DataFrame"""
+    def update_prepared(self, prepared: PreparedGridData):
+        """Atualiza o grid com payload precomputado."""
         self.beginResetModel()
-        self._df = df
+        self._prepared = prepared
+        self._df = pd.DataFrame()
         self.endResetModel()
+
+    def update_data(self, df: pd.DataFrame):
+        """Atualiza o DataFrame (caminho sincrono para datasets pequenos)."""
+        limit = len(df) if df is not None else 0
+        result = prepare_grid_data(df, {}, self._column_formats, limit)
+        self.update_prepared(result.prepared)
+        self._df = df if df is not None else pd.DataFrame()
 
     def set_column_formats(self, column_formats: dict):
         """Atualiza formatacoes visuais por coluna."""
@@ -1152,6 +1484,8 @@ class PandasModel(QAbstractTableModel):
 class ResultsViewer(QWidget):
     """Widget para visualizar resultados de queries"""
 
+    grid_selection_changed = pyqtSignal()
+
     SETTINGS_KEY_GRID_FONT_SIZE = "results/grid_font_size"
     DEFAULT_GRID_FONT_SIZE = 9
     MIN_GRID_FONT_SIZE = 7
@@ -1172,6 +1506,7 @@ class ResultsViewer(QWidget):
         self._column_filter_popup = None
         self._connection_color = ""
         self._grid_font_size = self._load_grid_font_size()
+        self._bound_selection_model = None
         self._setup_ui()
         self.current_df: Optional[pd.DataFrame] = None
         self._current_image_bytes: Optional[bytes] = None
@@ -1179,6 +1514,13 @@ class ResultsViewer(QWidget):
         # Background export tracking
         self._export_thread: Optional[QThread] = None
         self._export_worker: Optional[FileExportWorker] = None
+        self._grid_prepare_job_serial = 0
+        self._model_prepare_generation: dict[int, int] = {}
+        self._active_grid_prepare_job: Optional[dict] = None
+        self._grid_prepare_job_meta: dict[int, dict] = {}
+        self._primary_grid_cache_key = None
+        self._primary_filtered_df: Optional[pd.DataFrame] = None
+        self._summarize_refresh_timer: Optional[QTimer] = None
 
     def _setup_ui(self):
         """Configura a interface"""
@@ -1415,6 +1757,7 @@ class ResultsViewer(QWidget):
         self._setup_result_tab_close_button(0)
         self._result_tabs.tabBar().setVisible(True)
         self._result_tabs.currentChanged.connect(self._on_result_tab_changed)
+        self.stack.currentChanged.connect(self._on_stack_page_changed)
 
         self.btn_visualization = QToolButton(self._result_tabs)
         self.btn_visualization.setObjectName("visualizationButton")
@@ -1433,6 +1776,7 @@ class ResultsViewer(QWidget):
         self._secondary_pages: list = []
         self._primary_table_view = self.table_view
         self._primary_model = self.model
+        self._connect_active_selection_model()
         self._primary_df: Optional[pd.DataFrame] = None
 
         layout.addWidget(self._result_tabs)
@@ -1681,6 +2025,10 @@ class ResultsViewer(QWidget):
         table_view.setAlternatingRowColors(False)
         table_view.setWordWrap(False)
         table_view.setTextElideMode(Qt.TextElideMode.ElideRight)
+        table_view.setVerticalScrollMode(QAbstractItemView.ScrollMode.ScrollPerPixel)
+        table_view.setHorizontalScrollMode(QAbstractItemView.ScrollMode.ScrollPerPixel)
+        if hasattr(table_view, "setUniformRowHeights"):
+            table_view.setUniformRowHeights(True)
         table_view.setFont(QFont("Consolas", font_size))
         table_view.verticalHeader().setDefaultSectionSize(row_height)
         table_view.verticalHeader().setMinimumSectionSize(18)
@@ -1786,6 +2134,8 @@ class ResultsViewer(QWidget):
         self._collapse_to_primary()
         self._result_tabs.setTabText(0, tab_label)
         self._primary_df = df
+        self._primary_grid_cache_key = None
+        self._primary_filtered_df = None
         self._update_filter_columns(df)
         self._apply_active_dataframe_view(tab_label)
 
@@ -1832,16 +2182,19 @@ class ResultsViewer(QWidget):
 
         # Itens extras viram abas secundarias somente-grid
         for label, df in norm[1:]:
-            page = self._create_secondary_page(df)
+            page = self._create_secondary_page(df, label)
             self._secondary_pages.append(page)
             index = self._result_tabs.addTab(page, label)
             self._setup_result_tab_close_button(index)
 
         self._result_tabs.tabBar().setVisible(True)
+        self.table_view = self._primary_table_view
+        self.model = self._primary_model
         self._result_tabs.setCurrentIndex(0)
         self._restore_chart_tabs_for_current_data()
+        self._schedule_summarize_refresh()
 
-    def _create_secondary_page(self, df: pd.DataFrame) -> QWidget:
+    def _create_secondary_page(self, df: pd.DataFrame, label: str = "") -> QWidget:
         """Cria uma pagina leve somente-grid para uma aba secundaria."""
         page = QWidget()
         vbox = QVBoxLayout(page)
@@ -1858,14 +2211,11 @@ class ResultsViewer(QWidget):
 
         self._apply_table_style_to(table_view)
 
-        # Carrega slice respeitando o limite atual
-        limit = self.row_limit_spin.value()
-        filtered_df = self._filter_dataframe(df)
-        rows = len(filtered_df)
-        display_df = filtered_df.head(limit) if rows > limit else filtered_df
-        model.update_data(display_df)
-        model.set_column_formats(self._column_formats)
-        QTimer.singleShot(0, table_view.resizeColumnsToContents)
+        # Carrega slice respeitando o limite atual (fora da thread principal quando grande)
+        page._table_view = table_view
+        page._model = model
+        page._df = df
+        self._request_grid_view_update(df, var_name=label, model=model, table_view=table_view, page=page)
 
         # Ctrl+C e menu de contexto delegam aos metodos da viewer,
         # que operam em self.table_view/self.model (trocados pelo handler
@@ -1881,9 +2231,6 @@ class ResultsViewer(QWidget):
 
         # Anexa metadados a pagina para o handler de mudanca de aba
         page._df = df
-        page._filtered_df = filtered_df
-        page._table_view = table_view
-        page._model = model
         return page
 
     def _collapse_to_primary(self):
@@ -1915,12 +2262,13 @@ class ResultsViewer(QWidget):
         if tabs is None or index < 0:
             return
         if index == 0:
-            self.table_view = self._primary_table_view
-            self.model = self._primary_model
             if self._primary_df is not None:
-                self._update_filter_columns(self._primary_df)
-                self._apply_active_dataframe_view(tabs.tabText(0))
-                self._show_dataframe_toolbar_buttons()
+                self._switch_to_grid_tab(index, self._primary_df)
+            else:
+                self.table_view = self._primary_table_view
+                self.model = self._primary_model
+                self._connect_active_selection_model()
+                self._schedule_summarize_refresh()
             return
 
         page = tabs.widget(index)
@@ -1932,15 +2280,47 @@ class ResultsViewer(QWidget):
             self._show_chart_toolbar_buttons()
             if getattr(page, "_image_bytes", None) is None and not getattr(page, "_rendering", False):
                 self._render_visualization_page(page)
+            self._schedule_summarize_refresh()
             return
 
         df = getattr(page, "_df", None)
         if df is None:
             return
-        self.table_view = page._table_view
-        self.model = page._model
-        self._update_filter_columns(df)
-        self._apply_active_dataframe_view(tabs.tabText(index))
+        self._switch_to_grid_tab(
+            index,
+            df,
+            page=page,
+            model=getattr(page, "_model", None),
+            table_view=getattr(page, "_table_view", None),
+        )
+
+    def _switch_to_grid_tab(
+        self,
+        index: int,
+        source_df: pd.DataFrame,
+        *,
+        page=None,
+        model=None,
+        table_view=None,
+    ):
+        """Activate a grid tab without re-preparing when cached data is still valid."""
+        tabs = getattr(self, "_result_tabs", None)
+        var_name = tabs.tabText(index) if tabs is not None else self._current_result_label()
+
+        if page is None:
+            self.table_view = self._primary_table_view
+            self.model = self._primary_model
+            model = self._primary_model
+            table_view = self._primary_table_view
+        else:
+            self.table_view = table_view or page._table_view
+            self.model = model or page._model
+
+        self._update_filter_columns(source_df)
+        if self._can_use_cached_grid_view(source_df, self.model, page):
+            self._activate_cached_grid_view(var_name, source_df, self.model, self.table_view, page)
+        else:
+            self._apply_active_dataframe_view(var_name)
         self._show_dataframe_toolbar_buttons()
 
     def _on_result_tab_close_requested(self, index: int):
@@ -3079,6 +3459,69 @@ class ResultsViewer(QWidget):
             return tabs.tabText(tabs.currentIndex())
         return self._current_var_name()
 
+    def _grid_view_cache_key(self, source_df: pd.DataFrame) -> tuple:
+        filter_items = tuple(
+            sorted((str(column), json.dumps(spec, sort_keys=True, default=str)) for column, spec in self._column_filters.items())
+        )
+        format_items = tuple(
+            sorted((str(column), json.dumps(spec, sort_keys=True, default=str)) for column, spec in self._column_formats.items())
+        )
+        return (
+            id(source_df),
+            len(source_df),
+            filter_items,
+            format_items,
+            int(self.row_limit_spin.value()),
+        )
+
+    def _can_use_cached_grid_view(self, source_df: pd.DataFrame, model, page=None) -> bool:
+        if source_df is None or model is None:
+            return False
+        prepared = getattr(model, "_prepared", None)
+        if prepared is None or not prepared.columns:
+            return False
+        cache_key = self._grid_view_cache_key(source_df)
+        cached_key = getattr(page, "_grid_cache_key", None) if page is not None else self._primary_grid_cache_key
+        if cached_key != cache_key:
+            return False
+        filtered_df = getattr(page, "_filtered_df", None) if page is not None else self._primary_filtered_df
+        return filtered_df is not None
+
+    def _activate_cached_grid_view(
+        self,
+        var_name: str,
+        source_df: pd.DataFrame,
+        model,
+        table_view,
+        page=None,
+    ):
+        """Reuse already prepared grid data when switching tabs."""
+        self._cancel_grid_prepare_for_model(model)
+        filtered_df = getattr(page, "_filtered_df", None) if page is not None else self._primary_filtered_df
+        self.current_df = filtered_df
+        prepared = model._prepared
+        self._set_dataframe_info(
+            var_name,
+            prepared.filtered_row_count,
+            prepared.total_row_count,
+            len(prepared.columns),
+            prepared.limited,
+        )
+        self._refresh_filter_chips()
+        self._connect_active_selection_model()
+        self._schedule_summarize_refresh()
+
+    def _schedule_summarize_refresh(self):
+        """Defer summarize panel refresh to keep tab switches responsive."""
+        timer = self._summarize_refresh_timer
+        if timer is None:
+            timer = QTimer(self)
+            timer.setSingleShot(True)
+            timer.setInterval(32)
+            timer.timeout.connect(self.grid_selection_changed.emit)
+            self._summarize_refresh_timer = timer
+        timer.start()
+
     def _update_filter_columns(self, df: Optional[pd.DataFrame]):
         """Remove filtros de coluna que nao existem mais no DataFrame ativo."""
         if df is not None:
@@ -3091,98 +3534,271 @@ class ResultsViewer(QWidget):
 
     def _filter_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
         """Filtra DataFrame pelos filtros de coluna ativos."""
-        if df is None:
-            return pd.DataFrame()
-        active_column_filters = [
-            (column, self._normalize_filter_spec(value))
-            for column, value in self._column_filters.items()
-            if column in df.columns and not self._filter_spec_is_empty(self._normalize_filter_spec(value))
-        ]
-        if not active_column_filters:
-            return df
+        return filter_dataframe_with_specs(df, self._column_filters)
 
-        mask = pd.Series(True, index=df.index)
-        for column, spec in active_column_filters:
-            mask = mask & self._column_filter_mask(df, column, spec)
-        return df.loc[mask]
+    def _show_grid_preparing(self, total_rows: int):
+        preparing = getattr(S.results, "grid_preparing", "Preparing grid...")
+        try:
+            text = preparing.format(rows=f"{int(total_rows):,}")
+        except (KeyError, IndexError):
+            text = preparing
+        self.info_label.setText(text)
+
+    def _model_prepare_key(self, model) -> int:
+        return id(model)
+
+    def _cancel_grid_prepare_for_model(self, model):
+        """Cancel in-flight prepare jobs for one grid model only."""
+        if model is None:
+            return
+        model_key = self._model_prepare_key(model)
+        self._model_prepare_generation[model_key] = self._model_prepare_generation.get(model_key, 0) + 1
+        for job_id, job in list(self._grid_prepare_job_meta.items()):
+            if job.get("model") is not model:
+                continue
+            thread = job.get("thread")
+            if thread and thread.isRunning():
+                thread.quit()
+                thread.wait(200)
+            self._grid_prepare_job_meta.pop(job_id, None)
+            if self._active_grid_prepare_job is job:
+                self._active_grid_prepare_job = None
+
+    def _cancel_all_grid_prepare(self):
+        """Cancel every in-flight grid prepare job."""
+        for job_id, job in list(self._grid_prepare_job_meta.items()):
+            thread = job.get("thread")
+            if thread and thread.isRunning():
+                thread.quit()
+                thread.wait(200)
+        self._grid_prepare_job_meta.clear()
+        self._model_prepare_generation.clear()
+        self._active_grid_prepare_job = None
+
+    def _cancel_active_grid_prepare(self):
+        self._cancel_all_grid_prepare()
+
+    def _start_grid_prepare(
+        self,
+        source_df: pd.DataFrame,
+        var_name: str,
+        model: PandasModel,
+        table_view: QTableView,
+        page=None,
+    ):
+        self._cancel_grid_prepare_for_model(model)
+        self._grid_prepare_job_serial += 1
+        job_id = self._grid_prepare_job_serial
+        model_key = self._model_prepare_key(model)
+        model_generation = self._model_prepare_generation.get(model_key, 0)
+        limit = self.row_limit_spin.value()
+
+        thread = QThread(self)
+        worker = GridPrepareWorker(
+            job_id,
+            source_df,
+            self._column_filters,
+            self._column_formats,
+            limit,
+        )
+        worker.moveToThread(thread)
+
+        job = {
+            "thread": thread,
+            "worker": worker,
+            "var_name": var_name,
+            "model": model,
+            "model_key": model_key,
+            "model_generation": model_generation,
+            "table_view": table_view,
+            "page": page,
+        }
+        self._active_grid_prepare_job = job
+        self._grid_prepare_job_meta[job_id] = job
+
+        thread.started.connect(worker.run)
+        worker.finished.connect(self._on_grid_prepare_finished)
+        worker.error.connect(self._on_grid_prepare_error)
+        worker.finished.connect(thread.quit)
+        worker.error.connect(thread.quit)
+        thread.finished.connect(worker.deleteLater)
+        thread.finished.connect(thread.deleteLater)
+        thread.finished.connect(lambda: self._clear_grid_prepare_job(job))
+        thread.start()
+
+    def _clear_grid_prepare_job(self, job: dict):
+        if self._active_grid_prepare_job is job:
+            self._active_grid_prepare_job = None
+
+    def _grid_prepare_job_is_current(self, job: dict) -> bool:
+        if not job:
+            return False
+        model_key = job.get("model_key")
+        if model_key is None:
+            return False
+        return job.get("model_generation") == self._model_prepare_generation.get(model_key)
+
+    def _on_grid_prepare_finished(self, job_id: int, result: GridPrepareResult):
+        job = self._grid_prepare_job_meta.pop(job_id, None)
+        if not job or not self._grid_prepare_job_is_current(job):
+            return
+        self._apply_grid_prepare_result(
+            result,
+            var_name=job.get("var_name") or self._current_result_label(),
+            model=job.get("model") or self.model,
+            table_view=job.get("table_view") or self.table_view,
+            page=job.get("page"),
+        )
+
+    def _on_grid_prepare_error(self, job_id: int, error: str):
+        job = self._grid_prepare_job_meta.pop(job_id, None)
+        if not job or not self._grid_prepare_job_is_current(job):
+            return
+        self.info_label.setText(str(error)[:240])
+
+    def _apply_grid_prepare_result(
+        self,
+        result: GridPrepareResult,
+        *,
+        var_name: str,
+        model: PandasModel,
+        table_view: QTableView,
+        page=None,
+    ):
+        prepared = result.prepared
+        model.update_prepared(prepared)
+        model.set_column_formats(self._column_formats)
+
+        if page is not None:
+            page._filtered_df = result.filtered_df
+            source_df = getattr(page, "_df", None)
+            if source_df is not None:
+                page._grid_cache_key = self._grid_view_cache_key(source_df)
+        else:
+            self._primary_filtered_df = result.filtered_df
+            if self._primary_df is not None:
+                self._primary_grid_cache_key = self._grid_view_cache_key(self._primary_df)
+        tabs = getattr(self, "_result_tabs", None)
+        if page is None or (
+            tabs is not None
+            and tabs.currentIndex() > 0
+            and tabs.widget(tabs.currentIndex()) is page
+        ):
+            self.current_df = result.filtered_df
+
+        cols = len(prepared.columns)
+        self._set_dataframe_info(
+            var_name,
+            prepared.filtered_row_count,
+            prepared.total_row_count,
+            cols,
+            prepared.limited,
+        )
+        self._schedule_table_column_resize(table_view, prepared)
+        self._refresh_filter_chips()
+        if page is None or (
+            tabs is not None
+            and tabs.currentIndex() > 0
+            and tabs.widget(tabs.currentIndex()) is page
+        ) or (
+            tabs is not None
+            and tabs.currentIndex() == 0
+            and page is None
+        ):
+            self._connect_active_selection_model()
+            self._schedule_summarize_refresh()
+
+    def _apply_grid_view_sync(
+        self,
+        source_df: pd.DataFrame,
+        var_name: str,
+        model: PandasModel,
+        table_view: QTableView,
+        page=None,
+    ):
+        limit = self.row_limit_spin.value()
+        result = prepare_grid_data(source_df, self._column_filters, self._column_formats, limit)
+        self._apply_grid_prepare_result(
+            result,
+            var_name=var_name,
+            model=model,
+            table_view=table_view,
+            page=page,
+        )
+
+    def _request_grid_view_update(
+        self,
+        source_df: pd.DataFrame,
+        *,
+        var_name: str = None,
+        model: PandasModel = None,
+        table_view: QTableView = None,
+        page=None,
+    ):
+        var_name = var_name or self._current_result_label()
+        model = model or self.model
+        table_view = table_view or self.table_view
+        limit = self.row_limit_spin.value()
+        rows_to_prepare = min(len(source_df), limit)
+        use_async = (
+            len(source_df) > GRID_ASYNC_ROW_THRESHOLD
+            or rows_to_prepare > GRID_ASYNC_ROW_THRESHOLD
+        )
+
+        if use_async:
+            self._show_grid_preparing(len(source_df))
+            self._start_grid_prepare(source_df, var_name, model, table_view, page)
+            return
+
+        self._apply_grid_view_sync(source_df, var_name, model, table_view, page)
+
+    def _schedule_table_column_resize(self, table_view: QTableView, prepared: PreparedGridData):
+        def _table_view_is_valid(view) -> bool:
+            if view is None:
+                return False
+            try:
+                from shiboken6 import isValid
+
+                return isValid(view)
+            except ImportError:
+                return True
+
+        def resize_columns():
+            if not _table_view_is_valid(table_view):
+                return
+            try:
+                if len(prepared.display_rows) <= GRID_ASYNC_ROW_THRESHOLD:
+                    table_view.resizeColumnsToContents()
+                    return
+
+                header = table_view.horizontalHeader()
+                metrics = table_view.fontMetrics()
+                sample_rows = min(GRID_COLUMN_RESIZE_SAMPLE_ROWS, len(prepared.display_rows))
+                for col_index, column_name in enumerate(prepared.columns):
+                    max_width = metrics.horizontalAdvance(str(column_name)) + 24
+                    for row_index in range(sample_rows):
+                        cell_text = prepared.display_rows[row_index][col_index]
+                        max_width = max(max_width, metrics.horizontalAdvance(cell_text) + 24)
+                    header.resizeSection(col_index, min(max_width, GRID_COLUMN_MAX_WIDTH))
+            except RuntimeError:
+                return
+
+        QTimer.singleShot(0, resize_columns)
 
     def _normalize_filter_spec(self, value: Any) -> dict:
-        if isinstance(value, dict):
-            spec = dict(value)
-            spec["type"] = str(spec.get("type", "text") or "text")
-            return spec
-        return {"type": "text", "operator": "contains", "value": str(value or "")}
+        return _grid_normalize_filter_spec(value)
 
     def _filter_spec_is_empty(self, spec: dict) -> bool:
-        filter_type = str(spec.get("type", "text"))
-        if filter_type == "number":
-            return not str(spec.get("min", "")).strip() and not str(spec.get("max", "")).strip()
-        if filter_type == "bool":
-            return spec.get("value") in (None, "", "any")
-        if filter_type == "date":
-            return not str(spec.get("start", "")).strip() and not str(spec.get("end", "")).strip()
-        return not str(spec.get("value", "")).strip()
+        return _grid_filter_spec_is_empty(spec)
 
     def _column_filter_mask(self, df: pd.DataFrame, column, spec: dict):
-        filter_type = str(spec.get("type", "text"))
-        if filter_type == "number":
-            values = pd.to_numeric(df[column], errors="coerce")
-            mask = pd.Series(True, index=df.index)
-            min_value = self._parse_float(spec.get("min"))
-            max_value = self._parse_float(spec.get("max"))
-            if min_value is not None:
-                mask = mask & values.ge(min_value)
-            if max_value is not None:
-                mask = mask & values.le(max_value)
-            return mask.fillna(False)
-        if filter_type == "bool":
-            desired = self._parse_bool_value(spec.get("value"))
-            if desired is None:
-                return pd.Series(True, index=df.index)
-            values = df[column].map(self._parse_bool_value)
-            return values.eq(desired).fillna(False)
-        if filter_type == "date":
-            values = pd.to_datetime(df[column], errors="coerce")
-            mask = pd.Series(True, index=df.index)
-            start = pd.to_datetime(spec.get("start"), errors="coerce") if str(spec.get("start", "")).strip() else None
-            end = pd.to_datetime(spec.get("end"), errors="coerce") if str(spec.get("end", "")).strip() else None
-            if start is not None and not pd.isna(start):
-                mask = mask & values.ge(start)
-            if end is not None and not pd.isna(end):
-                mask = mask & values.le(end)
-            return mask.fillna(False)
-
-        value = str(spec.get("value", "")).strip()
-        operator = str(spec.get("operator", "contains") or "contains")
-        values = df[column].astype("string").fillna("")
-        if operator == "equals":
-            return values.str.lower().eq(value.lower())
-        if operator == "starts_with":
-            return values.str.lower().str.startswith(value.lower(), na=False)
-        if operator == "ends_with":
-            return values.str.lower().str.endswith(value.lower(), na=False)
-        return values.str.contains(value, case=False, regex=False, na=False)
+        return _grid_column_filter_mask(df, column, spec)
 
     def _parse_float(self, value: Any) -> Optional[float]:
-        text = str(value or "").strip()
-        if not text:
-            return None
-        try:
-            return float(text.replace(",", "."))
-        except ValueError:
-            return None
+        return _grid_parse_float(value)
 
     def _parse_bool_value(self, value: Any) -> Optional[bool]:
-        if isinstance(value, bool):
-            return value
-        if value is None:
-            return None
-        text = str(value).strip().lower()
-        if text in {"1", "true", "t", "yes", "y", "sim", "s"}:
-            return True
-        if text in {"0", "false", "f", "no", "n", "nao"}:
-            return False
-        return None
+        return _grid_parse_bool_value(value)
 
     def _apply_active_dataframe_view(self, var_name: str = None):
         """Aplica filtro/limite ao DataFrame original da aba ativa."""
@@ -3190,27 +3806,23 @@ class ResultsViewer(QWidget):
         if source_df is None:
             return
 
-        filtered_df = self._filter_dataframe(source_df)
-        self.current_df = filtered_df
-
         tabs = getattr(self, "_result_tabs", None)
+        page = None
+        model = self.model
+        table_view = self.table_view
         if tabs is not None and tabs.currentIndex() > 0:
             page = tabs.widget(tabs.currentIndex())
-            if page is not None:
-                page._filtered_df = filtered_df
+            if page is not None and hasattr(page, "_model"):
+                model = page._model
+                table_view = page._table_view
 
-        rows = len(filtered_df)
-        total_rows = len(source_df)
-        cols = len(source_df.columns)
-        limit = self.row_limit_spin.value()
-        display_df = filtered_df.head(limit) if rows > limit else filtered_df
-        self.model.update_data(display_df)
-        self.model.set_column_formats(self._column_formats)
-        QTimer.singleShot(0, self.table_view.resizeColumnsToContents)
-
-        label = var_name or self._current_result_label()
-        self._set_dataframe_info(label, rows, total_rows, cols, rows > limit)
-        self._refresh_filter_chips()
+        self._request_grid_view_update(
+            source_df,
+            var_name=var_name or self._current_result_label(),
+            model=model,
+            table_view=table_view,
+            page=page,
+        )
 
     def _refresh_filter_chips(self):
         """Atualiza chips visuais dos filtros ativos."""
@@ -3711,11 +4323,16 @@ class ResultsViewer(QWidget):
 
     def clear(self):
         """Clear visualization"""
+        self._cancel_all_grid_prepare()
+        self._grid_prepare_job_serial += 1
+        self._grid_prepare_job_meta.clear()
         self._collapse_to_primary()
         self._column_filters.clear()
         self._refresh_filter_chips()
         self.current_df = None
         self._primary_df = None
+        self._primary_filtered_df = None
+        self._primary_grid_cache_key = None
         self._current_image_bytes = None
         self.model.update_data(pd.DataFrame())
         self.image_label.clear()
@@ -3724,6 +4341,7 @@ class ResultsViewer(QWidget):
         self.info_label.setText(S.results.no_results)
         self.stack.setCurrentIndex(0)
         self._show_dataframe_toolbar_buttons()
+        self._schedule_summarize_refresh()
 
     def _get_export_destination(self) -> str:
         """Return selected destination: 'clipboard' or 'file'"""
@@ -3999,6 +4617,102 @@ class ResultsViewer(QWidget):
                 text = text[:-1]
             QApplication.instance().clipboard().setText(text)
             self._show_clipboard_success("Table")
+
+    def is_grid_active(self) -> bool:
+        """Return True when the active result tab is showing a data grid."""
+        tabs = getattr(self, "_result_tabs", None)
+        if tabs is None or tabs.currentIndex() < 0:
+            return False
+        if tabs.currentIndex() == 0:
+            return self.stack.currentIndex() == 0
+        page = tabs.widget(tabs.currentIndex())
+        if page is None or self._is_chart_page(page):
+            return False
+        return hasattr(page, "_table_view")
+
+    def get_current_result_label(self) -> str:
+        tabs = getattr(self, "_result_tabs", None)
+        if tabs is None or tabs.currentIndex() < 0:
+            return ""
+        return tabs.tabText(tabs.currentIndex())
+
+    def get_selection_cells(self) -> list[tuple[int, int]]:
+        """Return exact selected (row, column) pairs for the active grid."""
+        if not self.is_grid_active() or self.current_df is None:
+            return []
+
+        selection = self.table_view.selectionModel() if self.table_view is not None else None
+        if selection is None or not selection.hasSelection():
+            return []
+
+        return sorted({(idx.row(), idx.column()) for idx in selection.selectedIndexes()})
+
+    def get_selection_bounds(self) -> tuple[list[int], list[int]]:
+        """Return selected row/column indexes for the active grid."""
+        if not self.is_grid_active() or self.current_df is None:
+            return [], []
+
+        selection = self.table_view.selectionModel() if self.table_view is not None else None
+        if selection is None or not selection.hasSelection():
+            return [], []
+
+        indexes = selection.selectedIndexes()
+        if not indexes:
+            return [], []
+
+        rows = sorted({idx.row() for idx in indexes})
+        cols = sorted({idx.column() for idx in indexes})
+        return rows, cols
+
+    def build_summarize_payload(self) -> dict:
+        from src.ui.components.summarize_stats import build_selection_summary
+
+        cells = self.get_selection_cells()
+        numeric_indices = None
+        prepared = getattr(self.model, "_prepared", None)
+        if prepared is not None and getattr(prepared, "numeric_column_indices", None):
+            numeric_indices = set(prepared.numeric_column_indices)
+
+        return build_selection_summary(
+            self.current_df,
+            cells,
+            result_label=self.get_current_result_label(),
+            column_formats=self._column_formats,
+            numeric_column_indices=numeric_indices,
+        )
+
+    def show_column_format_menu(self, column, global_pos):
+        """Open the column format menu (shared with grid header)."""
+        source_df = self._get_active_source_df()
+        if source_df is None:
+            return
+        if column not in source_df.columns:
+            column = str(column)
+            if column not in source_df.columns:
+                return
+        menu = self._create_column_menu(column, global_pos=global_pos)
+        menu.exec(global_pos)
+
+    def _connect_active_selection_model(self):
+        table_view = getattr(self, "table_view", None)
+        selection_model = table_view.selectionModel() if table_view is not None else None
+        if selection_model is self._bound_selection_model:
+            return
+        if self._bound_selection_model is not None:
+            try:
+                self._bound_selection_model.selectionChanged.disconnect(self._on_grid_selection_changed)
+            except (TypeError, RuntimeError):
+                pass
+        self._bound_selection_model = selection_model
+        if selection_model is not None:
+            selection_model.selectionChanged.connect(self._on_grid_selection_changed)
+
+    def _on_grid_selection_changed(self, *_args):
+        self._schedule_summarize_refresh()
+
+    def _on_stack_page_changed(self, _index: int):
+        self._connect_active_selection_model()
+        self._schedule_summarize_refresh()
 
     def _copy_selection_to_clipboard(self, include_headers: bool = False):
         """Copy selected cells/rows/columns from the table view to clipboard.
@@ -4393,6 +5107,7 @@ class ResultsViewer(QWidget):
         if self._get_active_source_df() is not None:
             self._apply_active_dataframe_view(self._current_result_label())
         self._persist_view_state()
+        self._schedule_summarize_refresh()
 
     def _open_visualization_editor(self):
         """Abre editor compacto de configuracoes de grafico."""

--- a/source/src/ui/components/summarize_panel.py
+++ b/source/src/ui/components/summarize_panel.py
@@ -1,0 +1,702 @@
+"""Summarize panel — selection stats and aggregates for the results grid."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QFont
+from PyQt6.QtWidgets import (
+    QFrame,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QScrollArea,
+    QTabWidget,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+    QSizePolicy,
+)
+
+from src.design_system.tokens import SCROLLBAR_STYLE, get_colors
+from src.language import S
+
+try:
+    import qtawesome as qta
+
+    HAS_QTAWESOME = True
+except ImportError:
+    HAS_QTAWESOME = False
+
+
+ZOOM_LEVELS = (85, 100, 115, 130)
+DEFAULT_ZOOM_INDEX = 1
+
+
+class _StatChip(QFrame):
+    """Compact stat label + value."""
+
+    def __init__(self, label: str, value: str, *, accent: bool = False, parent=None, zoom: float = 1.0):
+        super().__init__(parent)
+        self.setObjectName("summarizeStatChip")
+        self._zoom = zoom
+        layout = QVBoxLayout(self)
+        self._apply_layout_metrics(layout)
+
+        self.label = QLabel(label)
+        self.label.setObjectName("summarizeStatLabel")
+        self.value = QLabel(value or "—")
+        self.value.setObjectName("summarizeStatValue")
+        self.value.setWordWrap(True)
+        self._accent = accent
+
+        layout.addWidget(self.label)
+        layout.addWidget(self.value)
+        self._apply_fonts()
+
+    def _apply_layout_metrics(self, layout: QVBoxLayout):
+        pad = max(2, int(4 * self._zoom))
+        layout.setContentsMargins(pad + 2, pad, pad + 2, pad)
+        layout.setSpacing(0)
+
+    def set_zoom(self, zoom: float):
+        self._zoom = zoom
+        self._apply_layout_metrics(self.layout())
+        self._apply_fonts()
+
+    def _apply_fonts(self):
+        label_font = QFont(self.label.font())
+        label_font.setPointSizeF(max(7.0, 7.5 * self._zoom))
+        self.label.setFont(label_font)
+
+        value_font = QFont(self.value.font())
+        value_font.setPointSizeF(max(8.0, 8.5 * self._zoom))
+        value_font.setWeight(QFont.Weight.DemiBold)
+        self.value.setFont(value_font)
+
+    def set_value(self, value: str):
+        self.value.setText(value or "—")
+
+    def apply_theme(self, tokens, accent_color: str):
+        bg = tokens.bg_tertiary if self._accent else tokens.bg_secondary
+        value_color = accent_color if self._accent else tokens.text_primary
+        self.setStyleSheet(f"""
+            QFrame#summarizeStatChip {{
+                background-color: {bg};
+                border: 1px solid {tokens.border_muted};
+                border-radius: 6px;
+            }}
+            QLabel#summarizeStatLabel {{
+                color: {tokens.text_tertiary};
+                background: transparent;
+            }}
+            QLabel#summarizeStatValue {{
+                color: {value_color};
+                background: transparent;
+            }}
+        """)
+
+
+class _ColumnSummaryCard(QFrame):
+    """Per-column summary card with optional format menu."""
+
+    format_requested = pyqtSignal(str, object)
+
+    def __init__(self, column: Dict[str, Any], parent=None):
+        super().__init__(parent)
+        self._column = dict(column or {})
+        self.setObjectName("summarizeColumnCard")
+        self._chips: List[_StatChip] = []
+        self._build_ui()
+
+    def _build_ui(self):
+        root = QVBoxLayout(self)
+        root.setContentsMargins(8, 6, 8, 6)
+        root.setSpacing(6)
+
+        header = QHBoxLayout()
+        header.setSpacing(6)
+
+        self.title = QLabel(self._column.get("name", ""))
+        title_font = QFont(self.title.font())
+        title_font.setPointSize(10)
+        title_font.setWeight(QFont.Weight.DemiBold)
+        self.title.setFont(title_font)
+
+        kind = self._column.get("kind", "text")
+        self.badge = QLabel(kind.upper())
+        self.badge.setObjectName("summarizeKindBadge")
+
+        self.format_btn = QToolButton()
+        self.format_btn.setObjectName("summarizeFormatBtn")
+        self.format_btn.setToolTip(S.summarize_panel.format_column)
+        self.format_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        if HAS_QTAWESOME:
+            self.format_btn.setIcon(qta.icon("mdi.tune-variant", color="#9aa0a6"))
+        self.format_btn.clicked.connect(self._on_format_clicked)
+
+        header.addWidget(self.title, 1)
+        header.addWidget(self.badge, 0)
+        header.addWidget(self.format_btn, 0)
+        root.addLayout(header)
+
+        grid = QGridLayout()
+        grid.setHorizontalSpacing(6)
+        grid.setVerticalSpacing(6)
+
+        labels = S.summarize_panel.headers
+        if kind == "numeric":
+            specs = [
+                ("sum", self._column.get("sum", "—"), True),
+                ("avg", self._column.get("avg", "—"), False),
+                ("min", self._column.get("min", "—"), False),
+                ("max", self._column.get("max", "—"), False),
+                ("count", self._column.get("count", "—"), False),
+                ("distinct", self._column.get("distinct", "—"), False),
+            ]
+        else:
+            specs = [
+                ("count", self._column.get("count", "—"), False),
+                ("distinct", self._column.get("distinct", "—"), False),
+                ("top", self._column.get("top", "—"), True),
+            ]
+
+        for index, (key, value, accent) in enumerate(specs):
+            chip = _StatChip(getattr(labels, key, key), str(value), accent=accent, parent=self)
+            self._chips.append(chip)
+            grid.addWidget(chip, index // 2, index % 2)
+
+        root.addLayout(grid)
+
+    def _on_format_clicked(self):
+        self.format_requested.emit(self._column.get("name", ""), self.format_btn)
+
+    def update_column(self, column: Dict[str, Any]):
+        self._column = dict(column or {})
+        kind = self._column.get("kind", "text")
+        self.title.setText(self._column.get("name", ""))
+        self.badge.setText(kind.upper())
+
+        if kind == "numeric":
+            values = [
+                self._column.get("sum", "—"),
+                self._column.get("avg", "—"),
+                self._column.get("min", "—"),
+                self._column.get("max", "—"),
+                self._column.get("count", "—"),
+                self._column.get("distinct", "—"),
+            ]
+        else:
+            values = [
+                self._column.get("count", "—"),
+                self._column.get("distinct", "—"),
+                self._column.get("top", "—"),
+            ]
+        for chip, value in zip(self._chips, values):
+            chip.set_value(str(value))
+
+    def apply_theme(self, tokens, accent_color: str):
+        kind = self._column.get("kind", "text")
+        badge_bg = getattr(tokens, "info", "#3b82f6") if kind == "numeric" else getattr(tokens, "warning", "#f59e0b")
+        self.setStyleSheet(f"""
+            QFrame#summarizeColumnCard {{
+                background-color: {tokens.bg_primary};
+                border: 1px solid {tokens.border_default};
+                border-radius: 8px;
+            }}
+            QLabel#summarizeKindBadge {{
+                color: {tokens.text_primary};
+                background-color: {badge_bg};
+                border-radius: 4px;
+                padding: 1px 6px;
+                font-size: 9px;
+                font-weight: 600;
+            }}
+            QToolButton#summarizeFormatBtn {{
+                border: 1px solid {tokens.border_muted};
+                border-radius: 4px;
+                padding: 2px;
+                min-width: 20px;
+                max-width: 20px;
+                min-height: 20px;
+                max-height: 20px;
+                background: {tokens.bg_secondary};
+            }}
+            QToolButton#summarizeFormatBtn:hover {{
+                background: {tokens.bg_elevated};
+            }}
+        """)
+        self.title.setStyleSheet(f"color: {tokens.text_primary}; background: transparent;")
+        for chip in self._chips:
+            chip.apply_theme(tokens, accent_color)
+
+
+class _AggregateRow(QFrame):
+    def __init__(self, label: str, value: str, parent=None, *, zoom: float = 1.0, show_divider: bool = True):
+        super().__init__(parent)
+        self.setObjectName("summarizeAggregateRow")
+        self._zoom = zoom
+        self._show_divider = show_divider
+
+        layout = QHBoxLayout(self)
+
+        self.label = QLabel(label)
+        self.value = QLabel(value or "—")
+        self.value.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+
+        layout.addWidget(self.label, 1)
+        layout.addWidget(self.value, 0)
+
+        self._apply_layout_metrics(layout)
+        self._apply_fonts()
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+
+    def _apply_layout_metrics(self, layout: QHBoxLayout):
+        pad_x = max(8, int(10 * self._zoom))
+        layout.setContentsMargins(pad_x, 0, pad_x, 0)
+        layout.setSpacing(max(4, int(6 * self._zoom)))
+        height = max(12, int(14 * self._zoom))
+        self.setFixedHeight(height)
+        self.label.setFixedHeight(height)
+        self.value.setFixedHeight(height)
+
+    def set_zoom(self, zoom: float):
+        self._zoom = zoom
+        self._apply_layout_metrics(self.layout())
+        self._apply_fonts()
+
+    def _apply_fonts(self):
+        label_font = QFont(self.label.font())
+        label_font.setPointSizeF(max(6.5, 7.0 * self._zoom))
+        label_font.setWeight(QFont.Weight.Medium)
+        label_font.setCapitalization(QFont.Capitalization.AllUppercase)
+        self.label.setFont(label_font)
+
+        value_font = QFont(self.value.font())
+        value_font.setPointSizeF(max(7.0, 7.5 * self._zoom))
+        value_font.setWeight(QFont.Weight.DemiBold)
+        self.value.setFont(value_font)
+
+    def set_value(self, value: str):
+        self.value.setText(value or "—")
+
+    def apply_theme(self, tokens, accent_color: str):
+        border = f"border-bottom: 1px solid {tokens.border_muted};" if self._show_divider else "border: none;"
+        self.setStyleSheet(f"""
+            QFrame#summarizeAggregateRow {{
+                background: transparent;
+                {border}
+            }}
+        """)
+        self.label.setStyleSheet(
+            f"color: {tokens.text_tertiary}; background: transparent; margin: 0; padding: 0;"
+        )
+        self.value.setStyleSheet(
+            f"color: {accent_color}; background: transparent; margin: 0; padding: 0;"
+        )
+
+
+class SummarizePanel(QWidget):
+    """Dock panel that summarizes the focused grid selection."""
+
+    cleared = pyqtSignal()
+
+    def __init__(self, theme_manager=None, parent=None):
+        super().__init__(parent)
+        self.theme_manager = theme_manager
+        self._results_viewer = None
+        self._payload: Dict[str, Any] = {}
+        self._column_cards: List[_ColumnSummaryCard] = []
+        self._aggregate_rows: List[_AggregateRow] = []
+        self._zoom_index = DEFAULT_ZOOM_INDEX
+        self._setup_ui()
+        self.clear()
+
+    def _zoom_scale(self) -> float:
+        return ZOOM_LEVELS[self._zoom_index] / 100.0
+
+    def _setup_ui(self):
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        self.header = QWidget()
+        header_layout = QVBoxLayout(self.header)
+        header_layout.setContentsMargins(10, 5, 10, 3)
+        header_layout.setSpacing(2)
+
+        self.title_label = QLabel()
+        title_font = QFont(self.title_label.font())
+        title_font.setPointSize(10)
+        title_font.setWeight(QFont.Weight.DemiBold)
+        self.title_label.setFont(title_font)
+
+        self.subtitle_label = QLabel()
+        self.subtitle_label.setWordWrap(True)
+
+        self.zoom_out_btn = QToolButton()
+        self.zoom_out_btn.setObjectName("summarizeZoomBtn")
+        self.zoom_out_btn.setToolTip(S.summarize_panel.zoom_out)
+        self.zoom_out_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        if HAS_QTAWESOME:
+            self.zoom_out_btn.setIcon(qta.icon("mdi.magnify-minus-outline", color="#9aa0a6"))
+
+        self.zoom_label = QLabel()
+        self.zoom_label.setObjectName("summarizeZoomLabel")
+        self.zoom_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.zoom_label.setMinimumWidth(34)
+
+        self.zoom_in_btn = QToolButton()
+        self.zoom_in_btn.setObjectName("summarizeZoomBtn")
+        self.zoom_in_btn.setToolTip(S.summarize_panel.zoom_in)
+        self.zoom_in_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        if HAS_QTAWESOME:
+            self.zoom_in_btn.setIcon(qta.icon("mdi.magnify-plus-outline", color="#9aa0a6"))
+
+        self.zoom_out_btn.clicked.connect(self._zoom_out)
+        self.zoom_in_btn.clicked.connect(self._zoom_in)
+
+        title_row = QHBoxLayout()
+        title_row.setContentsMargins(0, 0, 0, 0)
+        title_row.setSpacing(4)
+        title_row.addWidget(self.title_label, 1)
+        title_row.addWidget(self.zoom_out_btn, 0)
+        title_row.addWidget(self.zoom_label, 0)
+        title_row.addWidget(self.zoom_in_btn, 0)
+
+        self.grand_total_frame = QFrame()
+        self.grand_total_frame.setObjectName("summarizeGrandTotal")
+        grand_layout = QHBoxLayout(self.grand_total_frame)
+        grand_layout.setContentsMargins(10, 6, 10, 6)
+        self.grand_total_caption = QLabel(S.summarize_panel.grand_total)
+        self.grand_total_value = QLabel("—")
+        grand_value_font = QFont(self.grand_total_value.font())
+        grand_value_font.setPointSize(14)
+        grand_value_font.setWeight(QFont.Weight.Bold)
+        self.grand_total_value.setFont(grand_value_font)
+        self.grand_total_value.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+        grand_layout.addWidget(self.grand_total_caption, 0)
+        grand_layout.addWidget(self.grand_total_value, 1)
+
+        header_layout.addLayout(title_row)
+        header_layout.addWidget(self.subtitle_label)
+
+        layout.addWidget(self.header)
+        layout.addWidget(self.grand_total_frame)
+
+        self.tabs = QTabWidget()
+        self.tabs.setDocumentMode(True)
+        self.tabs.setObjectName("summarizeTabs")
+
+        self.summarize_page = QWidget()
+        summarize_layout = QVBoxLayout(self.summarize_page)
+        summarize_layout.setContentsMargins(0, 0, 0, 0)
+        summarize_layout.setSpacing(0)
+
+        self.empty_label = QLabel()
+        self.empty_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.empty_label.setWordWrap(True)
+
+        self.cards_scroll = QScrollArea()
+        self.cards_scroll.setWidgetResizable(True)
+        self.cards_scroll.setFrameShape(QFrame.Shape.NoFrame)
+        self.cards_host = QWidget()
+        self.cards_layout = QVBoxLayout(self.cards_host)
+        self.cards_layout.setContentsMargins(8, 6, 8, 6)
+        self.cards_layout.setSpacing(6)
+        self.cards_layout.addStretch(1)
+        self.cards_scroll.setWidget(self.cards_host)
+
+        summarize_layout.addWidget(self.empty_label)
+        summarize_layout.addWidget(self.cards_scroll, 1)
+
+        self.aggregate_page = QWidget()
+        aggregate_layout = QVBoxLayout(self.aggregate_page)
+        aggregate_layout.setContentsMargins(0, 0, 0, 0)
+        aggregate_layout.setSpacing(0)
+
+        self.aggregate_empty = QLabel()
+        self.aggregate_empty.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.aggregate_empty.setWordWrap(True)
+
+        self.aggregate_scroll = QScrollArea()
+        self.aggregate_scroll.setWidgetResizable(True)
+        self.aggregate_scroll.setFrameShape(QFrame.Shape.NoFrame)
+        self.aggregate_host = QWidget()
+        self.aggregate_layout = QVBoxLayout(self.aggregate_host)
+        self.aggregate_layout.setContentsMargins(0, 0, 0, 0)
+        self.aggregate_layout.setSpacing(0)
+        self.aggregate_scroll.setWidget(self.aggregate_host)
+
+        aggregate_layout.addWidget(self.aggregate_empty)
+        aggregate_layout.addWidget(self.aggregate_scroll, 1)
+
+        self.tabs.addTab(self.summarize_page, S.summarize_panel.tab_summarize)
+        self.tabs.addTab(self.aggregate_page, S.summarize_panel.tab_aggregate)
+        layout.addWidget(self.tabs, 1)
+
+        self._apply_theme()
+        self._update_zoom_controls()
+
+    def _zoom_out(self):
+        if self._zoom_index > 0:
+            self._zoom_index -= 1
+            self._apply_zoom()
+
+    def _zoom_in(self):
+        if self._zoom_index < len(ZOOM_LEVELS) - 1:
+            self._zoom_index += 1
+            self._apply_zoom()
+
+    def _update_zoom_controls(self):
+        percent = ZOOM_LEVELS[self._zoom_index]
+        self.zoom_label.setText(f"{percent}%")
+        self.zoom_out_btn.setEnabled(self._zoom_index > 0)
+        self.zoom_in_btn.setEnabled(self._zoom_index < len(ZOOM_LEVELS) - 1)
+
+    def _apply_zoom(self):
+        self._update_zoom_controls()
+        scale = self._zoom_scale()
+        for card in self._column_cards:
+            title_font = QFont(card.title.font())
+            title_font.setPointSizeF(max(9.0, 10.0 * scale))
+            title_font.setWeight(QFont.Weight.DemiBold)
+            card.title.setFont(title_font)
+            for chip in card._chips:
+                chip.set_zoom(scale)
+        for row in self._aggregate_rows:
+            row.set_zoom(scale)
+
+        grand_value_font = QFont(self.grand_total_value.font())
+        grand_value_font.setPointSizeF(max(12.0, 14.0 * scale))
+        grand_value_font.setWeight(QFont.Weight.Bold)
+        self.grand_total_value.setFont(grand_value_font)
+        self._apply_theme()
+
+    def set_theme_manager(self, theme_manager):
+        self.theme_manager = theme_manager
+        self._apply_theme()
+
+    def _accent_color(self, tokens) -> str:
+        return getattr(tokens, "info", "#7ec8ff")
+
+    def _apply_theme(self):
+        tokens = get_colors()
+        if self.theme_manager:
+            app_colors = self.theme_manager.get_app_colors()
+            fg = app_colors.get("foreground", tokens.text_primary)
+            bg = app_colors.get("background", tokens.bg_primary)
+        else:
+            fg = tokens.text_primary
+            bg = tokens.bg_primary
+
+        accent = self._accent_color(tokens)
+        self.title_label.setStyleSheet(f"color: {fg};")
+        self.subtitle_label.setStyleSheet(f"color: {tokens.text_secondary}; font-size: 10px;")
+        self.empty_label.setStyleSheet(
+            f"color: {tokens.text_tertiary}; font-size: 11px; padding: 16px;"
+        )
+        self.aggregate_empty.setStyleSheet(
+            f"color: {tokens.text_tertiary}; font-size: 11px; padding: 16px;"
+        )
+        self.grand_total_frame.setStyleSheet(f"""
+            QFrame#summarizeGrandTotal {{
+                background-color: {tokens.bg_tertiary};
+                border-top: 1px solid {tokens.border_default};
+                border-bottom: 1px solid {tokens.border_default};
+            }}
+        """)
+        self.grand_total_caption.setStyleSheet(f"color: {tokens.text_secondary}; font-size: 10px;")
+        self.grand_total_value.setStyleSheet(f"color: {accent};")
+        self.zoom_label.setStyleSheet(f"color: {tokens.text_tertiary}; font-size: 9px; padding: 0 2px;")
+        zoom_btn_style = f"""
+            QToolButton#summarizeZoomBtn {{
+                border: 1px solid {tokens.border_muted};
+                border-radius: 3px;
+                padding: 0;
+                min-width: 18px;
+                max-width: 18px;
+                min-height: 18px;
+                max-height: 18px;
+                background: {tokens.bg_secondary};
+            }}
+            QToolButton#summarizeZoomBtn:hover {{
+                background: {tokens.bg_elevated};
+            }}
+            QToolButton#summarizeZoomBtn:disabled {{
+                color: {tokens.text_tertiary};
+            }}
+        """
+        self.zoom_out_btn.setStyleSheet(zoom_btn_style)
+        self.zoom_in_btn.setStyleSheet(zoom_btn_style)
+        self.tabs.setStyleSheet(f"""
+            QTabWidget#summarizeTabs::pane {{
+                border: none;
+                background: {bg};
+            }}
+            QTabBar::tab {{
+                background: {tokens.bg_secondary};
+                color: {tokens.text_secondary};
+                padding: 5px 10px;
+                margin-right: 2px;
+                font-size: 10px;
+                border-top-left-radius: 5px;
+                border-top-right-radius: 5px;
+            }}
+            QTabBar::tab:selected {{
+                background: {tokens.bg_primary};
+                color: {fg};
+                font-weight: 600;
+            }}
+            {SCROLLBAR_STYLE}
+        """)
+        self.cards_scroll.setStyleSheet(f"background: {bg}; border: none; {SCROLLBAR_STYLE}")
+        self.aggregate_scroll.setStyleSheet(f"background: {bg}; border: none; {SCROLLBAR_STYLE}")
+        self.aggregate_host.setStyleSheet(f"background: {bg};")
+
+        for card in self._column_cards:
+            card.apply_theme(tokens, accent)
+        for row in self._aggregate_rows:
+            row.apply_theme(tokens, accent)
+
+    def clear(self):
+        self._payload = {}
+        self.title_label.setText(S.summarize_panel.title)
+        self.subtitle_label.setText("")
+        self.grand_total_frame.setVisible(False)
+        self.empty_label.setText(S.summarize_panel.empty_hint)
+        self.aggregate_empty.setText(S.summarize_panel.empty_hint)
+        self._set_content_visible(False)
+        self._clear_cards()
+        self._clear_aggregate_rows()
+        self.cleared.emit()
+
+    def _set_content_visible(self, visible: bool):
+        self.empty_label.setVisible(not visible)
+        self.cards_scroll.setVisible(visible)
+        self.aggregate_empty.setVisible(not visible)
+        self.aggregate_scroll.setVisible(visible)
+
+    def _clear_cards(self):
+        while self.cards_layout.count() > 1:
+            item = self.cards_layout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
+        self._column_cards.clear()
+
+    def _clear_aggregate_rows(self):
+        while self.aggregate_layout.count():
+            item = self.aggregate_layout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
+        self._aggregate_rows.clear()
+
+    def _rebuild_cards(self, columns: List[Dict[str, Any]]):
+        self._clear_cards()
+        tokens = get_colors()
+        accent = self._accent_color(tokens)
+        scale = self._zoom_scale()
+        for column in columns:
+            card = _ColumnSummaryCard(column, parent=self.cards_host)
+            card.format_requested.connect(self._on_format_requested)
+            for chip in card._chips:
+                chip.set_zoom(scale)
+            title_font = QFont(card.title.font())
+            title_font.setPointSizeF(max(9.0, 10.0 * scale))
+            title_font.setWeight(QFont.Weight.DemiBold)
+            card.title.setFont(title_font)
+            card.apply_theme(tokens, accent)
+            self.cards_layout.insertWidget(self.cards_layout.count() - 1, card)
+            self._column_cards.append(card)
+
+    def _rebuild_aggregates(self, aggregates: List[Dict[str, str]]):
+        self._clear_aggregate_rows()
+        labels = S.summarize_panel.aggregates
+        tokens = get_colors()
+        accent = self._accent_color(tokens)
+        scale = self._zoom_scale()
+        last_index = len(aggregates) - 1
+        for index, item in enumerate(aggregates):
+            key = item.get("key", "")
+            label = getattr(labels, key, key.upper())
+            row = _AggregateRow(
+                label,
+                item.get("value", "—"),
+                parent=self.aggregate_host,
+                zoom=scale,
+                show_divider=index < last_index,
+            )
+            row.apply_theme(tokens, accent)
+            self.aggregate_layout.addWidget(row)
+            self._aggregate_rows.append(row)
+
+    def _on_format_requested(self, column_name: str, button):
+        viewer = self._results_viewer
+        if viewer is None or not column_name:
+            return
+        global_pos = button.mapToGlobal(button.rect().bottomLeft())
+        if hasattr(viewer, "show_column_format_menu"):
+            viewer.show_column_format_menu(column_name, global_pos)
+
+    def set_summary(self, payload: Optional[Dict[str, Any]]):
+        payload = payload or {}
+        self._payload = payload
+        columns = payload.get("columns") or []
+        aggregates = payload.get("aggregates") or []
+
+        if not columns:
+            self.clear()
+            if payload.get("subtitle") == "no_data":
+                self.empty_label.setText(S.summarize_panel.no_data)
+                self.aggregate_empty.setText(S.summarize_panel.no_data)
+            return
+
+        title = payload.get("title") or S.summarize_panel.title
+        self.title_label.setText(title)
+
+        scope = payload.get("scope", "all")
+        rows_count = int(payload.get("rows_selected") or 0)
+        cols_count = int(payload.get("cols_selected") or 0)
+        cells_count = int(payload.get("cells_selected") or 0)
+        if scope == "selection":
+            self.subtitle_label.setText(
+                S.summarize_panel.selection_subtitle.format(
+                    rows=rows_count,
+                    cols=cols_count,
+                    cells=cells_count,
+                )
+            )
+        else:
+            self.subtitle_label.setText(
+                S.summarize_panel.all_rows_subtitle.format(
+                    rows=rows_count,
+                    cols=cols_count,
+                )
+            )
+
+        grand_total = payload.get("grand_total_display")
+        numeric_cols = [col for col in columns if col.get("kind") == "numeric"]
+        show_grand_total = grand_total is not None and (
+            len(numeric_cols) > 1 or int(payload.get("cells_selected") or 0) > 1
+        )
+        self.grand_total_frame.setVisible(show_grand_total)
+        if show_grand_total:
+            self.grand_total_value.setText(grand_total)
+
+        self._rebuild_cards(columns)
+        self._rebuild_aggregates(aggregates)
+        self._set_content_visible(True)
+        self._apply_theme()
+
+    def update_from_results_viewer(self, results_viewer) -> None:
+        self._results_viewer = results_viewer
+        if results_viewer is None or not hasattr(results_viewer, "build_summarize_payload"):
+            self.clear()
+            return
+        if not results_viewer.is_grid_active():
+            self.clear()
+            return
+        self.set_summary(results_viewer.build_summarize_payload())

--- a/source/src/ui/components/summarize_stats.py
+++ b/source/src/ui/components/summarize_stats.py
@@ -1,0 +1,273 @@
+"""Build grid selection summaries for the Summarize panel."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+
+import pandas as pd
+
+TEXT_PREVIEW_LIMIT = 48
+CellPair = Tuple[int, int]
+
+
+def _format_number(value: float, *, decimals: Optional[int] = None) -> str:
+    if pd.isna(value):
+        return "—"
+    if decimals is not None:
+        return f"{value:,.{decimals}f}"
+    abs_val = abs(value)
+    if abs_val >= 1_000_000_000 or abs_val >= 1000:
+        return f"{value:,.2f}"
+    if abs_val >= 1:
+        return f"{value:,.4g}"
+    return f"{value:.6g}"
+
+
+def _format_count(value: int) -> str:
+    return f"{value:,}"
+
+
+def _format_percent(value: float) -> str:
+    if pd.isna(value):
+        return "—"
+    return f"{value:.2f}%"
+
+
+def format_with_column_config(value: Any, format_config: Any) -> str:
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return "—"
+    from src.ui.components.results_viewer import _grid_format_display_value
+
+    return _grid_format_display_value(value, format_config)
+
+
+def _resolve_scope(
+    df: pd.DataFrame,
+    cells: Optional[Sequence[CellPair]],
+) -> tuple[str, List[CellPair], List[int], List[int]]:
+    cell_list = [(int(r), int(c)) for r, c in (cells or []) if r is not None and c is not None]
+    if cell_list:
+        rows = sorted({row for row, _ in cell_list})
+        cols = sorted({col for _, col in cell_list})
+        return "selection", cell_list, rows, cols
+
+    rows = list(range(len(df)))
+    cols = list(range(len(df.columns)))
+    return "all", [], rows, cols
+
+
+def _series_for_column(df: pd.DataFrame, rows: Sequence[int], col_index: int) -> pd.Series:
+    if df is None or df.empty or col_index < 0 or col_index >= len(df.columns):
+        return pd.Series(dtype=object)
+    row_indexes = [row for row in rows if 0 <= row < len(df)]
+    if not row_indexes:
+        return pd.Series(dtype=object)
+    return df.iloc[row_indexes, col_index]
+
+
+def _column_is_numeric(
+    series: pd.Series,
+    col_index: int,
+    numeric_column_indices: Optional[Set[int]],
+) -> bool:
+    from src.ui.components.results_viewer import _grid_column_is_numeric
+
+    if _grid_column_is_numeric(series):
+        return True
+    if numeric_column_indices is not None and col_index in numeric_column_indices:
+        converted = pd.to_numeric(series, errors="coerce")
+        return int(converted.notna().sum()) > 0
+    return False
+
+
+def _top_text_value(series: pd.Series) -> str:
+    cleaned = series.dropna().astype(str)
+    if cleaned.empty:
+        return "—"
+    counts = cleaned.value_counts()
+    top_value = str(counts.index[0])
+    if len(top_value) > TEXT_PREVIEW_LIMIT:
+        top_value = top_value[: TEXT_PREVIEW_LIMIT - 1] + "…"
+    if len(counts) == 1:
+        return top_value
+    return f"{top_value} ({counts.iloc[0]:,})"
+
+
+def _collect_numeric_values(df: pd.DataFrame, cells: Sequence[CellPair]) -> List[float]:
+    values: List[float] = []
+    for row, col in cells:
+        if row < 0 or col < 0 or row >= len(df) or col >= len(df.columns):
+            continue
+        numeric = pd.to_numeric(df.iloc[row, col], errors="coerce")
+        if pd.notna(numeric):
+            values.append(float(numeric))
+    return values
+
+
+def _collect_numeric_values_for_columns(
+    df: pd.DataFrame,
+    rows: Sequence[int],
+    cols: Sequence[int],
+) -> List[float]:
+    values: List[float] = []
+    row_indexes = [row for row in rows if 0 <= row < len(df)]
+    if not row_indexes:
+        return values
+    for col_index in cols:
+        if col_index < 0 or col_index >= len(df.columns):
+            continue
+        series = pd.to_numeric(df.iloc[row_indexes, col_index], errors="coerce").dropna()
+        if not series.empty:
+            values.extend(series.astype(float).tolist())
+    return values
+
+
+def _build_aggregates(
+    df: pd.DataFrame,
+    cells: Sequence[CellPair],
+    rows: Sequence[int],
+    cols: Sequence[int],
+    numeric_values: Sequence[float],
+    *,
+    cells_selected: Optional[int] = None,
+) -> List[Dict[str, str]]:
+    count_cells = cells_selected if cells_selected is not None else len(cells)
+    count_numeric = len(numeric_values)
+    aggregates: List[Dict[str, str]] = [
+        {"key": "rows", "value": _format_count(len(rows))},
+        {"key": "cols", "value": _format_count(len(cols))},
+        {"key": "count", "value": _format_count(count_cells)},
+        {"key": "count_numeric", "value": _format_count(count_numeric)},
+    ]
+
+    if not numeric_values:
+        aggregates.extend([
+            {"key": "sum", "value": "—"},
+            {"key": "avg", "value": "—"},
+            {"key": "min", "value": "—"},
+            {"key": "max", "value": "—"},
+            {"key": "median", "value": "—"},
+            {"key": "coefficient", "value": "—"},
+        ])
+        return aggregates
+
+    series = pd.Series(numeric_values, dtype=float)
+    total = float(series.sum())
+    avg = float(series.mean())
+    aggregates.extend([
+        {"key": "sum", "value": _format_number(total, decimals=2)},
+        {"key": "avg", "value": _format_number(avg, decimals=4)},
+        {"key": "min", "value": _format_number(float(series.min()), decimals=2)},
+        {"key": "max", "value": _format_number(float(series.max()), decimals=2)},
+        {"key": "median", "value": _format_number(float(series.median()), decimals=2)},
+    ])
+
+    if avg != 0 and count_numeric > 1:
+        coeff = float(series.std(ddof=0) / avg * 100)
+        aggregates.append({"key": "coefficient", "value": _format_percent(coeff)})
+    else:
+        aggregates.append({"key": "coefficient", "value": "—"})
+
+    return aggregates
+
+
+def build_selection_summary(
+    df: Optional[pd.DataFrame],
+    cells: Optional[Sequence[CellPair]],
+    *,
+    result_label: str = "",
+    column_formats: Optional[Dict[str, Any]] = None,
+    numeric_column_indices: Optional[Set[int]] = None,
+) -> Dict[str, Any]:
+    """Return a summary payload for the Summarize panel."""
+    empty = {
+        "title": result_label or "",
+        "subtitle": "",
+        "scope": "empty",
+        "rows_selected": 0,
+        "cols_selected": 0,
+        "cells_selected": 0,
+        "grand_total": None,
+        "columns": [],
+        "aggregates": [],
+    }
+    if df is None or df.empty:
+        empty["subtitle"] = "no_data"
+        return empty
+
+    format_map = dict(column_formats or {})
+    scope, target_cells, target_rows, target_cols = _resolve_scope(df, cells)
+    if scope == "selection":
+        numeric_values = _collect_numeric_values(df, target_cells)
+        cells_selected = len(target_cells)
+    else:
+        numeric_values = _collect_numeric_values_for_columns(df, target_rows, target_cols)
+        cells_selected = len(target_rows) * len(target_cols)
+
+    columns: List[Dict[str, Any]] = []
+    for col_index in target_cols:
+        if col_index < 0 or col_index >= len(df.columns):
+            continue
+        column_name = str(df.columns[col_index])
+        col_cells = [(row, col) for row, col in target_cells if col == col_index]
+        col_rows = sorted({row for row, _ in col_cells}) if col_cells else target_rows
+        series = _series_for_column(df, col_rows, col_index)
+        non_null = int(series.notna().sum())
+        total = int(len(series))
+        format_config = format_map.get(column_name, format_map.get(str(column_name), {"type": "default"}))
+
+        numeric_series = pd.to_numeric(series, errors="coerce")
+        is_numeric = _column_is_numeric(series, col_index, numeric_column_indices)
+        numeric_count = int(numeric_series.notna().sum())
+
+        if is_numeric and numeric_count > 0:
+            valid = numeric_series.dropna()
+            col_sum = float(valid.sum())
+            columns.append({
+                "name": column_name,
+                "kind": "numeric",
+                "format": format_config,
+                "count": _format_count(total),
+                "sum": format_with_column_config(col_sum, format_config),
+                "avg": format_with_column_config(float(valid.mean()), format_config),
+                "min": format_with_column_config(float(valid.min()), format_config),
+                "max": format_with_column_config(float(valid.max()), format_config),
+                "distinct": _format_count(int(valid.nunique(dropna=True))),
+                "sum_raw": col_sum,
+            })
+            continue
+
+        text_series = series.dropna().astype(str)
+        columns.append({
+            "name": column_name,
+            "kind": "text",
+            "format": format_config,
+            "count": _format_count(total),
+            "sum": "—",
+            "avg": "—",
+            "min": "—",
+            "max": "—",
+            "distinct": _format_count(int(text_series.nunique())),
+            "top": _top_text_value(series),
+        })
+
+    grand_total = float(sum(numeric_values)) if numeric_values else None
+    return {
+        "title": result_label or "",
+        "subtitle": "selection" if scope == "selection" else "all",
+        "scope": scope,
+        "rows_selected": len(target_rows),
+        "cols_selected": len(target_cols),
+        "cells_selected": cells_selected,
+        "grand_total": grand_total,
+        "grand_total_display": _format_number(grand_total, decimals=2) if grand_total is not None else None,
+        "columns": columns,
+        "aggregates": _build_aggregates(
+            df,
+            target_cells if scope == "selection" else [],
+            target_rows,
+            target_cols,
+            numeric_values,
+            cells_selected=cells_selected,
+        ),
+    }

--- a/source/src/ui/main_window/_layout.py
+++ b/source/src/ui/main_window/_layout.py
@@ -12,6 +12,7 @@ from PyQt6.QtWidgets import QDockWidget, QMessageBox, QStackedWidget, QTabBar
 from src.ui.components.results_viewer import ResultsViewer
 from src.ui.components.output_panel import OutputPanel
 from src.ui.components.variables_panel import VariablesPanel
+from src.ui.components.summarize_panel import SummarizePanel
 from src.ui.components.copilot_chat_panel import CopilotChatPanel
 from src.ui.components.copilot_output_panel import CopilotOutputPanel
 from src.design_system.tokens import get_colors
@@ -36,6 +37,7 @@ class LayoutMixin:
         self._results_stack = QStackedWidget()
         self._output_stack = QStackedWidget()
         self._variables_stack = QStackedWidget()
+        self._summarize_stack = QStackedWidget()
 
         # Mapeamento session_id -> indice no stack
         self._session_panel_indices: dict = {}
@@ -76,6 +78,14 @@ class LayoutMixin:
         self.results_dock.setStyleSheet(dock_style_bottom)
         self.addDockWidget(Qt.DockWidgetArea.BottomDockWidgetArea, self.results_dock)
 
+        # Summarize Panel (grid selection stats)
+        self.summarize_dock = QDockWidget(S.dock.summarize, self)
+        self.summarize_dock.setObjectName("SummarizeDock")
+        self.summarize_dock.setAllowedAreas(Qt.DockWidgetArea.AllDockWidgetAreas)
+        self.summarize_dock.setWidget(self._summarize_stack)
+        self.summarize_dock.setStyleSheet(dock_style_bottom)
+        self.addDockWidget(Qt.DockWidgetArea.BottomDockWidgetArea, self.summarize_dock)
+
         # Output Panel
         self.output_dock = QDockWidget(S.dock.output, self)
         self.output_dock.setObjectName("OutputDock")
@@ -94,6 +104,7 @@ class LayoutMixin:
 
         # Configure minimum sizes to ensure visibility
         self.results_dock.setMinimumHeight(180)
+        self.summarize_dock.setMinimumHeight(140)
         self.output_dock.setMinimumHeight(180)
         self.variables_dock.setMinimumWidth(200)
         self.variables_dock.setMinimumHeight(180)
@@ -138,45 +149,55 @@ class LayoutMixin:
         # Initialize centralized Copilot auth service
         self._setup_copilot_auth_service()
 
-        # Tabifica Results e Output por padrao (fica em abas)
+        # Tabifica Results, Summarize e Output por padrao (fica em abas)
+        self.tabifyDockWidget(self.results_dock, self.summarize_dock)
         self.tabifyDockWidget(self.results_dock, self.output_dock)
         self.tabifyDockWidget(self.output_dock, self.copilot_output_dock)
 
         # Results fica como aba ativa
         self.results_dock.raise_()
 
-        # Esconder Results e Variables ate a primeira execucao
+        # Esconder Results, Summarize e Variables ate a primeira execucao
         self.results_dock.hide()
+        self.summarize_dock.hide()
         self.variables_dock.hide()
 
         if getattr(self, "_empty_state_widget", None):
             self._show_empty_state()
 
     def _create_session_panels(self, session_id: str):
-        """Creates panels (Results, Output, Variables) for a session and adds to stacks."""
+        """Creates panels (Results, Output, Variables, Summarize) for a session and adds to stacks."""
         results = ResultsViewer(theme_manager=self.theme_manager)
         session = self.session_manager.get_session(session_id) if hasattr(self, "session_manager") else None
         if session is not None and hasattr(results, "set_session"):
             results.set_session(session)
         output = OutputPanel(theme_manager=self.theme_manager)
         variables = VariablesPanel(theme_manager=self.theme_manager)
+        summarize = SummarizePanel(theme_manager=self.theme_manager)
 
         # Connect signals do painel de variaveis
         variables.insert_variable_name.connect(self._on_insert_variable_in_editor)
         variables.delete_variable.connect(self._on_delete_variable)
         variables.show_in_results.connect(self._on_show_variable_in_results)
 
+        results.grid_selection_changed.connect(
+            lambda rv=results, panel=summarize: panel.update_from_results_viewer(rv)
+        )
+
         r_idx = self._results_stack.addWidget(results)
         o_idx = self._output_stack.addWidget(output)
         v_idx = self._variables_stack.addWidget(variables)
+        s_idx = self._summarize_stack.addWidget(summarize)
 
         self._session_panel_indices[session_id] = {
             "results_idx": r_idx,
             "output_idx": o_idx,
             "variables_idx": v_idx,
+            "summarize_idx": s_idx,
             "results": results,
             "output": output,
             "variables": variables,
+            "summarize": summarize,
         }
         return results, output, variables
 
@@ -188,9 +209,13 @@ class LayoutMixin:
         self._results_stack.removeWidget(info["results"])
         self._output_stack.removeWidget(info["output"])
         self._variables_stack.removeWidget(info["variables"])
+        if info.get("summarize"):
+            self._summarize_stack.removeWidget(info["summarize"])
         info["results"].deleteLater()
         info["output"].deleteLater()
         info["variables"].deleteLater()
+        if info.get("summarize"):
+            info["summarize"].deleteLater()
 
         # Remove Object Explorer from session
         if hasattr(self, "_session_explorers"):
@@ -211,6 +236,12 @@ class LayoutMixin:
             self._output_stack.setCurrentWidget(info["output"])
         if info["variables"]:
             self._variables_stack.setCurrentWidget(info["variables"])
+        if info.get("summarize"):
+            self._summarize_stack.setCurrentWidget(info["summarize"])
+            summarize = info["summarize"]
+            results = info.get("results")
+            if summarize and results:
+                summarize.update_from_results_viewer(results)
 
         # Trocar Object Explorer para a sessao ativa
         if hasattr(self, "_session_explorers"):
@@ -237,6 +268,13 @@ class LayoutMixin:
         info = self._session_panel_indices.get(sid) if sid else None
         return info["variables"] if info else None
 
+    @property
+    def global_summarize_panel(self):
+        """Returns the SummarizePanel of the active session."""
+        sid = self._get_active_session_id()
+        info = self._session_panel_indices.get(sid) if sid else None
+        return info.get("summarize") if info else None
+
     def _get_active_session_id(self) -> str:
         """Returns the session_id of the active tab."""
         widget = self._get_current_session_widget()
@@ -262,6 +300,7 @@ class LayoutMixin:
         """
         dock_map = {
             "results": self.results_dock,
+            "summarize": self.summarize_dock,
             "output": self.output_dock,
             "variables": self.variables_dock,
             "object_explorer": getattr(self, "object_explorer_dock", None),
@@ -274,14 +313,21 @@ class LayoutMixin:
         dock.show()
         dock.raise_()
 
-        # Se mostrando results pela primeira vez, mostrar variables tambem
-        if name == "results" and not self.variables_dock.isVisible():
-            self.variables_dock.show()
+        # Se mostrando results pela primeira vez, mostrar variables e summarize tambem
+        if name == "results":
+            if not self.variables_dock.isVisible():
+                self.variables_dock.show()
+            if hasattr(self, "summarize_dock") and not self.summarize_dock.isVisible():
+                self.summarize_dock.show()
+            panel = self.global_summarize_panel
+            viewer = self.global_results_viewer
+            if panel and viewer:
+                panel.update_from_results_viewer(viewer)
 
         # Para docks tabificados, raise_() nao troca a aba visivel.
         # Precisamos encontrar o QTabBar que controla o grupo e selecionar
         # a aba correspondente manualmente.
-        if name in ("results", "output"):
+        if name in ("results", "output", "summarize"):
             self._activate_tabified_dock(dock)
 
     def _activate_tabified_dock(self, dock: QDockWidget):
@@ -304,6 +350,10 @@ class LayoutMixin:
         """Hides specific panel using QDockWidget"""
         if name == "results":
             self.results_dock.hide()
+            if hasattr(self, "summarize_dock"):
+                self.summarize_dock.hide()
+        elif name == "summarize" and hasattr(self, "summarize_dock"):
+            self.summarize_dock.hide()
         elif name == "output":
             self.output_dock.hide()
         elif name == "variables":
@@ -383,7 +433,13 @@ class LayoutMixin:
                 self._setup_default_layout()
 
             # Ensure all non-hidden docks are properly docked (not floating)
-            for dock in [self.connections_dock, self.results_dock, self.output_dock, self.variables_dock]:
+            for dock in [
+                self.connections_dock,
+                self.results_dock,
+                self.summarize_dock,
+                self.output_dock,
+                self.variables_dock,
+            ]:
                 if dock.isFloating() and dock.isVisible():
                     dock.setFloating(False)
 
@@ -412,7 +468,13 @@ class LayoutMixin:
         self._layout_save_timer.timeout.connect(self._save_dock_layout)
 
         # Connect dock visibility changes to schedule save
-        all_docks = [self.connections_dock, self.results_dock, self.output_dock, self.variables_dock]
+        all_docks = [
+            self.connections_dock,
+            self.results_dock,
+            self.summarize_dock,
+            self.output_dock,
+            self.variables_dock,
+        ]
         if hasattr(self, "object_explorer_dock"):
             all_docks.append(self.object_explorer_dock)
         if hasattr(self, "copilot_dock"):
@@ -442,7 +504,13 @@ class LayoutMixin:
     def _setup_default_layout(self):
         """Configures the default dock layout."""
         try:
-            all_docks = [self.connections_dock, self.results_dock, self.output_dock, self.variables_dock]
+            all_docks = [
+                self.connections_dock,
+                self.results_dock,
+                self.summarize_dock,
+                self.output_dock,
+                self.variables_dock,
+            ]
             if hasattr(self, "object_explorer_dock"):
                 all_docks.append(self.object_explorer_dock)
             if hasattr(self, "copilot_dock"):
@@ -455,6 +523,7 @@ class LayoutMixin:
             # Position docks in their default areas
             self.addDockWidget(Qt.DockWidgetArea.LeftDockWidgetArea, self.connections_dock)
             self.addDockWidget(Qt.DockWidgetArea.BottomDockWidgetArea, self.results_dock)
+            self.addDockWidget(Qt.DockWidgetArea.BottomDockWidgetArea, self.summarize_dock)
             self.addDockWidget(Qt.DockWidgetArea.BottomDockWidgetArea, self.output_dock)
             self.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, self.variables_dock)
 
@@ -466,7 +535,8 @@ class LayoutMixin:
                 self.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, self.copilot_dock)
                 self.copilot_dock.hide()
 
-            # Tabify Results and Output (bottom tabs)
+            # Tabify Results, Summarize and Output (bottom tabs)
+            self.tabifyDockWidget(self.results_dock, self.summarize_dock)
             self.tabifyDockWidget(self.results_dock, self.output_dock)
             self.results_dock.raise_()
 
@@ -535,6 +605,7 @@ class LayoutMixin:
         dock_action_map = [
             ("connections_dock", "connections_action"),
             ("results_dock", "results_action"),
+            ("summarize_dock", "summarize_action"),
             ("output_dock", "output_action"),
             ("variables_dock", "variables_action"),
             ("object_explorer_dock", "object_explorer_action"),

--- a/source/src/ui/main_window/_ui_setup.py
+++ b/source/src/ui/main_window/_ui_setup.py
@@ -401,6 +401,14 @@ class UISetupMixin:
         panels_menu.addAction(results_action)
         self.results_action = results_action
 
+        # Summarize panel toggle
+        summarize_action = QAction(S.menu.panel_summarize, self)
+        summarize_action.setCheckable(True)
+        summarize_action.setChecked(True)
+        summarize_action.triggered.connect(lambda checked: self._toggle_panel_visibility("summarize", checked))
+        panels_menu.addAction(summarize_action)
+        self.summarize_action = summarize_action
+
         # Output panel toggle
         output_action = QAction(S.menu.panel_output, self)
         output_action.setCheckable(True)

--- a/tests/test_copilot_ux.py
+++ b/tests/test_copilot_ux.py
@@ -339,9 +339,8 @@ class TestCopilotChatWebViewApp:
         assert 'callBridge("requestClipboardPaste"' not in js
         assert "readClipboardImageJson" in js
         assert "callBridgeResult" in js
-        assert "requestComposerRepaint" in js
-        assert "syncAttachmentStrip" in js
         assert "forceComposerRepaint" in js
+        assert "syncAttachmentStrip" in js
 
     def test_app_exposes_runtime_update_functions(self, app_files):
         js = app_files["js"]

--- a/tests/test_results_viewer.py
+++ b/tests/test_results_viewer.py
@@ -606,6 +606,17 @@ class TestResultsViewerMultiTab:
         assert viewer._result_tabs.count() == 1
         assert viewer._result_tabs.tabText(0) == "green1"
 
+    def test_display_dataframes_renders_primary_with_secondary_tabs(self, viewer, qtbot):
+        """Primary tab must render even while secondary tabs prepare in parallel."""
+        first = pd.DataFrame({"a": [1, 2, 3]})
+        second = pd.DataFrame({"b": list(range(250))})
+        viewer.display_dataframes([("first", first), ("second", second)])
+
+        qtbot.waitUntil(lambda: viewer.model.rowCount() == len(first), timeout=5000)
+        assert viewer._result_tabs.currentIndex() == 0
+        assert viewer.table_view is viewer._primary_table_view
+        assert viewer.model.data(viewer.model.index(0, 0)) == "1"
+
     def test_display_dataframes_creates_n_tabs(self, viewer, df_a, df_b, df_c):
         """display_dataframes() with N items creates N tabs and shows the bar."""
         viewer.display_dataframes([
@@ -1609,5 +1620,33 @@ class TestSessionResultViewState:
         assert restored.result_view_state["column_formats"]["valor"]["decimals"] == 0
         assert restored.result_view_state["charts"]["configs"][0]["type"] == "bar"
 
+
+class TestResultsViewerGridPrepare:
+    """Tests for async grid preparation and cached model rendering."""
+
+    def test_prepare_grid_data_limits_display_rows(self):
+        from src.ui.components.results_viewer import prepare_grid_data
+
+        df = pd.DataFrame({"value": range(500)})
+        result = prepare_grid_data(df, {}, {}, limit=120)
+
+        assert result.prepared.filtered_row_count == 500
+        assert len(result.prepared.display_rows) == 120
+        assert result.prepared.limited is True
+
+    def test_large_grid_prepares_off_ui_thread(self, qtbot):
+        from src.ui.components.results_viewer import ResultsViewer
+
+        viewer = ResultsViewer()
+        qtbot.addWidget(viewer)
+        viewer.row_limit_spin.setValue(1500)
+
+        df = pd.DataFrame({"name": [f"row-{index}" for index in range(1800)], "value": range(1800)})
+        viewer.display_dataframe(df, "large_df")
+
+        qtbot.waitUntil(lambda: viewer.model.rowCount() == 1500, timeout=5000)
+        assert viewer.current_df is not None
+        assert len(viewer.current_df) == 1800
+        assert viewer.model.data(viewer.model.index(0, 0)) == "row-0"
 
 

--- a/tests/test_summarize_stats.py
+++ b/tests/test_summarize_stats.py
@@ -1,0 +1,97 @@
+"""Tests for grid selection summary stats."""
+
+import pandas as pd
+import pytest
+
+from src.ui.components.summarize_stats import build_selection_summary
+
+
+@pytest.fixture
+def sample_df():
+    return pd.DataFrame({
+        "amount": [10.0, 20.0, 30.0, 40.0],
+        "qty": [1, 2, 3, 4],
+        "region": ["North", "South", "North", "East"],
+        "note": ["a", "b", None, "a"],
+    })
+
+
+def test_empty_dataframe():
+    payload = build_selection_summary(pd.DataFrame(), [])
+    assert payload["subtitle"] == "no_data"
+    assert payload["columns"] == []
+
+
+def test_all_rows_when_no_selection(sample_df):
+    payload = build_selection_summary(sample_df, [])
+    assert payload["scope"] == "all"
+    assert payload["rows_selected"] == 4
+    assert payload["cols_selected"] == 4
+    assert len(payload["columns"]) == 4
+
+    amount = next(c for c in payload["columns"] if c["name"] == "amount")
+    assert amount["kind"] == "numeric"
+    assert amount["sum_raw"] == 100.0
+
+    region = next(c for c in payload["columns"] if c["name"] == "region")
+    assert region["kind"] == "text"
+    assert region["distinct"] == "3"
+    assert region["top"].startswith("North")
+
+
+def test_selection_subset(sample_df):
+    cells = [(0, 0), (1, 0), (0, 2), (1, 2)]
+    payload = build_selection_summary(sample_df, cells)
+    assert payload["scope"] == "selection"
+    assert payload["rows_selected"] == 2
+    assert payload["cols_selected"] == 2
+    assert payload["cells_selected"] == 4
+    assert len(payload["columns"]) == 2
+
+    amount = next(c for c in payload["columns"] if c["name"] == "amount")
+    assert amount["sum_raw"] == 30.0
+
+    region = next(c for c in payload["columns"] if c["name"] == "region")
+    assert region["top"].startswith("North")
+
+
+def test_grand_total_across_numeric_columns(sample_df):
+    cells = [(0, 0), (0, 1), (1, 0), (1, 1)]
+    payload = build_selection_summary(sample_df, cells)
+    assert payload["grand_total"] == 33.0
+    assert payload["aggregates"][4]["key"] == "sum"
+    assert payload["aggregates"][4]["value"] == "33.00"
+
+
+def test_numeric_hint_respected(sample_df):
+    payload = build_selection_summary(
+        sample_df,
+        [(0, 1), (1, 1), (2, 1), (3, 1)],
+        numeric_column_indices={1},
+    )
+    qty = payload["columns"][0]
+    assert qty["name"] == "qty"
+    assert qty["kind"] == "numeric"
+    assert qty["sum_raw"] == 10.0
+
+
+def test_scientific_notation_object_column():
+    df = pd.DataFrame({
+        "ValorBase": ["0.069734873671", "21.780000000000", "0.007369129005"],
+        "ValorComissao": ["0E-12", "0.087666856972", "8.710000000000"],
+    })
+    payload = build_selection_summary(df, [(0, 0), (1, 0), (2, 0), (0, 1), (1, 1), (2, 1)])
+    for name in ("ValorBase", "ValorComissao"):
+        col = next(c for c in payload["columns"] if c["name"] == name)
+        assert col["kind"] == "numeric", f"{name} should be numeric"
+    assert payload["grand_total"] is not None
+
+
+def test_column_format_applied(sample_df):
+    payload = build_selection_summary(
+        sample_df,
+        [],
+        column_formats={"amount": {"type": "currency", "prefix": "$ ", "decimals": 2}},
+    )
+    amount = next(c for c in payload["columns"] if c["name"] == "amount")
+    assert amount["sum"].startswith("$ ")


### PR DESCRIPTION
## Summary
- Adds a Summarize dock panel (View → Panels → Summarize) with **Summarize** and **Aggregate** tabs that update from results grid selection.
- Computes per-column stats (count, sum, avg, min, max, distinct, top value), Excel-style grand totals, and aggregate rows (ROWS, COLS, MEDIAN, COV, etc.) with column formatting from Results.
- Fixes multi-result primary tab not rendering (per-model grid prepare jobs), tab-switch stutter (grid view cache + debounced summarize refresh), and scientific-notation numeric detection (`0E-12`).

## Test plan
- [ ] Run multi-result query; confirm primary tab renders immediately without switching tabs.
- [ ] Select cells in Results; verify Summarize cards and Aggregate rows update.
- [ ] Select multiple numeric columns; verify grand total row.
- [ ] Toggle zoom controls on Summarize title row (85–130%).
- [ ] Column with scientific notation values shows as numeric in Summarize.
- [ ] `pytest tests/test_summarize_stats.py tests/test_results_viewer.py`