### PR TITLE
ci: require Conventional Commits for agents and improve release workflow

### DIFF
--- a/.cursor/rules/conventional-commits.mdc
+++ b/.cursor/rules/conventional-commits.mdc
@@ -1,0 +1,55 @@
+---
+description: Require Conventional Commits for all git commits and PR titles in DataPyn
+alwaysApply: true
+---
+
+# Conventional Commits (required)
+
+Every agent and human contributor **must** use [Conventional Commits](https://www.conventionalcommits.org/) in this repository.
+
+## Format
+
+```
+<type>(<scope>): <subject>
+```
+
+- **Language**: English only for commit messages and PR titles.
+- **Subject**: imperative mood, ≤50 characters, no trailing period.
+- **Body** (optional): explain what and why; separate from subject with a blank line.
+
+## Types that affect semver (CI release)
+
+| Type | Release |
+|------|---------|
+| `fix` | Patch (1.0.X) |
+| `feat` | Minor (1.X.0) |
+| `feat!` or footer `BREAKING CHANGE:` | Major (X.0.0) |
+
+Types that **do not** trigger a version bump: `docs`, `style`, `test`, `chore`, `ci`, `refactor`, `perf`, `build`, `revert`.
+
+## Scopes (prefer when relevant)
+
+`ui`, `editor`, `database`, `executor`, `services`, `workers`, `panels`, `copilot`, `settings`, `i18n`, `deps`, `installer`, `tests`, `ci`
+
+## Agent obligations
+
+1. **Before committing**: write the message as `type(scope): subject`, never free-form titles like `Improve grid performance` or `Delete file.txt`.
+2. **Before suggesting a PR title**: use the same format; squash-merge titles become the commit on `main` and drive python-semantic-release.
+3. **When the user asks to commit**: propose a conventional message; if the change is user-facing, prefer `feat` or `fix` over `chore`.
+4. **When creating commits for the user**: use conventional format in `git commit -m`.
+
+## Examples
+
+```
+feat(copilot): add image attachments to chat runtime
+fix(results): format epoch nanoseconds as datetime in grid
+ci(release): document manual force bump in PSR workflow
+chore(deps): bump uv lockfile
+```
+
+## Do not
+
+- `Improve Summarize panel` / `Make Monaco async` / `Update stuff`
+- Commits without a `type:` prefix on merges to `main` (release pipeline will skip with `no_release`)
+
+Full guide: `.github/git-commit-instructions.md`

--- a/.github/git-commit-instructions.md
+++ b/.github/git-commit-instructions.md
@@ -214,6 +214,12 @@ This project uses semantic-release for automatic versioning. Commits determine t
 
 Commits that don't trigger a release: `docs`, `style`, `test`, `chore`, `ci`, `refactor`
 
+**CI/CD (main branch):** after tests pass, `Continuous Delivery - PSR` runs python-semantic-release.
+If the merge/squash commit title is free-form (e.g. `Improve grid performance` or `Delete file.txt`),
+the workflow succeeds but **no version bump** occurs (`no_release`). Use a PR title / squash message
+starting with `feat:` or `fix:` when you expect a new MSI. Manual recovery: run the PSR workflow with
+`force: patch|minor|major` (not `rebuild_only`).
+
 ---
 
 ## Pre-Commit Checklist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,21 @@ on:
     types:
       - completed
   workflow_dispatch:
+    inputs:
+      rebuild_only:
+        description: "Rebuild MSI for the current pyproject.toml version (no version bump)"
+        required: false
+        type: boolean
+        default: false
+      force:
+        description: "Force a semver bump on manual run (patch, minor, or major). Ignored when rebuild_only is true."
+        required: false
+        type: choice
+        options:
+          - ""
+          - patch
+          - minor
+          - major
 
 # default: least privileged permissions across all jobs
 permissions:
@@ -39,7 +54,7 @@ jobs:
 
     steps:
       - name: Install SSH Client and add private key to ssh-agent
-        if: github.event_name != 'workflow_dispatch'
+        if: github.event_name != 'workflow_dispatch' || inputs.rebuild_only != true
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
@@ -50,7 +65,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || github.event.workflow_run.head_branch }}
-          ssh-key: ${{ github.event_name != 'workflow_dispatch' && secrets.ACTIONS_DEPLOY_KEY || '' }}
+          ssh-key: ${{ (github.event_name != 'workflow_dispatch' || inputs.rebuild_only != true) && secrets.ACTIONS_DEPLOY_KEY || '' }}
 
       - name: Setup | Force release branch to be at workflow sha
         if: github.event_name != 'workflow_dispatch'
