### PR TITLE
feat(installer): replace MSI with ZIP setup and in-app updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       rebuild_only:
-        description: "Rebuild MSI for the current pyproject.toml version (no version bump)"
+        description: "Rebuild Windows artifacts for the current pyproject.toml version (no version bump)"
         required: false
         type: boolean
         default: false
@@ -119,10 +119,10 @@ jobs:
           echo "  feat: new feature (minor bump)"
           echo "  fix: bug fix (patch bump)"
           echo "Free-form subjects like 'Improve grid performance' are mapped by scripts/datapyn_commit_parser.py."
-          echo "Pure ci:/docs:/chore: merges may still skip MSI unless fallback patch applies."
+          echo "Pure ci:/docs:/chore: merges may still skip artifacts unless fallback patch applies."
           echo "Manual recovery: Actions → Continuous Delivery - PSR → force: patch|minor|major"
 
-      - name: Manual | Read version from pyproject.toml (rebuild MSI only)
+      - name: Manual | Read version from pyproject.toml (rebuild only)
         id: dry_run_version
         if: github.event_name == 'workflow_dispatch' && inputs.rebuild_only == true
         run: |
@@ -137,21 +137,20 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Rebuild only: version=$VERSION tag=v${VERSION} (no bump)"
 
-  # Automatic runs that only merge ci:/chore:/docs: succeed the release job but skip MSI.
-  # Fail the workflow so "green" does not look like a published installer.
-  verify-msi-published:
+  # Automatic runs that only merge ci:/chore:/docs: succeed the release job but skip artifacts.
+  verify-release-published:
     needs: release
     if: github.event_name == 'workflow_run' && needs.release.outputs.released != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Fail when no release was published
         run: |
-          echo "::error::MSI was not built: semantic-release and fallback patch both returned released=false."
+          echo "::error::Windows artifacts were not built: semantic-release returned released=false."
           echo "Check commits since the last tag and scripts/datapyn_commit_parser.py heuristics."
           echo "Manual recovery: Actions → Continuous Delivery - PSR → force: patch|minor|major"
           exit 1
 
-  build-windows-msi:
+  build-windows-release:
     needs: release
     if: needs.release.outputs.released == 'true'
     runs-on: windows-latest
@@ -178,124 +177,37 @@ jobs:
       - name: Setup | Install Dependencies
         run: uv sync --dev
 
-      - name: Build | Generate Windows EXE
+      - name: Build | Generate Windows application bundle
         run: uv run pyinstaller scripts/datapyn.spec --clean
 
-      - name: Build | Copy Installer Assets
+      - name: Build | Package ZIP artifact
         shell: pwsh
         run: |
-          # Pre-generated BMPs with DataPyn logo are committed in scripts/
-          # installer_dialog.bmp (493x312) - Welcome/finish dialog left panel
-          # installer_banner.bmp (493x58) - Top banner on intermediate pages
-          New-Item -ItemType Directory -Path "dist\scripts" -Force | Out-Null
-          Copy-Item "scripts\installer_dialog.bmp" "dist\scripts\" -Force
-          Copy-Item "scripts\installer_banner.bmp" "dist\scripts\" -Force
-          Copy-Item "scripts\license.rtf" "dist\scripts\" -Force
-          Write-Host "Installer assets copied successfully"
+          $version = "${{ needs.release.outputs.version }}"
+          $zipName = "DataPyn-${version}-windows.zip"
+          if (Test-Path $zipName) { Remove-Item $zipName -Force }
+          Compress-Archive -Path "dist\DataPyn" -DestinationPath $zipName -CompressionLevel Optimal
+          Write-Host "Created $zipName ($((Get-Item $zipName).Length / 1MB) MB)"
 
-      - name: Build | Create MSI Installer
+      - name: Build | Generate DataPyn-Setup.exe
+        run: uv run pyinstaller installer/datapyn_setup.spec --clean
+
+      - name: Build | Rename setup executable
         shell: pwsh
         run: |
-          $rawVersion = "${{ needs.release.outputs.version }}"
-          # MSI requires version format x.x.x.x (integers only)
-          # Remove any suffix like -dryrun, -alpha, -beta, etc.
-          $version = $rawVersion -replace '-.*$', ''
-          # Ensure at least 3 parts (add .0 if needed)
-          $parts = $version.Split('.')
-          while ($parts.Count -lt 3) { $parts += '0' }
-          $version = ($parts[0..2] -join '.') + '.0'
-          Write-Host "MSI version: $version (from $rawVersion)"
-          
-          $sourceDir = "dist\DataPyn"
+          $version = "${{ needs.release.outputs.version }}"
+          Move-Item -Force "dist\DataPyn-Setup.exe" "DataPyn-Setup-${version}.exe"
+          Copy-Item "DataPyn-Setup-${version}.exe" "DataPyn-Setup.exe"
+          Write-Host "Setup executables ready"
 
