### PR TITLE
fix(execution): run SQL for current editor selection, not stale cache

### DIFF
--- a/source/src/editors/block_editor.py
+++ b/source/src/editors/block_editor.py
@@ -230,18 +230,17 @@ class BlockEditor(QWidget):
         - If no selection: runs focused block
         """
         if self._focused_block:
+            editor = getattr(self._focused_block, "editor", None)
+            if editor is not None and hasattr(editor, "request_execute"):
+                editor.request_execute()
+                return
             has_sel = self._focused_block.has_selection()
-            print(f"[BlockEditor] _execute_smart: has_selection={has_sel}")
             if has_sel:
-                # Run selection
                 code = self._focused_block.get_selected_text()
-                print(f"[BlockEditor] Running selected text ({len(code)} chars): {code[:50]!r}...")
                 lang = self._focused_block.get_language()
                 self._execute_code(code, lang, self._focused_block)
                 return
-        
-        # Run focused block
-        print("[BlockEditor] Running full block (no selection)")
+
         self._execute_block(self._focused_block or (self._blocks[0] if self._blocks else None))
 
     def _execute_focused_and_advance(self):
@@ -272,6 +271,7 @@ class BlockEditor(QWidget):
 
     def _execute_code(self, code: str, language: str, block: CodeBlock):
         """Emit appropriate execution signal"""
+        self._current_executing_block = block
         block.set_running(True)
 
         if language == "sql":

--- a/source/src/editors/code_block.py
+++ b/source/src/editors/code_block.py
@@ -900,6 +900,8 @@ class CodeBlock(QFrame):
         """Handle run button click - execute or cancel depending on state"""
         if self._is_running:
             self.cancel_requested.emit(self)
+        elif hasattr(self.editor, "request_execute"):
+            self.editor.request_execute()
         else:
             self.execute_requested.emit(self, "")
 

--- a/source/src/editors/monaco/monaco_editor.py
+++ b/source/src/editors/monaco/monaco_editor.py
@@ -443,6 +443,13 @@ class MonacoEditor(QWidget):
         """Force trigger an inline completion request (Ctrl+. shortcut)."""
         self._run_js_when_ready("forceRequestCompletion()")
     
+    def request_execute(self) -> None:
+        """Run the current selection (or full block) using live Monaco selection."""
+        if self._is_ready:
+            self._run_js("triggerExecute()")
+        else:
+            self.execute_requested.emit(self.get_selected_text())
+
     def get_selected_text(self) -> str:
         """Returns selected text from the latest JS selection snapshot."""
         return self._selected_text_cache

--- a/source/src/editors/monaco/monaco_template.html
+++ b/source/src/editors/monaco/monaco_template.html
@@ -284,11 +284,7 @@
                     monaco.KeyMod.Shift | monaco.KeyCode.Enter
                 ],
                 run: function() {
-                    if (pyBridge) {
-                        // Pass selected text so Python doesn't need async round-trip
-                        var selectedText = getSelectedText();
-                        pyBridge.onExecuteRequested(selectedText);
-                    }
+                    triggerExecute();
                 }
             });
             
@@ -731,6 +727,14 @@
                 return editor.getModel().getValueInRange(editor.getSelection());
             }
             return '';
+        }
+
+        /** Read selection at execute time (avoids stale Python cache). */
+        function triggerExecute() {
+            if (!pyBridge || !pyBridge.onExecuteRequested) {
+                return;
+            }
+            pyBridge.onExecuteRequested(getSelectedText());
         }
         
         function hasSelection() {

--- a/source/src/ui/components/session_widget.py
+++ b/source/src/ui/components/session_widget.py
@@ -221,6 +221,7 @@ class SessionWidget(QWidget):
         self._current_block_index: Optional[int] = None
         self._current_connection_name_exec: str = ""
         self._current_database_name_exec: str = ""
+        self._sql_execution_token: int = 0
 
         # Overlay de loading
         self._loading_overlay: Optional[QLabel] = None
@@ -911,6 +912,8 @@ class SessionWidget(QWidget):
 
         self._is_executing = True
         self._cancel_requested = False  # Limpar flag de cancelamento anterior
+        self._sql_execution_token += 1
+        execution_token = self._sql_execution_token
 
         # Reset notification counters for single-block execution
         if self._queue_blocks_done == 0:
@@ -925,7 +928,7 @@ class SessionWidget(QWidget):
         self.execution_started.emit()  # Notify main_window to show running indicator
         block = self._get_active_execution_block()
         if block is not None:
-            block.set_running(True)
+            self.editor.mark_block_started(block)
 
         # Track execution context for structured logs
         self._execution_start_time = time.time()
@@ -933,6 +936,12 @@ class SessionWidget(QWidget):
         self._current_block_index = self.editor.get_current_block_index()
         self._current_connection_name_exec = connection_name or self.session.connection_name or ""
         self._current_database_name_exec = database_name or ""
+
+        if self._sql_worker:
+            try:
+                self._sql_worker.finished.disconnect()
+            except (TypeError, RuntimeError):
+                pass
 
         # Criar worker e thread
         self._sql_thread = QThread()
@@ -955,7 +964,23 @@ class SessionWidget(QWidget):
 
         # Conectar sinais
         self._sql_thread.started.connect(self._sql_worker.run)
-        self._sql_worker.finished.connect(self._on_sql_finished)
+        token = execution_token
+
+        def _sql_finished_handler(df, err, _token=token):
+            if _token != self._sql_execution_token:
+                if self._sql_thread:
+                    thread = self._sql_thread
+                    self._sql_thread = None
+                    try:
+                        self.session.unregister_thread(thread)
+                    except Exception:
+                        pass
+                    thread.quit()
+                    thread.deleteLater()
+                return
+            self._on_sql_finished(df, err)
+
+        self._sql_worker.finished.connect(_sql_finished_handler)
 
         # Iniciar
         self._sql_thread.start()

--- a/tests/test_sql_selection_execute.py
+++ b/tests/test_sql_selection_execute.py
@@ -1,0 +1,55 @@
+"""Regression: SQL selection execute must use live editor selection, not stale cache."""
+
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from src.editors.block_editor import BlockEditor
+
+
+def test_execute_smart_uses_monaco_request_execute(qtbot):
+    editor = BlockEditor()
+    qtbot.addWidget(editor)
+
+    block = MagicMock()
+    monaco = MagicMock()
+    monaco.request_execute = MagicMock()
+    block.editor = monaco
+    block.has_selection.return_value = True
+    block.get_selected_text.return_value = "stale selection"
+    block.get_language.return_value = "sql"
+
+    editor._focused_block = block
+    editor._execute_smart()
+
+    monaco.request_execute.assert_called_once()
+    block.get_selected_text.assert_not_called()
+
+
+def test_run_button_uses_request_execute(qtbot):
+    from src.editors.code_block import CodeBlock
+
+    block = CodeBlock.__new__(CodeBlock)
+    block._is_running = False
+    block.editor = MagicMock()
+    block.editor.request_execute = MagicMock()
+    block.cancel_requested = MagicMock()
+    block.execute_requested = MagicMock()
+
+    block._on_run_btn_clicked()
+
+    block.editor.request_execute.assert_called_once()
+    block.execute_requested.emit.assert_not_called()
+
+
+def test_monaco_request_execute_runs_trigger_js(qtbot):
+    from src.editors.monaco.monaco_editor import MonacoEditor
+
+    monaco = MonacoEditor()
+    qtbot.addWidget(monaco)
+    monaco._is_ready = True
+    monaco._run_js = MagicMock()
+
+    monaco.request_execute()
+
+    monaco._run_js.assert_called_once_with("triggerExecute()")

--- a/uv.lock
+++ b/uv.lock
@@ -468,7 +468,7 @@ wheels = [
 
 [[package]]
 name = "datapyn"
-version = "1.35.1"
+version = "1.36.1"
 source = { virtual = "." }
 dependencies = [
     { name = "azure-identity" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In a block with multiple SQL statements, selecting the second query and executing (F5 or Run) sometimes showed the **previous** query's result. Running again showed the correct result.

## Root cause

1. **Stale selection cache** — `BlockEditor._execute_smart()` (F5 when focus is on the block container) and the block **Run** button used `get_selected_text()` from a cached snapshot updated asynchronously by Monaco. Changing selection and executing quickly could still run the **old** selection.

2. **Late SQL callbacks** — A finished worker could still update the results grid after a newer execution started (defensive fix with execution token).

## Fix

- `triggerExecute()` in Monaco reads `getSelection()` at execute time and passes it to Python.
- `MonacoEditor.request_execute()` — used by F5 (`_execute_smart`) and the Run button.
- SQL execution token — ignore outdated `finished` callbacks.
- `mark_block_started()` when SQL starts so the correct block is tracked.

## Testing

`uv run pytest tests/test_sql_selection_execute.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9f9eae1-885b-4aad-afd3-d3e492b50e03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9f9eae1-885b-4aad-afd3-d3e492b50e03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

