### PR TITLE
docs(agents): add Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,28 @@ After tests pass on `main`, python-semantic-release bumps the version and builds
 
 - Python 3.12+, PyQt6, `uv` for dependencies
 - Run tests: `uv run pytest` (see `pytest.ini` for CI ignores)
+
+## Cursor Cloud specific instructions
+
+DataPyn is a **single-process PyQt6 desktop IDE** (no separate API server or Docker stack). The update script only runs `uv sync --dev`; Linux **system packages** are not installed automatically on each VM start.
+
+### Linux system dependencies
+
+On Ubuntu/Debian, match CI (`.github/workflows/tests.yml`) or run `./scripts/linux/install.sh` once per VM: Qt/XCB/OpenGL libs, `libmariadb-dev`, `freeglut3-dev`, `xvfb` (optional, for headless GUI tests). Without these, `uv sync` may succeed but PyQt/WebEngine tests or the app can fail at runtime.
+
+### Running the app
+
+- Dev: `uv run python source/main.py` (needs `DISPLAY`; Cloud VMs usually have `:1`).
+- WebEngine: set `QTWEBENGINE_DISABLE_SANDBOX=1` and `QTWEBENGINE_CHROMIUM_FLAGS=--no-sandbox` if Chromium sandbox errors appear.
+- Optional: `./scripts/linux/run.sh` after install.
+
+### Tests and lint
+
+- Lint: `uv run ruff check source/` (tests are excluded in `pyproject.toml`).
+- **CI-like pytest** (headless, ignores QWebEngine-heavy modules): use the same `--ignore=…` list as `.github/workflows/tests.yml`, plus env `QT_QPA_PLATFORM=offscreen`, `QTWEBENGINE_DISABLE_SANDBOX=1`, `QTWEBENGINE_CHROMIUM_FLAGS=--no-sandbox`.
+- **Full GUI tests** (`tests/test_gui.py`, etc.): need a real display (`DISPLAY=:1`) and the WebEngine env vars above; do not force `QT_QPA_PLATFORM=offscreen` for those.
+- `pytest.ini` sets `QT_QPA_PLATFORM=offscreen` by default; override in the shell when running GUI tests with a display.
+
+### External services (optional)
+
+Live databases, GitHub Copilot (`gh` auth), and GitHub Releases (auto-update) are **not** required for the default test suite. No in-repo database container is provided.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a **Cursor Cloud specific instructions** section to `AGENTS.md` documenting:

- Linux system packages required beyond `uv sync`
- How to run the PyQt6 app and WebEngine sandbox env vars on cloud VMs
- CI-like vs full GUI pytest differences (`QT_QPA_PLATFORM`, `--ignore` list)
- Optional external services (DBs, Copilot, auto-update)

No application code changes. VM update script remains `uv sync --dev`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5079f7e8-586e-493d-ba7d-19d84e4d1c49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5079f7e8-586e-493d-ba7d-19d84e4d1c49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