-          # Find WiX bin directory (env:WIX on older runners, or well-known path)
-          $wixBin = if ($env:WIX) { "${env:WIX}bin\" } else {
-            $found = Get-ChildItem -Path "C:\Program Files (x86)\WiX*" -Directory -ErrorAction SilentlyContinue |
-                     Sort-Object Name -Descending | Select-Object -First 1
-            if ($found) { "$($found.FullName)\bin\" }
-            else { throw "WiX Toolset not found. Set WIX env var or install WiX 3.x." }
-          }
-          Write-Host "WiX bin: $wixBin"
-
-          # Harvest all files from PyInstaller output
-          # -sreg: suppress SelfReg warnings (not applicable to PyInstaller output)
-          # Exclude documentation, test files, and other unnecessary content via XSLT transform
-          # Filtered patterns: .md, .txt, .rst, .log, .pyc, .pyo, __pycache__, README, LICENSE, CHANGELOG
-          & "${wixBin}heat.exe" dir "$sourceDir" `
-            -cg AppFiles -dr INSTALLFOLDER `
-            -gg -sfrag -srd -sreg `
-            -var var.SourceDir `
-            -out heat.wxs `
-            -t:scripts\exclude_docs.xslt
-
-          # Compile WXS sources
-          & "${wixBin}candle.exe" `
-            -dSourceDir="$sourceDir" `
-            -dProductVersion="$version" `
-            scripts\installer.wxs heat.wxs
-
-          # Link into MSI
-          # Suppress ICE validations that are expected/acceptable for per-user PyInstaller bundles:
-          # -sice:ICE38 - Components in user profile should use registry KeyPath (not applicable for heat-generated files)
-          # -sice:ICE60 - Files should have language specified (not applicable for PyInstaller DLLs)
-          # -sice:ICE64 - Directories need RemoveFile entries (handled by Windows Installer)
-          # -sice:ICE91 - Files in per-user folder won't copy to all users (expected behavior)
-          & "${wixBin}light.exe" `
-            -ext WixUIExtension `
-            -spdb `
-            -sice:ICE38 -sice:ICE60 -sice:ICE64 -sice:ICE91 `
-            installer.wixobj heat.wixobj `
-            -o "DataPyn-${rawVersion}-windows.msi"
-
-      # Optional: Sign the MSI if a code signing certificate is configured
-      # To use this, add these secrets to your GitHub repository:
-      # - CODE_SIGNING_CERT_BASE64: Base64-encoded PFX certificate
-      # - CODE_SIGNING_CERT_PASSWORD: Password for the PFX file
-      - name: Build | Sign MSI (if certificate available)
-        if: ${{ env.HAS_CODE_SIGNING_CERT == 'true' }}
-        env:
-          HAS_CODE_SIGNING_CERT: ${{ secrets.CODE_SIGNING_CERT_BASE64 != '' }}
-          CODE_SIGNING_CERT_BASE64: ${{ secrets.CODE_SIGNING_CERT_BASE64 }}
-          CODE_SIGNING_CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CERT_PASSWORD }}
-        shell: pwsh
-        run: |
-          $rawVersion = "${{ needs.release.outputs.version }}"
-          $msiPath = "DataPyn-${rawVersion}-windows.msi"
-          
-          # Decode certificate from base64
-          $certBytes = [Convert]::FromBase64String($env:CODE_SIGNING_CERT_BASE64)
-          $certPath = "codesigning.pfx"
-          [IO.File]::WriteAllBytes($certPath, $certBytes)
-          
-          # Find signtool.exe
-          $signtool = Get-ChildItem -Path "${env:ProgramFiles(x86)}\Windows Kits" -Recurse -Filter signtool.exe | 
-                      Where-Object { $_.FullName -like "*x64*" } | 
-                      Select-Object -First 1 -ExpandProperty FullName
-          
-          if ($signtool) {
-            Write-Host "Signing MSI with signtool..."
-            & $signtool sign /f $certPath /p $env:CODE_SIGNING_CERT_PASSWORD `
-              /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 `
-              /d "DataPyn" /du "https://github.com/datapyn/datapyn" `
-              $msiPath
-            
-            if ($LASTEXITCODE -eq 0) {
-              Write-Host "MSI signed successfully!"
-            } else {
-              Write-Warning "Failed to sign MSI, continuing with unsigned installer"
-            }
-          } else {
-            Write-Warning "signtool.exe not found, skipping signing"
-          }
-          
-          # Clean up certificate file
-          Remove-Item -Path $certPath -Force -ErrorAction SilentlyContinue
-
-      - name: Publish | Upload MSI to GitHub Release
+      - name: Publish | Upload artifacts to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.release.outputs.tag }}
-          files: DataPyn-${{ needs.release.outputs.version }}-windows.msi
+          files: |
+            DataPyn-${{ needs.release.outputs.version }}-windows.zip
+            DataPyn-Setup-${{ needs.release.outputs.version }}.exe
+            DataPyn-Setup.exe
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ O projeto usa [uv](https://docs.astral.sh/uv/) como gerenciador de dependencias.
 
 ### Windows
 
+**End users:** download `DataPyn-Setup.exe` from [GitHub Releases](https://github.com/natharuc/datapyn/releases/latest). The setup wizard installs the latest build under `%LOCALAPPDATA%\DataPyn` and creates Start Menu / Desktop shortcuts.
+
+**Developers:**
+
 ```powershell
 git clone https://github.com/natharuc/datapyn.git
 cd datapyn
@@ -124,6 +128,8 @@ scripts\run.bat
 uv sync
 uv run python source/main.py
 ```
+
+Build the setup helper locally: `uv run pyinstaller installer/datapyn_setup.spec --clean`
 
 ### Linux (Ubuntu/Debian)
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,0 +1,29 @@
+# DataPyn Setup (Windows)
+
+Lightweight GUI installer that downloads the latest **ZIP** artifact from GitHub Releases.
+
+## Build
+
+```powershell
+uv sync --dev
+uv run pyinstaller installer/datapyn_setup.spec --clean
+# Output: dist/DataPyn-Setup.exe
+```
+
+## Usage
+
+| Command | Description |
+|---------|-------------|
+| `DataPyn-Setup.exe` | Fresh install (default `%LOCALAPPDATA%\DataPyn`) |
+| `DataPyn-Setup.exe --update <zip> --version 1.2.3 --dir <path>` | Silent upgrade from downloaded ZIP |
+| `DataPyn-Setup.exe --uninstall` | Remove install dir, shortcuts, registry |
+
+## Release artifacts
+
+CI publishes:
+
+- `DataPyn-{version}-windows.zip` — PyInstaller folder
+- `DataPyn-Setup.exe` — version-agnostic bootstrap (always fetches latest)
+- `DataPyn-Setup-{version}.exe` — pinned to that release
+
+The desktop app auto-update downloads the ZIP and applies it on exit.

--- a/installer/_bootstrap.py
+++ b/installer/_bootstrap.py
@@ -1,0 +1,30 @@
+"""Load windows_installer without importing src.services (avoids pandas, PyQt WebEngine, etc.)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _module_path() -> Path:
+    if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
+        return Path(sys._MEIPASS) / "src" / "services" / "windows_installer.py"
+    root = Path(__file__).resolve().parents[1]
+    return root / "source" / "src" / "services" / "windows_installer.py"
+
+
+def load_windows_installer() -> ModuleType:
+    path = _module_path()
+    if not path.is_file():
+        raise FileNotFoundError(f"windows_installer.py not found: {path}")
+
+    spec = importlib.util.spec_from_file_location("datapyn_windows_installer", path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load installer module from {path}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["datapyn_windows_installer"] = module
+    spec.loader.exec_module(module)
+    return module

--- a/installer/datapyn_setup.spec
+++ b/installer/datapyn_setup.spec
@@ -1,0 +1,46 @@
+# -*- mode: python ; coding: utf-8 -*-
+# Build: uv run pyinstaller installer/datapyn_setup.spec --clean
+
+import os
+
+ROOT = os.path.abspath(os.path.join(SPEC, "..", ".."))
+
+a = Analysis(
+    [os.path.join(ROOT, "installer", "main.py")],
+    pathex=[os.path.join(ROOT, "source")],
+    binaries=[],
+    datas=[
+        (os.path.join(ROOT, "source", "src", "assets", "datapyn_logo.svg"), "assets"),
+    ],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=["matplotlib", "pandas", "numpy", "PyQt6.QtWebEngineWidgets"],
+    noarchive=False,
+    optimize=0,
+)
+
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name="DataPyn-Setup",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=os.path.join(ROOT, "source", "src", "assets", "datapyn-logo.ico"),
+)

--- a/installer/datapyn_setup.spec
+++ b/installer/datapyn_setup.spec
@@ -7,12 +7,16 @@ ROOT = os.path.abspath(os.path.join(SPEC, "..", ".."))
 
 a = Analysis(
     [os.path.join(ROOT, "installer", "main.py")],
-    pathex=[os.path.join(ROOT, "source")],
     binaries=[],
     datas=[
         (os.path.join(ROOT, "source", "src", "assets", "datapyn_logo.svg"), "assets"),
+        (
+            os.path.join(ROOT, "source", "src", "services", "windows_installer.py"),
+            os.path.join("src", "services"),
+        ),
     ],
-    hiddenimports=[],
+    hiddenimports=["_bootstrap", "datapyn_windows_installer", "PyQt6.QtSvg"],
+    pathex=[os.path.join(ROOT, "source"), os.path.join(ROOT, "installer")],
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],

--- a/installer/main.py
+++ b/installer/main.py
@@ -1,0 +1,267 @@
+"""
+DataPyn Setup — lightweight Windows installer (downloads latest release ZIP).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "source"))
+
+from PyQt6.QtCore import Qt, QThread, pyqtSignal
+from PyQt6.QtGui import QFont, QIcon
+from PyQt6.QtWidgets import (
+    QApplication,
+    QHBoxLayout,
+    QLabel,
+    QMainWindow,
+    QMessageBox,
+    QProgressBar,
+    QPushButton,
+    QStackedWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.services import windows_installer as wi
+
+
+class InstallWorker(QThread):
+    progress = pyqtSignal(int, str)
+    finished_ok = pyqtSignal(str, str)  # exe path, version
+    failed = pyqtSignal(str)
+
+    def __init__(self, install_dir: Path, mode: str, zip_path: Path | None, version: str):
+        super().__init__()
+        self.install_dir = install_dir
+        self.mode = mode
+        self.zip_path = zip_path
+        self.version = version
+
+    def run(self):
+        try:
+            def on_progress(pct: int, msg: str):
+                self.progress.emit(pct, msg)
+
+            if self.mode == "update" and self.zip_path:
+                exe = wi.install_from_zip(
+                    self.zip_path, self.install_dir, self.version, on_progress=on_progress
+                )
+                self.finished_ok.emit(str(exe), self.version)
+                return
+
+            exe, release = wi.install_latest_release(self.install_dir, on_progress=on_progress)
+            self.finished_ok.emit(str(exe), release.version)
+        except Exception as exc:
+            self.failed.emit(str(exc))
+
+
+class SetupWindow(QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("DataPyn Setup")
+        self.setFixedSize(520, 420)
+        self._install_dir = wi.DEFAULT_INSTALL_DIR
+        self._worker: InstallWorker | None = None
+        self._exe_path: str | None = None
+
+        logo_path = ROOT / "source" / "src" / "assets" / "datapyn_logo.svg"
+        if logo_path.exists():
+            self.setWindowIcon(QIcon(str(logo_path)))
+
+        self._stack = QStackedWidget()
+        self.setCentralWidget(self._stack)
+        self._stack.addWidget(self._page_welcome())
+        self._stack.addWidget(self._page_progress())
+        self._stack.addWidget(self._page_done())
+        self._apply_theme()
+
+    def _apply_theme(self):
+        self.setStyleSheet(
+            """
+            QMainWindow { background: #0c111b; }
+            QLabel { color: #eef2f7; }
+            QLabel#muted { color: #8b9cb3; font-size: 12px; }
+            QLabel#title { font-size: 22px; font-weight: 600; }
+            QPushButton {
+                background: #3369ff;
+                color: white;
+                border: none;
+                border-radius: 8px;
+                padding: 10px 20px;
+                font-weight: 600;
+            }
+            QPushButton:hover { background: #4f80ff; }
+            QPushButton#ghost {
+                background: transparent;
+                color: #8b9cb3;
+                border: 1px solid rgba(148,163,184,0.25);
+            }
+            QPushButton#ghost:hover { color: #eef2f7; border-color: #3369ff; }
+            QProgressBar {
+                border: none;
+                border-radius: 6px;
+                background: #161f30;
+                height: 10px;
+                text-align: center;
+                color: #8b9cb3;
+            }
+            QProgressBar::chunk {
+                border-radius: 6px;
+                background: qlineargradient(x1:0, y1:0, x2:1, y2:0,
+                    stop:0 #3369ff, stop:1 #33c2ff);
+            }
+            """
+        )
+
+    def _page_welcome(self) -> QWidget:
+        page = QWidget()
+        layout = QVBoxLayout(page)
+        layout.setContentsMargins(32, 28, 32, 28)
+        layout.setSpacing(12)
+
+        title = QLabel("Install DataPyn")
+        title.setObjectName("title")
+        layout.addWidget(title)
+
+        subtitle = QLabel(
+            "Downloads the latest release from GitHub, installs for your user "
+            f"({self._install_dir}) and creates shortcuts."
+        )
+        subtitle.setWordWrap(True)
+        subtitle.setObjectName("muted")
+        layout.addWidget(subtitle)
+
+        existing = wi.read_installed_version()
+        if existing:
+            hint = QLabel(f"Installed version: {existing}. Setup will upgrade to the latest release.")
+            hint.setWordWrap(True)
+            hint.setObjectName("muted")
+            layout.addWidget(hint)
+
+        layout.addStretch()
+
+        row = QHBoxLayout()
+        row.addStretch()
+        cancel = QPushButton("Cancel")
+        cancel.setObjectName("ghost")
+        cancel.clicked.connect(self.close)
+        row.addWidget(cancel)
+        install = QPushButton("Install")
+        install.clicked.connect(self._start_install)
+        row.addWidget(install)
+        layout.addLayout(row)
+        return page
+
+    def _page_progress(self) -> QWidget:
+        page = QWidget()
+        layout = QVBoxLayout(page)
+        layout.setContentsMargins(32, 28, 32, 28)
+        layout.setSpacing(16)
+
+        self._progress_title = QLabel("Downloading…")
+        self._progress_title.setObjectName("title")
+        layout.addWidget(self._progress_title)
+
+        self._progress_status = QLabel("Connecting to GitHub…")
+        self._progress_status.setObjectName("muted")
+        self._progress_status.setWordWrap(True)
+        layout.addWidget(self._progress_status)
+
+        self._progress_bar = QProgressBar()
+        self._progress_bar.setRange(0, 100)
+        layout.addWidget(self._progress_bar)
+        layout.addStretch()
+        return page
+
+    def _page_done(self) -> QWidget:
+        page = QWidget()
+        layout = QVBoxLayout(page)
+        layout.setContentsMargins(32, 28, 32, 28)
+        layout.setSpacing(12)
+
+        done_title = QLabel("DataPyn is ready")
+        done_title.setObjectName("title")
+        layout.addWidget(done_title)
+
+        self._done_label = QLabel("")
+        self._done_label.setWordWrap(True)
+        self._done_label.setObjectName("muted")
+        layout.addWidget(self._done_label)
+        layout.addStretch()
+
+        row = QHBoxLayout()
+        row.addStretch()
+        close_btn = QPushButton("Close")
+        close_btn.setObjectName("ghost")
+        close_btn.clicked.connect(self.close)
+        row.addWidget(close_btn)
+        self._launch_btn = QPushButton("Open DataPyn")
+        self._launch_btn.clicked.connect(self._launch_app)
+        row.addWidget(self._launch_btn)
+        layout.addLayout(row)
+        return page
+
+    def _start_install(self):
+        self._stack.setCurrentIndex(1)
+        self._worker = InstallWorker(self._install_dir, "install", None, "")
+        self._worker.progress.connect(self._on_progress)
+        self._worker.finished_ok.connect(self._on_success)
+        self._worker.failed.connect(self._on_failed)
+        self._worker.start()
+
+    def _on_progress(self, pct: int, msg: str):
+        self._progress_bar.setValue(pct)
+        self._progress_status.setText(msg)
+        if pct < 30:
+            self._progress_title.setText("Downloading…")
+        elif pct < 70:
+            self._progress_title.setText("Installing…")
+        else:
+            self._progress_title.setText("Finishing…")
+
+    def _on_success(self, exe_path: str, version: str):
+        self._exe_path = exe_path
+        self._done_label.setText(f"Version {version} installed at:\n{Path(exe_path).parent}")
+        self._stack.setCurrentIndex(2)
+
+    def _on_failed(self, message: str):
+        QMessageBox.critical(self, "Setup failed", message)
+        self._stack.setCurrentIndex(0)
+
+    def _launch_app(self):
+        if self._exe_path:
+            wi.launch_application(Path(self._exe_path))
+        self.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv if argv is not None else sys.argv[1:]
+    flags = wi.parse_cli_args(argv)
+
+    if "--uninstall" in flags:
+        ok = wi.uninstall(Path(flags["--dir"]) if "--dir" in flags else None)
+        return 0 if ok else 1
+
+    if "--update" in flags:
+        zip_path = Path(flags["--update"])
+        version = flags.get("--version", "0.0.0")
+        install_dir = Path(flags.get("--dir", wi.DEFAULT_INSTALL_DIR))
+        try:
+            wi.install_from_zip(zip_path, install_dir, version)
+            return 0
+        except Exception as exc:
+            print(exc, file=sys.stderr)
+            return 1
+
+    app = QApplication(sys.argv)
+    app.setFont(QFont("Segoe UI", 10))
+    window = SetupWindow()
+    window.show()
+    return app.exec()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/installer/main.py
+++ b/installer/main.py
@@ -8,12 +8,21 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / "source"))
+_INSTALLER_DIR = Path(__file__).resolve().parent
+if str(_INSTALLER_DIR) not in sys.path:
+    sys.path.insert(0, str(_INSTALLER_DIR))
 