@@ -59,16 +74,27 @@ jobs:
 
       - name: Action | Semantic Version Release
         id: release
-        if: github.event_name != 'workflow_dispatch'
+        if: github.event_name != 'workflow_dispatch' || inputs.rebuild_only != true
         uses: python-semantic-release/python-semantic-release@v10.5.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           git_committer_name: "github-actions"
           git_committer_email: "actions@users.noreply.github.com"
+          force: ${{ github.event_name == 'workflow_dispatch' && inputs.force || '' }}
 
-      - name: Manual | Read version from pyproject.toml
+      - name: Report | No semantic release (conventional commits required)
+        if: steps.release.outputs.released != 'true' && (github.event_name != 'workflow_dispatch' || inputs.rebuild_only != true)
+        run: |
+          echo "::notice::Semantic Release did not bump the version (released=false)."
+          echo "Commits on main since the last tag must use Conventional Commits, for example:"
+          echo "  feat: new feature (minor bump)"
+          echo "  fix: bug fix (patch bump)"
+          echo "Merge/squash titles like 'Improve grid performance' or 'Delete file.txt' do not trigger a release."
+          echo "To publish anyway, run this workflow manually with rebuild_only=false and force=patch|minor|major."
+
+      - name: Manual | Read version from pyproject.toml (rebuild MSI only)
         id: dry_run_version
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && inputs.rebuild_only == true
         run: |
           VERSION=$(grep '^version = ' pyproject.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
           if [ -z "$VERSION" ] || [ "$VERSION" = "0.0.0" ]; then
@@ -79,7 +105,7 @@ jobs:
           echo "released=true" >> "$GITHUB_OUTPUT"
           echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Manual release: version=$VERSION tag=v${VERSION}"
+          echo "Rebuild only: version=$VERSION tag=v${VERSION} (no bump)"
 
   build-windows-msi:
     needs: release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# Agent instructions (DataPyn)
+
+Instructions for AI agents (Cursor, Copilot, Claude, etc.) working in this repository.
+
+## Conventional Commits (mandatory)
+
+**All commits and PR titles must use Conventional Commits in English.**
+
+Format: `type(scope): subject`
+
+- `feat` — new feature (minor release on merge to `main`)
+- `fix` — bug fix (patch release)
+- `feat!` or `BREAKING CHANGE:` — major release
+- `chore`, `ci`, `docs`, `test`, `refactor`, etc. — no automatic version bump
+
+Free-form messages (e.g. `Improve grid performance`, `Delete file.txt`) cause the **Continuous Delivery - PSR** workflow to succeed without incrementing `pyproject.toml`.
+
+When committing or opening a PR:
+
+1. Pick the correct `type` and optional `scope`.
+2. Use imperative mood in the subject (`add`, `fix`, `remove`, not `added` / `fixes`).
+3. Align squash-merge PR titles with the same format so `main` receives a releasable commit.
+
+See `.github/git-commit-instructions.md` and `.cursor/rules/conventional-commits.mdc` for details and scopes.
+
+## Releases
+
+After tests pass on `main`, python-semantic-release bumps the version and builds the Windows MSI. Manual recovery: GitHub Actions → **Continuous Delivery - PSR** → `force: patch|minor|major` (with `rebuild_only: false`).
+
+## Project
+
+- Python 3.12+, PyQt6, `uv` for dependencies
+- Run tests: `uv run pytest` (see `pytest.ini` for CI ignores)


### PR DESCRIPTION
## Summary

- Add `.cursor/rules/conventional-commits.mdc` (`alwaysApply: true`) so every Cursor agent must use Conventional Commits in English.
- Add root `AGENTS.md` with the same requirement for any AI tooling in the repo.
- Extend `.github/git-commit-instructions.md` with CI/CD / semantic-release notes.
- Improve **Continuous Delivery - PSR**: manual `force` bump, `rebuild_only` MSI mode, clearer log when `no_release`.

## Why

Recent merges to `main` used free-form titles (e.g. `Delete file.txt`, `Improve grid performance`), so python-semantic-release correctly skipped version bumps while the pipeline still looked green.

## Test plan

- [ ] Merge with squash title `ci: ...` (this PR title).
- [ ] Confirm Cursor picks up `.cursor/rules/conventional-commits.mdc`.
- [ ] After merge, optional: run PSR with `force: patch` if pending changes need a release before the next `feat`/`fix` PR.