-from PyQt6.QtCore import Qt, QThread, pyqtSignal
-from PyQt6.QtGui import QFont, QIcon
+from _bootstrap import load_windows_installer
+
+wi = load_windows_installer()
+
+from PyQt6.QtCore import QByteArray, Qt, QPoint, QThread, pyqtSignal
+from PyQt6.QtGui import QFont, QIcon, QMouseEvent, QPainter, QPixmap
+from PyQt6.QtSvg import QSvgRenderer
 from PyQt6.QtWidgets import (
     QApplication,
+    QFrame,
+    QGraphicsDropShadowEffect,
     QHBoxLayout,
     QLabel,
     QMainWindow,
@@ -25,12 +34,70 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-from src.services import windows_installer as wi
+C_BG_DEEP = "#070b12"
+C_BG_BASE = "#0c111b"
+C_BG_CARD = "#161f30"
+C_BORDER = "rgba(148, 163, 184, 0.18)"
+C_TEXT = "#eef2f7"
+C_MUTED = "#8b9cb3"
+C_DIM = "#5c6d85"
+C_ACCENT = "#3369ff"
+C_CYAN = "#33c2ff"
+C_SUCCESS = "#4ade80"
+
+
+def _load_logo_pixmap(size: int = 40) -> QPixmap:
+    for name in ("datapyn_logo.svg", "datapyn-logo.svg"):
+        path = ROOT / "source" / "src" / "assets" / name
+        if path.is_file():
+            renderer = QSvgRenderer(QByteArray(path.read_bytes()))
+            pixmap = QPixmap(size, size)
+            pixmap.fill(Qt.GlobalColor.transparent)
+            painter = QPainter(pixmap)
+            renderer.render(painter)
+            painter.end()
+            return pixmap
+    return QPixmap()
+
+
+class TitleBar(QWidget):
+    """Draggable header for frameless window."""
+
+    def __init__(self, parent_window: QMainWindow):
+        super().__init__(parent_window)
+        self._window = parent_window
+        self._drag_pos: QPoint | None = None
+
+        row = QHBoxLayout(self)
+        row.setContentsMargins(12, 8, 8, 8)
+        row.setSpacing(0)
+
+        row.addStretch()
+
+        close_btn = QPushButton("×")
+        close_btn.setObjectName("closeBtn")
+        close_btn.setFixedSize(32, 32)
+        close_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        close_btn.clicked.connect(parent_window.close)
+        row.addWidget(close_btn)
+
+    def mousePressEvent(self, event: QMouseEvent):
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._drag_pos = event.globalPosition().toPoint() - self._window.frameGeometry().topLeft()
+            event.accept()
+
+    def mouseMoveEvent(self, event: QMouseEvent):
+        if self._drag_pos is not None and event.buttons() & Qt.MouseButton.LeftButton:
+            self._window.move(event.globalPosition().toPoint() - self._drag_pos)
+            event.accept()
+
+    def mouseReleaseEvent(self, event: QMouseEvent):
+        self._drag_pos = None
 
 
 class InstallWorker(QThread):
     progress = pyqtSignal(int, str)
-    finished_ok = pyqtSignal(str, str)  # exe path, version
+    finished_ok = pyqtSignal(str, str)
     failed = pyqtSignal(str)
 
     def __init__(self, install_dir: Path, mode: str, zip_path: Path | None, version: str):
@@ -62,146 +129,246 @@ class SetupWindow(QMainWindow):
     def __init__(self):
         super().__init__()
         self.setWindowTitle("DataPyn Setup")
-        self.setFixedSize(520, 420)
+        self.setFixedSize(440, 380)
+        self.setWindowFlags(Qt.WindowType.FramelessWindowHint | Qt.WindowType.Window)
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+
         self._install_dir = wi.DEFAULT_INSTALL_DIR
         self._worker: InstallWorker | None = None
         self._exe_path: str | None = None
 
-        logo_path = ROOT / "source" / "src" / "assets" / "datapyn_logo.svg"
-        if logo_path.exists():
-            self.setWindowIcon(QIcon(str(logo_path)))
+        icon_path = ROOT / "source" / "src" / "assets"
+        for name in ("datapyn-logo.ico", "datapyn_logo.svg"):
+            p = icon_path / name
+            if p.exists():
+                self.setWindowIcon(QIcon(str(p)))
+                break
+
+        shell = QFrame()
+        shell.setObjectName("shell")
+        shadow = QGraphicsDropShadowEffect(shell)
+        shadow.setBlurRadius(28)
+        shadow.setOffset(0, 8)
+        shadow.setColor(Qt.GlobalColor.black)
+        shell.setGraphicsEffect(shadow)
+
+        root = QVBoxLayout(shell)
+        root.setContentsMargins(0, 0, 0, 0)
+        root.setSpacing(0)
+
+        self._title_bar = TitleBar(self)
+        root.addWidget(self._title_bar)
+
+        accent = QFrame()
+        accent.setObjectName("accentLine")
+        accent.setFixedHeight(2)
+        root.addWidget(accent)
+
+        body = QWidget()
+        body.setObjectName("body")
+        body_layout = QVBoxLayout(body)
+        body_layout.setContentsMargins(36, 8, 36, 36)
+        body_layout.setSpacing(0)
 
         self._stack = QStackedWidget()
-        self.setCentralWidget(self._stack)
         self._stack.addWidget(self._page_welcome())
         self._stack.addWidget(self._page_progress())
         self._stack.addWidget(self._page_done())
+        body_layout.addWidget(self._stack)
+        root.addWidget(body, 1)
+
+        outer = QWidget()
+        outer_layout = QVBoxLayout(outer)
+        outer_layout.setContentsMargins(16, 16, 16, 16)
+        outer_layout.addWidget(shell)
+        self.setCentralWidget(outer)
         self._apply_theme()
 
     def _apply_theme(self):
         self.setStyleSheet(
-            """
-            QMainWindow { background: #0c111b; }
-            QLabel { color: #eef2f7; }
-            QLabel#muted { color: #8b9cb3; font-size: 12px; }
-            QLabel#title { font-size: 22px; font-weight: 600; }
-            QPushButton {
-                background: #3369ff;
-                color: white;
+            f"""
+            QFrame#shell {{
+                background: {C_BG_BASE};
+                border: 1px solid {C_BORDER};
+                border-radius: 14px;
+            }}
+            QFrame#accentLine {{
+                background: qlineargradient(x1:0, y1:0, x2:1, y2:0,
+                    stop:0 {C_ACCENT}, stop:0.5 {C_CYAN}, stop:1 {C_ACCENT});
+                border: none;
+            }}
+            QWidget#body {{
+                background: transparent;
+            }}
+            QLabel {{
+                color: {C_TEXT};
+                background: transparent;
+            }}
+            QLabel#title {{
+                font-size: 18px;
+                font-weight: 600;
+            }}
+            QLabel#muted {{
+                color: {C_DIM};
+                font-size: 11px;
+            }}
+            QLabel#path {{
+                color: {C_MUTED};
+                font-size: 10px;
+                font-family: "Cascadia Mono", Consolas, monospace;
+            }}
+            QPushButton {{
+                background: {C_ACCENT};
+                color: #ffffff;
                 border: none;
                 border-radius: 8px;
-                padding: 10px 20px;
+                padding: 10px 24px;
                 font-weight: 600;
-            }
-            QPushButton:hover { background: #4f80ff; }
-            QPushButton#ghost {
+                font-size: 13px;
+                min-width: 108px;
+            }}
+            QPushButton:hover {{
+                background: #4f80ff;
+            }}
+            QPushButton:pressed {{
+                background: #2858e0;
+            }}
+            QPushButton#ghost {{
                 background: transparent;
-                color: #8b9cb3;
-                border: 1px solid rgba(148,163,184,0.25);
-            }
-            QPushButton#ghost:hover { color: #eef2f7; border-color: #3369ff; }
-            QProgressBar {
+                color: {C_MUTED};
+                border: 1px solid {C_BORDER};
+            }}
+            QPushButton#ghost:hover {{
+                color: {C_TEXT};
+                border-color: rgba(51, 105, 255, 0.45);
+            }}
+            QPushButton#closeBtn {{
+                background: transparent;
+                color: {C_MUTED};
                 border: none;
-                border-radius: 6px;
-                background: #161f30;
-                height: 10px;
-                text-align: center;
-                color: #8b9cb3;
-            }
-            QProgressBar::chunk {
-                border-radius: 6px;
-                background: qlineargradient(x1:0, y1:0, x2:1, y2:0,
-                    stop:0 #3369ff, stop:1 #33c2ff);
-            }
+                border-radius: 8px;
+                font-size: 18px;
+                min-width: 32px;
+                padding: 0;
+            }}
+            QPushButton#closeBtn:hover {{
+                background: rgba(239, 68, 68, 0.12);
+                color: #f87171;
+            }}
+            QProgressBar {{
+                border: none;
+                border-radius: 4px;
+                background: {C_BG_CARD};
+                height: 6px;
+            }}
+            QProgressBar::chunk {{
+                border-radius: 4px;
+                background: {C_ACCENT};
+            }}
             """
         )
 
-    def _page_welcome(self) -> QWidget:
+    def _centered_page(self) -> tuple[QWidget, QVBoxLayout]:
         page = QWidget()
         layout = QVBoxLayout(page)
-        layout.setContentsMargins(32, 28, 32, 28)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(16)
+        layout.setAlignment(Qt.AlignmentFlag.AlignHCenter)
+        return page, layout
+
+    def _button_row(self, primary_text: str, primary_slot, ghost_text: str, ghost_slot) -> QWidget:
+        row = QWidget()
+        h = QHBoxLayout(row)
+        h.setContentsMargins(0, 0, 0, 0)
+        h.setSpacing(10)
+        h.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        ghost = QPushButton(ghost_text)
+        ghost.setObjectName("ghost")
+        ghost.setCursor(Qt.CursorShape.PointingHandCursor)
+        ghost.clicked.connect(ghost_slot)
+        primary = QPushButton(primary_text)
+        primary.setCursor(Qt.CursorShape.PointingHandCursor)
+        primary.clicked.connect(primary_slot)
+        h.addWidget(ghost)
+        h.addWidget(primary)
+        return row
+
+    def _page_welcome(self) -> QWidget:
+        page, layout = self._centered_page()
         layout.setSpacing(12)
 
-        title = QLabel("Install DataPyn")
-        title.setObjectName("title")
-        layout.addWidget(title)
+        logo = QLabel()
+        logo.setPixmap(_load_logo_pixmap(56))
+        logo.setFixedSize(56, 56)
+        logo.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(logo, 0, Qt.AlignmentFlag.AlignHCenter)
 
-        subtitle = QLabel(
-            "Downloads the latest release from GitHub, installs for your user "
-            f"({self._install_dir}) and creates shortcuts."
-        )
-        subtitle.setWordWrap(True)
-        subtitle.setObjectName("muted")
-        layout.addWidget(subtitle)
+        title = QLabel("DataPyn")
+        title.setObjectName("title")
+        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(title)
 
         existing = wi.read_installed_version()
         if existing:
-            hint = QLabel(f"Installed version: {existing}. Setup will upgrade to the latest release.")
-            hint.setWordWrap(True)
-            hint.setObjectName("muted")
-            layout.addWidget(hint)
+            sub = QLabel(f"Atualizar · v{existing}")
+            sub.setObjectName("muted")
+            sub.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        else:
+            sub = QLabel("Instalar")
+            sub.setObjectName("muted")
+            sub.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(sub)
+
+        path = QLabel(str(self._install_dir))
+        path.setObjectName("path")
+        path.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(path)
 
         layout.addStretch()
-
-        row = QHBoxLayout()
-        row.addStretch()
-        cancel = QPushButton("Cancel")
-        cancel.setObjectName("ghost")
-        cancel.clicked.connect(self.close)
-        row.addWidget(cancel)
-        install = QPushButton("Install")
-        install.clicked.connect(self._start_install)
-        row.addWidget(install)
-        layout.addLayout(row)
+        layout.addWidget(
+            self._button_row("Instalar", self._start_install, "Cancelar", self.close)
+        )
         return page
 
     def _page_progress(self) -> QWidget:
-        page = QWidget()
-        layout = QVBoxLayout(page)
-        layout.setContentsMargins(32, 28, 32, 28)
-        layout.setSpacing(16)
+        page, layout = self._centered_page()
+        layout.setSpacing(20)
 
-        self._progress_title = QLabel("Downloading…")
-        self._progress_title.setObjectName("title")
-        layout.addWidget(self._progress_title)
-
-        self._progress_status = QLabel("Connecting to GitHub…")
-        self._progress_status.setObjectName("muted")
-        self._progress_status.setWordWrap(True)
-        layout.addWidget(self._progress_status)
+        layout.addStretch()
 
         self._progress_bar = QProgressBar()
         self._progress_bar.setRange(0, 100)
-        layout.addWidget(self._progress_bar)
+        self._progress_bar.setTextVisible(False)
+        self._progress_bar.setFixedWidth(280)
+        layout.addWidget(self._progress_bar, 0, Qt.AlignmentFlag.AlignHCenter)
+
+        self._progress_status = QLabel("…")
+        self._progress_status.setObjectName("muted")
+        self._progress_status.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self._progress_status)
+
         layout.addStretch()
         return page
 
     def _page_done(self) -> QWidget:
-        page = QWidget()
-        layout = QVBoxLayout(page)
-        layout.setContentsMargins(32, 28, 32, 28)
-        layout.setSpacing(12)
+        page, layout = self._centered_page()
 
-        done_title = QLabel("DataPyn is ready")
-        done_title.setObjectName("title")
-        layout.addWidget(done_title)
-
-        self._done_label = QLabel("")
-        self._done_label.setWordWrap(True)
-        self._done_label.setObjectName("muted")
-        layout.addWidget(self._done_label)
         layout.addStretch()
 
-        row = QHBoxLayout()
-        row.addStretch()
-        close_btn = QPushButton("Close")
-        close_btn.setObjectName("ghost")
-        close_btn.clicked.connect(self.close)
-        row.addWidget(close_btn)
-        self._launch_btn = QPushButton("Open DataPyn")
-        self._launch_btn.clicked.connect(self._launch_app)
-        row.addWidget(self._launch_btn)
-        layout.addLayout(row)
+        ok = QLabel("✓")
+        ok.setStyleSheet(f"font-size: 32px; color: {C_SUCCESS}; font-weight: 700;")
+        ok.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(ok)
+
+        self._done_label = QLabel("")
+        self._done_label.setObjectName("title")
+        self._done_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self._done_label)
+
+        layout.addStretch()
+        layout.addWidget(
+            self._button_row("Abrir", self._launch_app, "Fechar", self.close)
+        )
         return page
 
     def _start_install(self):
@@ -215,20 +382,14 @@ class SetupWindow(QMainWindow):
     def _on_progress(self, pct: int, msg: str):
         self._progress_bar.setValue(pct)
         self._progress_status.setText(msg)
-        if pct < 30:
-            self._progress_title.setText("Downloading…")
-        elif pct < 70:
-            self._progress_title.setText("Installing…")
-        else:
-            self._progress_title.setText("Finishing…")
 
     def _on_success(self, exe_path: str, version: str):
         self._exe_path = exe_path
-        self._done_label.setText(f"Version {version} installed at:\n{Path(exe_path).parent}")
+        self._done_label.setText(f"v{version}")
         self._stack.setCurrentIndex(2)
 
     def _on_failed(self, message: str):
-        QMessageBox.critical(self, "Setup failed", message)
+        QMessageBox.critical(self, "Falha na instalação", message)
         self._stack.setCurrentIndex(0)
 
     def _launch_app(self):

--- a/source/src/services/auto_update_service.py
+++ b/source/src/services/auto_update_service.py
@@ -1,17 +1,23 @@
 """
 Auto-update service for DataPyn
-Checks and installs updates from GitHub Releases
+Checks and installs updates from GitHub Releases (Windows ZIP artifacts).
 """
 
-import sys
+import logging
 import os
-import requests
-import subprocess
 import tempfile
 from pathlib import Path
-from typing import Optional, Tuple
-from PyQt6.QtCore import QObject, pyqtSignal, QThread, QSettings
-import logging
+from typing import Optional
+
+import requests
+from PyQt6.QtCore import QObject, QSettings, QThread, pyqtSignal
+
+from src.services.windows_installer import (
+    apply_downloaded_update,
+    find_windows_zip_asset,
+    is_newer_version,
+    normalize_version,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -37,26 +43,16 @@ class UpdateChecker(QObject):
             response.raise_for_status()
 
             release_data = response.json()
-            latest_version = release_data["tag_name"]
-            # Remove 'v' prefix if present (e.g. v1.0.0 -> 1.0.0)
-            if latest_version.startswith("v"):
-                latest_version = latest_version[1:]
+            latest_version = normalize_version(release_data.get("tag_name", ""))
             release_notes = release_data.get("body", "")
 
-            # Find MSI asset for Windows
-            download_url = None
-            for asset in release_data.get("assets", []):
-                if asset["name"].endswith("-windows.msi"):
-                    download_url = asset["browser_download_url"]
-                    break
-
-            if not download_url:
-                self.check_failed.emit("No Windows installer found in release")
+            asset = find_windows_zip_asset(release_data.get("assets", []))
+            if not asset or not asset.download_url:
+                self.check_failed.emit("No Windows ZIP package found in release")
                 return
 
-            # Compare versions
-            if self._is_newer_version(latest_version, self.current_version):
-                self.update_available.emit(latest_version, download_url, release_notes)
+            if is_newer_version(latest_version, self.current_version):
+                self.update_available.emit(latest_version, asset.download_url, release_notes)
             else:
                 self.no_update_available.emit()
 
@@ -66,27 +62,6 @@ class UpdateChecker(QObject):
         except Exception as e:
             logger.error(f"Unexpected error checking for updates: {e}")
             self.check_failed.emit(f"Error: {str(e)}")
-
-    def _is_newer_version(self, latest: str, current: str) -> bool:
-        """Compare versions in semantic versioning format"""
-        try:
-            # Remove suffixes like -dryrun, -alpha, etc.
-            latest_clean = latest.split("-")[0]
-            current_clean = current.split("-")[0]
-
-            latest_parts = [int(x) for x in latest_clean.split(".")]
-            current_parts = [int(x) for x in current_clean.split(".")]
-
-            # Ensure same size
-            while len(latest_parts) < 3:
-                latest_parts.append(0)
-            while len(current_parts) < 3:
-                current_parts.append(0)
-
-            return latest_parts > current_parts
-        except (ValueError, IndexError):
-            logger.warning(f"Error comparing versions: {latest} vs {current}")
-            return False
 
 
 class UpdateDownloader(QObject):
@@ -102,14 +77,12 @@ class UpdateDownloader(QObject):
         self.filename = filename
 
     def run(self):
-        """Download the installer"""
+        """Download the update package"""
         try:
-            # Create temporary directory for download
             temp_dir = tempfile.gettempdir()
             file_path = os.path.join(temp_dir, self.filename)
 
-            # Download with progress
-            response = requests.get(self.download_url, stream=True, timeout=30)
+            response = requests.get(self.download_url, stream=True, timeout=60)
             response.raise_for_status()
 
             total_size = int(response.headers.get("content-length", 0))
@@ -142,143 +115,103 @@ class AutoUpdateService:
         self.repo_owner = repo_owner
         self.repo_name = repo_name
         self.settings = QSettings("DataPyn", "DataPyn")
+        self._pending_update_version: str = ""
 
-        # Threads and workers (keep reference to avoid GC)
         self._check_thread: Optional[QThread] = None
         self._checker: Optional[UpdateChecker] = None
         self._download_thread: Optional[QThread] = None
         self._downloader: Optional[UpdateDownloader] = None
 
     def is_auto_update_enabled(self) -> bool:
-        """Check if auto-update is enabled"""
         return self.settings.value("auto_update/enabled", True, type=bool)
 
     def set_auto_update_enabled(self, enabled: bool):
-        """Enable or disable auto-update"""
         self.settings.setValue("auto_update/enabled", enabled)
 
     def check_for_updates(self, on_available, on_no_update, on_error):
-        """
-        Check if updates are available
-        
-        Args:
-            on_available: callback(version, download_url, release_notes)
-            on_no_update: callback()
-            on_error: callback(error_message)
-        """
-        # Check if thread already running (with try/except for deleted object)
         try:
             if self._check_thread and self._check_thread.isRunning():
                 logger.warning("Update check already in progress")
                 return
         except RuntimeError:
-            # C++ object was deleted, clear reference
             self._check_thread = None
 
         self._check_thread = QThread()
         self._checker = UpdateChecker(self.current_version, self.repo_owner, self.repo_name)
         self._checker.moveToThread(self._check_thread)
 
-        # Conectar sinais
         self._check_thread.started.connect(self._checker.run)
         self._checker.update_available.connect(on_available)
         self._checker.no_update_available.connect(on_no_update)
         self._checker.check_failed.connect(on_error)
 
-        # Quit thread when worker finishes (use queued connection to ensure signals are delivered first)
         self._checker.update_available.connect(self._check_thread.quit)
         self._checker.no_update_available.connect(self._check_thread.quit)
         self._checker.check_failed.connect(self._check_thread.quit)
-        
-        # Cleanup - use deleteLater to ensure proper cleanup after event loop processes
+
         self._check_thread.finished.connect(self._checker.deleteLater)
         self._check_thread.finished.connect(self._check_thread.deleteLater)
 
         self._check_thread.start()
 
     def download_update(self, download_url: str, version: str, on_progress, on_complete, on_error):
-        """
-        Download the update
-        
-        Args:
-            download_url: MSI installer URL
-            version: Version being downloaded
-            on_progress: callback(percentage)
-            on_complete: callback(file_path)
-            on_error: callback(error_message)
-        """
-        # Check if download already running (with try/except for deleted object)
         try:
             if self._download_thread and self._download_thread.isRunning():
                 logger.warning("Update download already in progress")
                 return
         except RuntimeError:
-            # C++ object was deleted, clear reference
             self._download_thread = None
 
-        filename = f"DataPyn-{version}-windows.msi"
+        self._pending_update_version = version
+        filename = f"DataPyn-{version}-windows.zip"
 
         self._download_thread = QThread()
         self._downloader = UpdateDownloader(download_url, filename)
         self._downloader.moveToThread(self._download_thread)
 
-        # Conectar sinais
         self._download_thread.started.connect(self._downloader.run)
         self._downloader.download_progress.connect(on_progress)
         self._downloader.download_complete.connect(on_complete)
         self._downloader.download_failed.connect(on_error)
 
-        # Quit thread when worker finishes
         self._downloader.download_complete.connect(self._download_thread.quit)
         self._downloader.download_failed.connect(self._download_thread.quit)
-        
-        # Cleanup - use deleteLater to ensure proper cleanup after event loop processes
+
         self._download_thread.finished.connect(self._downloader.deleteLater)
         self._download_thread.finished.connect(self._download_thread.deleteLater)
 
         self._download_thread.start()
 
-    def install_update(self, installer_path: str) -> bool:
-        """
-        Start update installation
-        
-        Args:
-            installer_path: MSI installer path
-            
-        Returns:
-            True if installation started successfully
-        """
+    def install_update(self, package_path: str, version: str = "") -> bool:
+        """Apply a downloaded ZIP update (app should exit immediately after)."""
         try:
-            if not os.path.exists(installer_path):
-                logger.error(f"Installer not found: {installer_path}")
+            if not os.path.exists(package_path):
+                logger.error(f"Update package not found: {package_path}")
                 return False
 
-            # Validate file is MSI and in temp directory
-            if not installer_path.lower().endswith(".msi"):
-                logger.error(f"File is not an MSI installer: {installer_path}")
+            if not package_path.lower().endswith(".zip"):
+                logger.error(f"Update package must be a ZIP file: {package_path}")
                 return False
 
-            # Validate it's in temp directory (security)
             temp_dir = tempfile.gettempdir()
-            if not os.path.commonpath([installer_path, temp_dir]) == temp_dir:
-                logger.error(f"Installer not in temp directory: {installer_path}")
+            if os.path.commonpath([os.path.abspath(package_path), temp_dir]) != temp_dir:
+                logger.error(f"Update package not in temp directory: {package_path}")
                 return False
 
-            # Execute MSI installer
-            # /i = install
-            # /passive = show progress bar but no interaction
-            # /norestart = don't restart automatically
-            subprocess.Popen(["msiexec", "/i", installer_path, "/passive", "/norestart"])
+            target_version = normalize_version(version or self._pending_update_version or "")
+            if not target_version:
+                logger.error("Update version is required to apply ZIP update")
+                return False
 
-            logger.info(f"Installation started: {installer_path}")
+            apply_downloaded_update(Path(package_path), target_version)
+            logger.info("Update applied from %s", package_path)
             return True
 
         except Exception as e:
-            logger.error(f"Error starting installation: {e}")
+            logger.error(f"Error applying update: {e}")
             return False
 
     def cleanup(self):
-        """Clean up resources"""
         self._stop_thread("_check_thread")
         self._stop_thread("_download_thread")
         self._checker = None

--- a/source/src/services/windows_installer.py
+++ b/source/src/services/windows_installer.py
@@ -1,0 +1,428 @@
+"""
+Windows install/update helpers for DataPyn release ZIP artifacts.
+
+Replaces MSI-based installation: downloads a PyInstaller folder archive from
+GitHub Releases, extracts to the user profile, registers uninstall info, and
+creates Start Menu / Desktop shortcuts.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import winreg
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+from urllib.request import Request, urlopen
+
+logger = logging.getLogger(__name__)
+
+APP_NAME = "DataPyn"
+REGISTRY_KEY = r"Software\Microsoft\Windows\CurrentVersion\Uninstall\DataPyn"
+DEFAULT_INSTALL_DIR = Path(os.environ.get("LOCALAPPDATA", "")) / "DataPyn"
+GITHUB_OWNER = "natharuc"
+GITHUB_REPO = "datapyn"
+ZIP_ASSET_PATTERN = re.compile(r"^DataPyn-[\d.]+(?:-[\w.]+)?-windows\.zip$", re.I)
+SETUP_ASSET_PATTERN = re.compile(r"^DataPyn-Setup(?:-[\d.]+)?\.exe$", re.I)
+VERSION_FILE = "installed.json"
+
+
+@dataclass(frozen=True)
+class ReleaseAsset:
+    name: str
+    download_url: str
+    size: int = 0
+
+
+@dataclass(frozen=True)
+class GitHubRelease:
+    tag_name: str
+    version: str
+    body: str
+    zip_asset: ReleaseAsset
+    setup_asset: Optional[ReleaseAsset] = None
+
+
+ProgressCallback = Callable[[int, str], None]
+
+
+def normalize_version(tag_or_version: str) -> str:
+    value = (tag_or_version or "").strip()
+    if value.lower().startswith("v"):
+        value = value[1:]
+    return value.split("-")[0]
+
+
+def compare_versions(latest: str, current: str) -> int:
+    """Return 1 if latest > current, -1 if older, 0 if equal."""
+
+    def parts(v: str) -> list[int]:
+        clean = normalize_version(v)
+        nums = []
+        for piece in clean.split("."):
+            try:
+                nums.append(int(piece))
+            except ValueError:
+                nums.append(0)
+        while len(nums) < 3:
+            nums.append(0)
+        return nums[:3]
+
+    left, right = parts(latest), parts(current)
+    if left > right:
+        return 1
+    if left < right:
+        return -1
+    return 0
+
+
+def is_newer_version(latest: str, current: str) -> bool:
+    return compare_versions(latest, current) > 0
+
+
+def fetch_latest_release(
+    owner: str = GITHUB_OWNER,
+    repo: str = GITHUB_REPO,
+    timeout: float = 30.0,
+) -> GitHubRelease:
+    url = f"https://api.github.com/repos/{owner}/{repo}/releases/latest"
+    request = Request(url, headers={"Accept": "application/vnd.github+json", "User-Agent": APP_NAME})
+    with urlopen(request, timeout=timeout) as response:
+        data = json.loads(response.read().decode("utf-8"))
+
+    zip_asset = None
+    setup_asset = None
+    for asset in data.get("assets", []):
+        name = asset.get("name", "")
+        if ZIP_ASSET_PATTERN.match(name):
+            zip_asset = ReleaseAsset(name=name, download_url=asset["browser_download_url"], size=asset.get("size", 0))
+        elif SETUP_ASSET_PATTERN.match(name):
+            setup_asset = ReleaseAsset(
+                name=name, download_url=asset["browser_download_url"], size=asset.get("size", 0)
+            )
+
+    if zip_asset is None:
+        raise RuntimeError("No Windows ZIP artifact found in the latest release")
+
+    tag = data.get("tag_name", "")
+    return GitHubRelease(
+        tag_name=tag,
+        version=normalize_version(tag),
+        body=data.get("body", "") or "",
+        zip_asset=zip_asset,
+        setup_asset=setup_asset,
+    )
+
+
+def download_file(
+    url: str,
+    destination: Path,
+    on_progress: Optional[ProgressCallback] = None,
+    timeout: float = 120.0,
+) -> Path:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    request = Request(url, headers={"User-Agent": APP_NAME})
+    with urlopen(request, timeout=timeout) as response:
+        total = int(response.headers.get("Content-Length", 0) or 0)
+        downloaded = 0
+        chunk_size = 1024 * 256
+        with destination.open("wb") as handle:
+            while True:
+                chunk = response.read(chunk_size)
+                if not chunk:
+                    break
+                handle.write(chunk)
+                downloaded += len(chunk)
+                if on_progress and total > 0:
+                    pct = min(100, int(downloaded * 100 / total))
+                    on_progress(pct, f"Downloading… {pct}%")
+
+    if on_progress:
+        on_progress(100, "Download complete")
+    return destination
+
+
+def get_install_dir() -> Optional[Path]:
+    try:
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, REGISTRY_KEY) as key:
+            value, _ = winreg.QueryValueEx(key, "InstallLocation")
+            if value:
+                path = Path(value)
+                if path.is_dir():
+                    return path
+    except OSError:
+        pass
+
+    if DEFAULT_INSTALL_DIR.is_dir() and (DEFAULT_INSTALL_DIR / "DataPyn.exe").exists():
+        return DEFAULT_INSTALL_DIR
+    return None
+
+
+def read_installed_version(install_dir: Optional[Path] = None) -> Optional[str]:
+    root = install_dir or get_install_dir()
+    if root is None:
+        return None
+    manifest = root / VERSION_FILE
+    if manifest.is_file():
+        try:
+            payload = json.loads(manifest.read_text(encoding="utf-8"))
+            return normalize_version(str(payload.get("version", "")))
+        except (json.JSONDecodeError, OSError):
+            pass
+    try:
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, REGISTRY_KEY) as key:
+            value, _ = winreg.QueryValueEx(key, "DisplayVersion")
+            return normalize_version(str(value))
+    except OSError:
+        return None
+
+
+def write_installed_version(install_dir: Path, version: str) -> None:
+    payload = {"version": normalize_version(version), "app": APP_NAME}
+    (install_dir / VERSION_FILE).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _resolve_zip_root(temp_dir: Path) -> Path:
+    entries = [p for p in temp_dir.iterdir() if p.name not in ("__MACOSX",)]
+    if len(entries) == 1 and entries[0].is_dir():
+        inner = entries[0]
+        if (inner / "DataPyn.exe").exists():
+            return inner
+    if (temp_dir / "DataPyn.exe").exists():
+        return temp_dir
+    for candidate in entries:
+        if candidate.is_dir() and (candidate / "DataPyn.exe").exists():
+            return candidate
+    raise RuntimeError("ZIP does not contain DataPyn.exe")
+
+
+def install_from_zip(
+    zip_path: Path,
+    install_dir: Path,
+    version: str,
+    on_progress: Optional[ProgressCallback] = None,
+) -> Path:
+    if not zip_path.is_file():
+        raise FileNotFoundError(zip_path)
+
+    install_dir = Path(install_dir)
+    install_dir.parent.mkdir(parents=True, exist_ok=True)
+
+    if on_progress:
+        on_progress(5, "Preparing installation…")
+
+    staging_parent = Path(tempfile.mkdtemp(prefix="datapyn-install-"))
+    try:
+        with zipfile.ZipFile(zip_path, "r") as archive:
+            if on_progress:
+                on_progress(15, "Extracting files…")
+            archive.extractall(staging_parent)
+
+        source_root = _resolve_zip_root(staging_parent)
+        exe_name = "DataPyn.exe"
+
+        if install_dir.exists():
+            if on_progress:
+                on_progress(40, "Updating existing installation…")
+            backup = install_dir.with_name(install_dir.name + ".old")
+            if backup.exists():
+                shutil.rmtree(backup, ignore_errors=True)
+            try:
+                install_dir.rename(backup)
+            except OSError:
+                shutil.rmtree(install_dir, ignore_errors=True)
+
+        if on_progress:
+            on_progress(60, "Copying application files…")
+        shutil.copytree(source_root, install_dir)
+
+        if not (install_dir / exe_name).exists():
+            raise RuntimeError(f"{exe_name} missing after install")
+
+        write_installed_version(install_dir, version)
+        register_uninstall(install_dir, version)
+        create_shortcuts(install_dir / exe_name)
+
+        if on_progress:
+            on_progress(100, "Installation complete")
+
+        return install_dir / exe_name
+    finally:
+        shutil.rmtree(staging_parent, ignore_errors=True)
+        old_dir = install_dir.with_name(install_dir.name + ".old")
+        if old_dir.exists():
+            shutil.rmtree(old_dir, ignore_errors=True)
+
+
+def register_uninstall(install_dir: Path, version: str) -> None:
+    install_dir = Path(install_dir)
+    uninstall_cmd = install_dir / "uninstall.cmd"
+    uninstall_cmd.write_text(
+        "\r\n".join(
+            [
+                "@echo off",
+                f'cd /d "{install_dir}"',
+                'taskkill /IM DataPyn.exe /F >nul 2>&1',
+                f'cd /d "{install_dir.parent}"',
+                f'rmdir /s /q "{install_dir}"',
+                r'reg delete "HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall\DataPyn" /f >nul 2>&1',
+                "echo DataPyn was removed.",
+                "pause",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    display_name = APP_NAME
+    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, REGISTRY_KEY) as key:
+        winreg.SetValueEx(key, "DisplayName", 0, winreg.REG_SZ, display_name)
+        winreg.SetValueEx(key, "DisplayVersion", 0, winreg.REG_SZ, normalize_version(version))
+        winreg.SetValueEx(key, "Publisher", 0, winreg.REG_SZ, "natharuc")
+        winreg.SetValueEx(key, "InstallLocation", 0, winreg.REG_SZ, str(install_dir))
+        winreg.SetValueEx(key, "UninstallString", 0, winreg.REG_SZ, str(uninstall_cmd))
+        winreg.SetValueEx(key, "QuietUninstallString", 0, winreg.REG_SZ, f'"{uninstall_cmd}"')
+        winreg.SetValueEx(key, "NoModify", 0, winreg.REG_DWORD, 1)
+        winreg.SetValueEx(key, "NoRepair", 0, winreg.REG_DWORD, 1)
+
+
+def create_shortcuts(target_exe: Path) -> None:
+    target_exe = Path(target_exe)
+    work_dir = str(target_exe.parent)
+    target = str(target_exe)
+    start_menu = Path(os.environ.get("APPDATA", "")) / "Microsoft" / "Windows" / "Start Menu" / "Programs"
+    desktop = Path(os.environ.get("USERPROFILE", "")) / "Desktop"
+
+    for folder, label in ((start_menu, APP_NAME), (desktop, APP_NAME)):
+        if not folder.exists():
+            continue
+        shortcut = folder / f"{label}.lnk"
+        _create_shortcut_ps(target, work_dir, shortcut)
+
+
+def _create_shortcut_ps(target: str, work_dir: str, shortcut: Path) -> None:
+    script = (
+        "$shell = New-Object -ComObject WScript.Shell; "
+        f"$s = $shell.CreateShortcut('{shortcut}'); "
+        f"$s.TargetPath = '{target}'; "
+        f"$s.WorkingDirectory = '{work_dir}'; "
+        f"$s.IconLocation = '{target},0'; "
+        "$s.Save()"
+    )
+    subprocess.run(
+        ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script],
+        check=False,
+        creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+    )
+
+
+def uninstall(install_dir: Optional[Path] = None) -> bool:
+    root = install_dir or get_install_dir()
+    if root is None:
+        return False
+    try:
+        subprocess.run(
+            ["taskkill", "/IM", "DataPyn.exe", "/F"],
+            check=False,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        )
+    except Exception:
+        pass
+    try:
+        shutil.rmtree(root, ignore_errors=True)
+        winreg.DeleteKey(winreg.HKEY_CURRENT_USER, REGISTRY_KEY)
+    except OSError as exc:
+        logger.error("Uninstall failed: %s", exc)
+        return False
+    for folder in (
+        Path(os.environ.get("APPDATA", "")) / "Microsoft" / "Windows" / "Start Menu" / "Programs",
+        Path(os.environ.get("USERPROFILE", "")) / "Desktop",
+    ):
+        link = folder / f"{APP_NAME}.lnk"
+        if link.exists():
+            link.unlink(missing_ok=True)
+    return True
+
+
+def launch_application(exe_path: Path) -> None:
+    subprocess.Popen([str(exe_path)], cwd=str(exe_path.parent), creationflags=subprocess.DETACHED_PROCESS)
+
+
+def install_latest_release(
+    install_dir: Path,
+    on_progress: Optional[ProgressCallback] = None,
+) -> tuple[Path, GitHubRelease]:
+    release = fetch_latest_release()
+    temp_zip = Path(tempfile.gettempdir()) / release.zip_asset.name
+    download_file(release.zip_asset.download_url, temp_zip, on_progress=on_progress)
+    exe = install_from_zip(temp_zip, install_dir, release.version, on_progress=on_progress)
+    try:
+        temp_zip.unlink(missing_ok=True)
+    except OSError:
+        pass
+    return exe, release
+
+
+def apply_downloaded_update(zip_path: Path, version: str, install_dir: Optional[Path] = None) -> Path:
+    root = install_dir or get_install_dir() or DEFAULT_INSTALL_DIR
+    return install_from_zip(zip_path, root, version)
+
+
+def run_setup_for_update(zip_path: Path, version: str, install_dir: Optional[Path] = None) -> bool:
+    """Launch the setup helper in update mode (used when in-app download completes)."""
+    setup_exe = None
+    try:
+        release = fetch_latest_release()
+        if release.setup_asset:
+            temp_setup = Path(tempfile.gettempdir()) / release.setup_asset.name
+            download_file(release.setup_asset.download_url, temp_setup)
+            setup_exe = temp_setup
+    except Exception as exc:
+        logger.warning("Could not download setup helper: %s", exc)
+
+    root = install_dir or get_install_dir() or DEFAULT_INSTALL_DIR
+    if setup_exe and setup_exe.is_file():
+        cmd = [str(setup_exe), "--update", str(zip_path), "--version", version, "--dir", str(root)]
+    else:
+        # Fallback: apply in-process (caller should exit app first)
+        apply_downloaded_update(zip_path, version, root)
+        return True
+
+    subprocess.Popen(cmd, creationflags=subprocess.DETACHED_PROCESS)
+    return True
+
+
+def parse_cli_args(argv: list[str]) -> dict[str, str]:
+    flags: dict[str, str] = {}
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--uninstall":
+            flags[arg] = "1"
+            i += 1
+            continue
+        if arg in ("--update", "--dir", "--version") and i + 1 < len(argv):
+            flags[arg] = argv[i + 1]
+            i += 2
+            continue
+        i += 1
+    return flags
+
+
+def find_windows_zip_asset(assets: list[dict]) -> Optional[ReleaseAsset]:
+    for asset in assets or []:
+        name = asset.get("name", "")
+        if ZIP_ASSET_PATTERN.match(name):
+            return ReleaseAsset(
+                name=name,
+                download_url=asset.get("browser_download_url", ""),
+                size=int(asset.get("size", 0) or 0),
+            )
+    return None

--- a/source/src/ui/main_window/_ui_setup.py
+++ b/source/src/ui/main_window/_ui_setup.py
@@ -1271,7 +1271,8 @@ class UISetupMixin:
         )
 
         if reply == QMessageBox.StandardButton.Yes:
-            if self.auto_update_service.install_update(installer_path):
+            version = getattr(download_dialog, "version", "")
+            if self.auto_update_service.install_update(installer_path, version):
                 QApplication.quit()
             else:
                 QMessageBox.critical(

--- a/tests/test_auto_update_service.py
+++ b/tests/test_auto_update_service.py
@@ -7,6 +7,7 @@ import pytest
 from unittest.mock import Mock, patch, MagicMock
 from PyQt6.QtCore import QSettings
 from src.services.auto_update_service import AutoUpdateService, UpdateChecker, UpdateDownloader
+from src.services.windows_installer import is_newer_version
 
 
 @pytest.fixture
@@ -21,28 +22,19 @@ class TestUpdateChecker:
     """Testes para UpdateChecker"""
 
     def test_is_newer_version_returns_true_for_newer(self):
-        """Testa se detecta versao mais nova corretamente"""
-        checker = UpdateChecker("1.0.0", "owner", "repo")
-        assert checker._is_newer_version("1.1.0", "1.0.0") is True
-        assert checker._is_newer_version("2.0.0", "1.0.0") is True
-        assert checker._is_newer_version("1.0.1", "1.0.0") is True
+        assert is_newer_version("1.1.0", "1.0.0") is True
+        assert is_newer_version("2.0.0", "1.0.0") is True
+        assert is_newer_version("1.0.1", "1.0.0") is True
 
     def test_is_newer_version_returns_false_for_older_or_same(self):
-        """Testa se detecta versao mais antiga ou igual corretamente"""
-        checker = UpdateChecker("1.0.0", "owner", "repo")
-        assert checker._is_newer_version("1.0.0", "1.0.0") is False
-        assert checker._is_newer_version("0.9.0", "1.0.0") is False
-        assert checker._is_newer_version("1.0.0", "1.1.0") is False
+        assert is_newer_version("1.0.0", "1.0.0") is False
+        assert is_newer_version("0.9.0", "1.0.0") is False
+        assert is_newer_version("1.0.0", "1.1.0") is False
 
     def test_is_newer_version_handles_prereleases(self):
-        """Testa se lida com pre-releases corretamente removendo sufixos"""
-        checker = UpdateChecker("1.0.0", "owner", "repo")
-        # Pre-release suffixes sao removidos, entao 1.1.0-alpha e tratado como 1.1.0
-        assert checker._is_newer_version("1.1.0-alpha", "1.0.0") is True
-        # Ambos 1.0.0-alpha e 1.0.0-beta sao tratados como 1.0.0, logo nao ha diferenca
-        assert checker._is_newer_version("1.0.0-beta", "1.0.0-alpha") is False
-        # 1.0.0 nao e mais novo que 1.0.0
-        assert checker._is_newer_version("1.0.0", "1.0.0") is False
+        assert is_newer_version("1.1.0-alpha", "1.0.0") is True
+        assert is_newer_version("1.0.0-beta", "1.0.0-alpha") is False
+        assert is_newer_version("1.0.0", "1.0.0") is False
 
     @patch("src.services.auto_update_service.requests.get")
     def test_check_for_updates_emits_update_available(self, mock_get, qtbot):
@@ -53,7 +45,7 @@ class TestUpdateChecker:
         mock_response.json.return_value = {
             "tag_name": "v1.1.0",
             "body": "Release notes",
-            "assets": [{"name": "App-1.1.0-windows.msi", "browser_download_url": "http://example.com/file.msi"}],
+            "assets": [{"name": "DataPyn-1.1.0-windows.zip", "browser_download_url": "http://example.com/file.zip"}],
         }
         mock_response.raise_for_status = Mock()
         mock_get.return_value = mock_response
@@ -70,7 +62,7 @@ class TestUpdateChecker:
         mock_response.json.return_value = {
             "tag_name": "v1.0.0",
             "body": "Release notes",
-            "assets": [{"name": "App-1.0.0-windows.msi", "browser_download_url": "http://example.com/file.msi"}],
+            "assets": [{"name": "DataPyn-1.0.0-windows.zip", "browser_download_url": "http://example.com/file.zip"}],
         }
         mock_response.raise_for_status = Mock()
         mock_get.return_value = mock_response
@@ -127,7 +119,7 @@ class TestAutoUpdateService:
         on_complete = Mock()
         on_error = Mock()
 
-        auto_update_service.download_update("http://example.com/file.msi", "1.1.0", on_progress, on_complete, on_error)
+        auto_update_service.download_update("http://example.com/file.zip", "1.1.0", on_progress, on_complete, on_error)
 
         assert auto_update_service._download_thread is not None
         assert auto_update_service._download_thread.isRunning()
@@ -135,26 +127,21 @@ class TestAutoUpdateService:
         # Cleanup
         auto_update_service.cleanup()
 
-    @patch("src.services.auto_update_service.subprocess.Popen")
+    @patch("src.services.auto_update_service.apply_downloaded_update")
     @patch("src.services.auto_update_service.os.path.exists", return_value=True)
-    def test_install_update_starts_installer(self, mock_exists, mock_popen, auto_update_service):
-        """Testa se inicia o instalador MSI"""
+    def test_install_update_applies_zip(self, mock_exists, mock_apply, auto_update_service):
         import tempfile
+
         temp_dir = tempfile.gettempdir()
-        installer_path = os.path.join(temp_dir, "installer.msi")
-        result = auto_update_service.install_update(installer_path)
+        package_path = os.path.join(temp_dir, "DataPyn-1.1.0-windows.zip")
+        result = auto_update_service.install_update(package_path, "1.1.0")
 
         assert result is True
-        mock_popen.assert_called_once()
-        args = mock_popen.call_args[0][0]
-        assert args[0] == "msiexec"
-        assert args[1] == "/i"
-        assert "installer.msi" in args[2]
+        mock_apply.assert_called_once()
 
     @patch("src.services.auto_update_service.os.path.exists", return_value=False)
     def test_install_update_fails_if_file_not_found(self, mock_exists, auto_update_service):
-        """Testa se falha quando arquivo nao existe"""
-        result = auto_update_service.install_update("C:\\temp\\nonexistent.msi")
+        result = auto_update_service.install_update("C:\\temp\\nonexistent.zip", "1.1.0")
 
         assert result is False
 
@@ -181,7 +168,7 @@ class TestUpdateDownloader:
     @patch("builtins.open", create=True)
     def test_download_emits_progress(self, mock_open, mock_get, qtbot):
         """Testa se emite progresso durante download"""
-        downloader = UpdateDownloader("http://example.com/file.msi", "installer.msi")
+        downloader = UpdateDownloader("http://example.com/file.zip", "DataPyn-1.1.0-windows.zip")
 
         mock_response = Mock()
         mock_response.headers.get.return_value = "1000"
@@ -195,7 +182,7 @@ class TestUpdateDownloader:
     @patch("src.services.auto_update_service.requests.get")
     def test_download_handles_error(self, mock_get, qtbot):
         """Testa se lida com erros de download"""
-        downloader = UpdateDownloader("http://example.com/file.msi", "installer.msi")
+        downloader = UpdateDownloader("http://example.com/file.zip", "DataPyn-1.1.0-windows.zip")
 
         mock_get.side_effect = Exception("Download error")
 

--- a/tests/test_windows_installer.py
+++ b/tests/test_windows_installer.py
@@ -1,0 +1,73 @@
+"""Tests for Windows ZIP-based installer helpers."""
+
+import json
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.services.windows_installer import (
+    compare_versions,
+    find_windows_zip_asset,
+    install_from_zip,
+    is_newer_version,
+    normalize_version,
+    read_installed_version,
+    write_installed_version,
+)
+
+
+class TestVersionHelpers:
+    def test_normalize_version_strips_v_prefix(self):
+        assert normalize_version("v1.2.3") == "1.2.3"
+
+    def test_is_newer_version(self):
+        assert is_newer_version("1.2.0", "1.1.9") is True
+        assert is_newer_version("1.0.0", "1.0.0") is False
+        assert compare_versions("2.0.0", "1.9.9") == 1
+
+
+class TestReleaseAssets:
+    def test_find_windows_zip_asset(self):
+        assets = [
+            {"name": "notes.md", "browser_download_url": "http://x"},
+            {"name": "DataPyn-1.2.3-windows.zip", "browser_download_url": "http://zip"},
+        ]
+        found = find_windows_zip_asset(assets)
+        assert found is not None
+        assert found.name.endswith("-windows.zip")
+
+
+class TestZipInstall:
+    def test_install_from_zip_creates_exe_and_manifest(self, tmp_path, monkeypatch):
+        install_dir = tmp_path / "DataPyn"
+        zip_path = tmp_path / "pkg.zip"
+
+        staging = tmp_path / "stage" / "DataPyn"
+        staging.mkdir(parents=True)
+        (staging / "DataPyn.exe").write_bytes(b"MZ")
+
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.write(staging / "DataPyn.exe", "DataPyn/DataPyn.exe")
+
+        monkeypatch.setattr(
+            "src.services.windows_installer.create_shortcuts",
+            lambda *_args, **_kwargs: None,
+        )
+        monkeypatch.setattr(
+            "src.services.windows_installer.register_uninstall",
+            lambda *_args, **_kwargs: None,
+        )
+
+        exe = install_from_zip(zip_path, install_dir, "1.2.3")
+        assert exe.name == "DataPyn.exe"
+        assert (install_dir / "installed.json").is_file()
+        payload = json.loads((install_dir / "installed.json").read_text(encoding="utf-8"))
+        assert payload["version"] == "1.2.3"
+
+    def test_read_installed_version_from_manifest(self, tmp_path):
+        install_dir = tmp_path / "DataPyn"
+        install_dir.mkdir()
+        write_installed_version(install_dir, "9.8.7")
+        assert read_installed_version(install_dir) == "9.8.7"


### PR DESCRIPTION
Add a small PyQt6 DataPyn-Setup wizard that downloads the latest release ZIP, installs under LOCALAPPDATA, registers uninstall info, and creates shortcuts. CI now publishes ZIP + Setup.exe instead of WiX MSI. Auto-update applies downloaded ZIP packages on exit.