### PR TITLE
feat(db): server-side query cancellation for all databases

### DIFF
--- a/source/src/database/database_connector.py
+++ b/source/src/database/database_connector.py
@@ -39,7 +39,11 @@ class QueryBusyError(ConnectionError):
     """Raised when a second query starts while another is still running."""
 
 
-# Fetch rows from DB cursors in bounded chunks. Long fetchall() calls hold
+class OperationCancelled(Exception):
+    """Raised when a running query was cancelled by the user."""
+
+
+# Fetch rows from DB cursors in bounded chunks.
 # the GIL for the whole result set, starving the Qt UI thread even though the
 # query runs in a worker thread. Chunking adds explicit yield points so the
 # UI keeps painting while large results stream into memory.
@@ -394,6 +398,8 @@ class DatabaseConnector:
         self._active_cursor = None  # Cursor reference for cancellation
         self._cancelled = False  # Cancellation flag
         self._query_lock = threading.Lock()
+        self._abandoned = False
+        self._active_mysql_thread_id: Optional[int] = None
         self._connection_config: Dict[str, Any] = {}
         self._sqlserver_mfa_credential = None
 
@@ -804,11 +810,19 @@ class DatabaseConnector:
         if not self.engine:
             raise ConnectionError("No active database connection")
 
+        if getattr(self, "_abandoned", False):
+            raise QueryBusyError(
+                "Connection is blocked after a query failed to cancel on the server. "
+                "Reconnect to continue."
+            )
+
         if not self._query_lock.acquire(blocking=False):
             raise QueryBusyError("A query is still running on this connection")
 
         try:
             return self._execute_query_unlocked(query, parameters=parameters)
+        except OperationCancelled:
+            raise
         except Exception as e:
             logger.error(f"Error executing query: {str(e)}")
             raise
@@ -853,6 +867,12 @@ class DatabaseConnector:
         """Execute query and stream result sets to files without building DataFrames."""
         if not self.engine:
             raise ConnectionError("No active database connection")
+
+        if getattr(self, "_abandoned", False):
+            raise QueryBusyError(
+                "Connection is blocked after a query failed to cancel on the server. "
+                "Reconnect to continue."
+            )
 
         if not self._query_lock.acquire(blocking=False):
             raise QueryBusyError("A query is still running on this connection")
@@ -1262,12 +1282,15 @@ class DatabaseConnector:
         commands = self._split_sql_statements(query)
         result = StreamExportResult()
         file_index = 0
+        raw_conn = None
+        cursor = None
 
         if not commands:
             result.errors.append("No SQL commands to execute.")
             return result
 
-        with self.engine.connect() as conn:
+        try:
+            raw_conn, cursor = self._begin_cancellable_raw_query()
             for cmd in commands:
                 if self._cancelled or (is_cancelled and is_cancelled()):
                     result.cancelled = True
@@ -1278,17 +1301,16 @@ class DatabaseConnector:
                 executable_params = prepared.params if prepared else {}
 
                 if self._requires_postgresql_autocommit(cmd):
-                    conn.commit()
                     self._execute_postgresql_autocommit_statement(executable_sql, executable_params)
                     continue
 
                 if self._is_select_query(cmd):
-                    db_result = conn.execute(text(executable_sql), executable_params)
-                    columns = list(db_result.keys())
+                    self._execute_raw_statement(cursor, executable_sql, executable_params)
+                    columns = [desc[0] for desc in cursor.description] if cursor.description else []
                     file_index += 1
                     if not self._stream_write_result_set(
                         columns,
-                        db_result,
+                        cursor,
                         base_path=base_path,
                         export_format=export_format,
                         file_index=file_index,
@@ -1297,12 +1319,23 @@ class DatabaseConnector:
                         on_file_started=on_file_started,
                         is_cancelled=is_cancelled,
                     ):
+                        result.cancelled = True
                         break
                 else:
-                    conn.execute(text(executable_sql), executable_params)
+                    self._execute_raw_statement(cursor, executable_sql, executable_params)
 
-            conn.commit()
+            if not result.cancelled:
+                try:
+                    raw_conn.commit()
+                except Exception:
+                    pass
+        except OperationCancelled:
+            result.cancelled = True
+        finally:
+            self._end_cancellable_raw_query(raw_conn, cursor)
 
+        if self._cancelled:
+            result.cancelled = True
         return result
 
     def _execute_query_unlocked(
@@ -1334,6 +1367,144 @@ class DatabaseConnector:
         # For other databases, use legacy logic
         return self._execute_generic_query(query, parameters=parameters)
 
+    def _ensure_not_cancelled(self) -> None:
+        if self._cancelled:
+            raise OperationCancelled()
+
+    @staticmethod
+    def _is_mysql_kill_access_denied(error: BaseException) -> bool:
+        text = _safe_exception_text(error).lower()
+        markers = (
+            "access denied",
+            "command denied",
+            "kill denied",
+            "er_kill_denied_error",
+            "1045",
+            "1095",
+            "1227",
+        )
+        return any(marker in text for marker in markers)
+
+    def _adapt_named_params_sql(self, sql: str, params: Optional[Dict[str, Any]]) -> tuple[str, Optional[Dict[str, Any]]]:
+        if not params:
+            return sql, None
+        if self.db_type in ("postgresql", "mysql", "mariadb"):
+            import re
+
+            adapted = re.sub(r":(\w+)", r"%(\1)s", sql)
+            return adapted, params
+        return sql, params
+
+    def _execute_raw_statement(self, cursor, sql: str, params: Optional[Dict[str, Any]] = None) -> None:
+        adapted_sql, adapted_params = self._adapt_named_params_sql(sql, params)
+        if adapted_params:
+            cursor.execute(adapted_sql, adapted_params)
+        else:
+            cursor.execute(adapted_sql)
+
+    def _cursor_to_dataframe(self, cursor) -> pd.DataFrame:
+        columns = [desc[0] for desc in cursor.description] if cursor.description else []
+        if not columns:
+            return pd.DataFrame()
+        rows = fetch_rows_chunked(cursor)
+        return records_to_dataframe(rows, columns)
+
+    def _capture_mysql_thread_id(self, cursor) -> None:
+        if self.db_type not in ("mysql", "mariadb"):
+            return
+        try:
+            cursor.execute("SELECT CONNECTION_ID()")
+            row = cursor.fetchone()
+            if row:
+                self._active_mysql_thread_id = int(row[0])
+        except Exception as exc:
+            logger.debug("Could not read MySQL CONNECTION_ID(): %s", exc)
+
+    def _spawn_admin_connection(self) -> tuple["DatabaseConnector", Any]:
+        from src.database.block_connector_pool import connect_connector_from_config
+
+        config = dict(getattr(self, "_connection_config", None) or {})
+        if not config:
+            raise ConnectionError("No connection configuration for admin connection")
+        admin = connect_connector_from_config(config, password=config.get("password", ""))
+        if not admin.is_connected() or admin.engine is None:
+            raise ConnectionError("Failed to open admin connection for query cancel")
+        return admin, admin.engine.raw_connection()
+
+    def _kill_mysql_query(self, thread_id: int) -> None:
+        admin = None
+        admin_raw = None
+        try:
+            admin, admin_raw = self._spawn_admin_connection()
+            cursor = admin_raw.cursor()
+            try:
+                cursor.execute(f"KILL QUERY {int(thread_id)}")
+                logger.info("MySQL/MariaDB query cancelled via KILL QUERY %s", thread_id)
+            finally:
+                try:
+                    cursor.close()
+                except Exception:
+                    pass
+        except Exception as exc:
+            if self._is_mysql_kill_access_denied(exc):
+                logger.debug("KILL QUERY skipped (insufficient privileges): %s", exc)
+                return
+            logger.warning(
+                "KILL QUERY failed for thread %s: %s",
+                thread_id,
+                type(exc).__name__,
+            )
+        finally:
+            if admin_raw is not None:
+                try:
+                    admin_raw.close()
+                except Exception:
+                    pass
+            if admin is not None:
+                try:
+                    admin.disconnect()
+                except Exception:
+                    pass
+
+    def _begin_cancellable_raw_query(self) -> tuple[Any, Any]:
+        self._cancelled = False
+        self._active_mysql_thread_id = None
+        raw_conn = self.engine.raw_connection()
+        self._active_raw_conn = raw_conn
+        cursor = raw_conn.cursor()
+        self._active_cursor = cursor
+        self._capture_mysql_thread_id(cursor)
+        return raw_conn, cursor
+
+    def _end_cancellable_raw_query(self, raw_conn, cursor) -> None:
+        self._active_raw_conn = None
+        self._active_cursor = None
+        self._active_mysql_thread_id = None
+        if cursor is not None:
+            try:
+                cursor.close()
+            except Exception:
+                pass
+        if raw_conn is not None:
+            try:
+                raw_conn.close()
+            except Exception:
+                pass
+
+    def force_disconnect(self) -> None:
+        """Drop pooled connections so a stuck server-side query cannot block reuse."""
+        self._active_raw_conn = None
+        self._active_cursor = None
+        self._active_mysql_thread_id = None
+        self._cancelled = False
+        self._abandoned = False
+        if self.engine is not None:
+            try:
+                self.engine.dispose()
+            except Exception as exc:
+                logger.warning("Error disposing engine during force_disconnect: %s", exc)
+            self.engine = None
+
     def request_cancel(self) -> None:
         """Set cancellation flag (safe from any thread; does not call the driver)."""
         self._cancelled = True
@@ -1363,10 +1534,17 @@ class DatabaseConnector:
                     logger.info("Databricks query cancelled via cursor.cancel()")
                 else:
                     logger.warning("Cancel requested but Databricks cursor not available")
+            elif self.db_type in ("mysql", "mariadb"):
+                thread_id = getattr(self, "_active_mysql_thread_id", None)
+                if thread_id:
+                    self._kill_mysql_query(thread_id)
+                else:
+                    logger.debug(
+                        "Cancel requested for %s but no active connection id is available",
+                        self.db_type,
+                    )
             else:
-                # MySQL/MariaDB: no native cancel in driver,
-                # but _cancelled flag will interrupt processing
-                logger.info(f"Cancel requested for {self.db_type} (via flag)")
+                logger.debug("Cancel requested for %s (no driver interrupt available)", self.db_type)
         except Exception as e:
             logger.warning(f"Error cancelling query: {e}")
 
@@ -1832,80 +2010,83 @@ class DatabaseConnector:
         return records_to_dataframe(rows, columns)
 
     def _execute_generic_query(self, query: str, parameters: Optional[List[Dict[str, Any]]] = None) -> pd.DataFrame:
-        """Execute generic query for non-MSSQL databases"""
-        # Split statements with DELIMITER-awareness
+        """Execute generic query for non-MSSQL databases using raw DBAPI for cancellation."""
         commands = self._split_sql_statements(query)
+        if not commands:
+            return self._success_message_df("no_commands")
 
-        if len(commands) > 1:
-            # Multiple commands - execute all and capture SELECT results
-            dataframes = []
-
-            with self.engine.connect() as conn:
-                for cmd in commands:
-                    prepared = prepare_generic_sql(cmd, parameters) if parameters else None
-                    executable_sql = prepared.query if prepared else cmd
-                    executable_params = prepared.params if prepared else {}
-
-                    if self._requires_postgresql_autocommit(cmd):
-                        conn.commit()
-                        result_df = self._execute_postgresql_autocommit_statement(executable_sql, executable_params)
-                    elif self._is_select_query(cmd):
-                        # Is SELECT - capture result
-                        try:
-                            result = conn.execute(text(executable_sql), executable_params)
-                            df = self._result_to_dataframe(result)
-                            logger.info(f"SELECT executed: {len(df)} rows returned")
-                            dataframes.append(df)
-                        except Exception as e:
-                            logger.error(f"Error executing SELECT: {str(e)}")
-                            raise
-                    else:
-                        # Not SELECT - execute as statement
-                        conn.execute(text(executable_sql), executable_params)
-
-                conn.commit()
-
-            # If captured multiple results, return list of DataFrames
-            if len(dataframes) > 1:
-                logger.info(f"Returning list with {len(dataframes)} DataFrames")
-                return dataframes
-
-            # If captured single result, return directly
-            if dataframes:
-                logger.info(f"Returning single DataFrame with {len(dataframes[0])} rows")
-                return dataframes[0]
-
-            # No SELECT executed - return success message
-            logger.info("Commands executed successfully.")
-            return self._success_message_df("success_commands_plural")
-        elif len(commands) == 1:
-            # Single command - use the cleaned statement (DELIMITER stripped)
+        if len(commands) == 1:
             cmd = commands[0]
             prepared = prepare_generic_sql(cmd, parameters) if parameters else None
             executable_sql = prepared.query if prepared else cmd
             executable_params = prepared.params if prepared else {}
             if self._requires_postgresql_autocommit(cmd):
                 return self._execute_postgresql_autocommit_statement(executable_sql, executable_params)
-            if self._is_select_query(cmd):
-                # SELECT query - fetch rows directly so DB driver values are preserved
-                with self.engine.connect() as conn:
-                    result = conn.execute(text(executable_sql), executable_params)
-                    df = self._result_to_dataframe(result)
-                logger.info(f"Query executed successfully. Rows returned: {len(df)}")
-                return df
-            else:
-                # Non-SELECT - execute as statement
-                with self.engine.connect() as conn:
-                    result = conn.execute(text(executable_sql), executable_params)
-                    conn.commit()
-                    rows_affected = result.rowcount
 
-                    if rows_affected >= 0:
-                        return self._success_message_df("success_command_rows", rows=rows_affected)
-                    return self._success_message_df("success_command")
-        else:
-            # No commands (empty input or only DELIMITER directives)
-            return self._success_message_df("no_commands")
+            raw_conn = None
+            cursor = None
+            try:
+                raw_conn, cursor = self._begin_cancellable_raw_query()
+                if self._is_select_query(cmd):
+                    self._execute_raw_statement(cursor, executable_sql, executable_params)
+                    self._ensure_not_cancelled()
+                    df = self._cursor_to_dataframe(cursor)
+                    logger.info(f"Query executed successfully. Rows returned: {len(df)}")
+                    return df
+
+                self._execute_raw_statement(cursor, executable_sql, executable_params)
+                self._ensure_not_cancelled()
+                try:
+                    raw_conn.commit()
+                except Exception:
+                    pass
+                rows_affected = cursor.rowcount if hasattr(cursor, "rowcount") else -1
+                if isinstance(rows_affected, int) and rows_affected >= 0:
+                    return self._success_message_df("success_command_rows", rows=rows_affected)
+                return self._success_message_df("success_command")
+            finally:
+                self._end_cancellable_raw_query(raw_conn, cursor)
+
+        dataframes = []
+        raw_conn = None
+        cursor = None
+        try:
+            raw_conn, cursor = self._begin_cancellable_raw_query()
+            for cmd in commands:
+                self._ensure_not_cancelled()
+
+                prepared = prepare_generic_sql(cmd, parameters) if parameters else None
+                executable_sql = prepared.query if prepared else cmd
+                executable_params = prepared.params if prepared else {}
+
+                if self._requires_postgresql_autocommit(cmd):
+                    self._execute_postgresql_autocommit_statement(executable_sql, executable_params)
+                    continue
+
+                if self._is_select_query(cmd):
+                    self._execute_raw_statement(cursor, executable_sql, executable_params)
+                    self._ensure_not_cancelled()
+                    df = self._cursor_to_dataframe(cursor)
+                    logger.info(f"SELECT executed: {len(df)} rows returned")
+                    dataframes.append(df)
+                else:
+                    self._execute_raw_statement(cursor, executable_sql, executable_params)
+
+            try:
+                raw_conn.commit()
+            except Exception:
+                pass
+        finally:
+            self._end_cancellable_raw_query(raw_conn, cursor)
+
+        if len(dataframes) > 1:
+            logger.info(f"Returning list with {len(dataframes)} DataFrames")
+            return dataframes
+        if dataframes:
+            logger.info(f"Returning single DataFrame with {len(dataframes[0])} rows")
+            return dataframes[0]
+        logger.info("Commands executed successfully.")
+        return self._success_message_df("success_commands_plural")
 
     def execute_statement(self, statement: str) -> int:
         """

--- a/source/src/ui/components/session_widget.py
+++ b/source/src/ui/components/session_widget.py
@@ -28,6 +28,7 @@ from src.database.database_connector import (
     _format_sql_error_for_user,
     _safe_exception_text,
     get_connector_database_context,
+    OperationCancelled,
     QueryBusyError,
 )
 from src.editors.block_editor import BlockEditor
@@ -127,6 +128,8 @@ class SessionSqlWorker(QObject):
         try:
             df = self.connector.execute_query(self.query, parameters=self.sql_parameters)
             self.finished.emit(df, "")
+        except OperationCancelled:
+            self.finished.emit(None, "__CANCELLED__")
         except QueryBusyError as e:
             self.finished.emit(None, str(e))
         except Exception as e:
@@ -2630,6 +2633,21 @@ class SessionWidget(QWidget):
         if not self._sql_stopping:
             return
         if self._sql_stop_timed_out():
+            thread = getattr(self, "_sql_stopping_thread", None)
+            thread_alive = False
+            if thread is not None:
+                try:
+                    thread_alive = thread.isRunning()
+                except RuntimeError:
+                    thread_alive = False
+            connector = self._sql_stopping_connector
+            if thread_alive and connector is not None:
+                connector._abandoned = True
+                logger.warning(
+                    "SQL cancel timed out with worker still running; connection marked abandoned"
+                )
+                self._finalize_sql_stop()
+                return
             logger.warning("SQL cancel finalize timed out; forcing cleanup")
             self._force_release_stopping_query_lock()
             self._finalize_sql_stop()

--- a/source/src/workers/__init__.py
+++ b/source/src/workers/__init__.py
@@ -531,7 +531,7 @@ class QueryDownloadWorker(BaseWorker):
     def run(self):
         from pathlib import Path
 
-        from src.database.database_connector import QueryBusyError
+        from src.database.database_connector import OperationCancelled, QueryBusyError
         from src.database.query_stream_exporter import StreamExportResult
 
         self.started.emit()
@@ -559,6 +559,8 @@ class QueryDownloadWorker(BaseWorker):
                 error_msg = "__CANCELLED__"
             elif result.errors and not result.files:
                 error_msg = "\n".join(result.errors)
+        except OperationCancelled:
+            error_msg = "__CANCELLED__"
         except QueryBusyError as e:
             error_msg = str(e)
         except Exception as e:

--- a/tests/test_sql_cancel_nonblocking.py
+++ b/tests/test_sql_cancel_nonblocking.py
@@ -1,5 +1,6 @@
 """Tests for non-blocking SQL query cancellation."""
 
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -8,7 +9,7 @@ from PyQt6.QtWidgets import QApplication
 
 from PyQt6.QtCore import QThread
 
-from src.database.database_connector import DatabaseConnector, QueryBusyError
+from src.database.database_connector import DatabaseConnector, OperationCancelled, QueryBusyError
 from src.ui.components.session_widget import SessionSqlWorker, SessionWidget
 
 
@@ -362,3 +363,142 @@ def test_tab_spinner_clockwise_and_counter_clockwise(qtbot, monkeypatch):
     angle_ccw_before = tabs._spinner_angle_ccw
     tabs._tick_spinner()
     assert tabs._spinner_angle_ccw == (angle_ccw_before + 30) % 360
+
+
+def test_generic_execute_sets_active_raw_conn_and_cursor():
+    connector = DatabaseConnector()
+    connector.db_type = "postgresql"
+    connector.engine = MagicMock()
+
+    raw_conn = MagicMock()
+    cursor = MagicMock()
+    cursor.description = [("value",)]
+    cursor.fetchmany.side_effect = [[(1,)], []]
+    raw_conn.cursor.return_value = cursor
+    connector.engine.raw_connection.return_value = raw_conn
+
+    connector._execute_generic_query("SELECT 1")
+
+    raw_conn.cursor.assert_called_once()
+    raw_conn.close.assert_called_once()
+    assert connector._active_raw_conn is None
+    assert connector._active_cursor is None
+
+
+def test_generic_execute_raises_operation_cancelled_when_flag_set():
+    connector = DatabaseConnector()
+    connector.db_type = "postgresql"
+    connector.engine = MagicMock()
+
+    raw_conn = MagicMock()
+    cursor = MagicMock()
+
+    def _mark_cancelled(*_args, **_kwargs):
+        connector._cancelled = True
+
+    cursor.execute.side_effect = _mark_cancelled
+    raw_conn.cursor.return_value = cursor
+    connector.engine.raw_connection.return_value = raw_conn
+
+    with pytest.raises(OperationCancelled):
+        connector._execute_generic_query("SELECT 1")
+
+
+def test_interrupt_query_postgresql_uses_active_raw_conn_cancel():
+    connector = DatabaseConnector()
+    connector.db_type = "postgresql"
+    raw_conn = MagicMock()
+    connector._active_raw_conn = raw_conn
+
+    connector.interrupt_query()
+
+    raw_conn.cancel.assert_called_once()
+
+
+def test_interrupt_query_mysql_kill_query_fallback():
+    connector = DatabaseConnector()
+    connector.db_type = "mysql"
+    connector._active_mysql_thread_id = 42
+
+    admin = MagicMock()
+    admin_raw = MagicMock()
+    admin_cursor = MagicMock()
+    admin_raw.cursor.return_value = admin_cursor
+
+    with patch.object(connector, "_spawn_admin_connection", return_value=(admin, admin_raw)):
+        connector.interrupt_query()
+
+    admin_cursor.execute.assert_called_once_with("KILL QUERY 42")
+    admin_raw.close.assert_called_once()
+    admin.disconnect.assert_called_once()
+
+
+def test_interrupt_query_mysql_kill_access_denied_silent(caplog):
+    connector = DatabaseConnector()
+    connector.db_type = "mariadb"
+    connector._active_mysql_thread_id = 7
+
+    with patch.object(
+        connector,
+        "_spawn_admin_connection",
+        side_effect=Exception("Access denied for user"),
+    ):
+        with caplog.at_level("DEBUG"):
+            connector.interrupt_query()
+
+    assert not any(record.levelname == "WARNING" for record in caplog.records)
+
+
+def test_execute_query_rejects_abandoned_connection():
+    connector = DatabaseConnector()
+    connector.engine = MagicMock()
+    connector._abandoned = True
+
+    with pytest.raises(QueryBusyError, match="blocked after a query failed to cancel"):
+        connector.execute_query("SELECT 1")
+
+
+def test_force_disconnect_disposes_engine():
+    connector = DatabaseConnector()
+    engine = MagicMock()
+    connector.engine = engine
+    connector._abandoned = True
+
+    connector.force_disconnect()
+
+    engine.dispose.assert_called_once()
+    assert connector.engine is None
+    assert connector._abandoned is False
+
+
+def test_lock_not_released_while_thread_alive_after_cancel(qtbot, monkeypatch):
+    monkeypatch.setattr(SessionWidget, "_setup_ui", lambda self: None)
+    monkeypatch.setattr(SessionWidget, "_connect_signals", lambda self: None)
+
+    session = MagicMock()
+    session.session_id = "s1"
+    session.blocks = []
+    session.code = ""
+    session.finish_execution = MagicMock()
+
+    widget = SessionWidget(session)
+    qtbot.addWidget(widget)
+
+    connector = DatabaseConnector()
+    connector._query_lock.acquire()
+    thread = MagicMock()
+    thread.isRunning.return_value = True
+
+    widget._sql_stopping = True
+    widget._sql_stopping_thread = thread
+    widget._sql_stopping_connector = connector
+    widget._sql_stop_started_at = time.time() - 1.0
+    widget._SQL_STOP_TIMEOUT_SEC = 0.0
+
+    with patch.object(widget, "_force_release_stopping_query_lock") as force_release:
+        with patch.object(widget, "_finalize_sql_stop") as finalize:
+            widget._schedule_sql_stop_finalize()
+
+    assert connector._abandoned is True
+    force_release.assert_not_called()
+    finalize.assert_called_once()


### PR DESCRIPTION
## Summary

- Refactor generic query execute/stream paths to raw DBAPI (`raw_connection` + cursor) so `_active_raw_conn` / `_active_cursor` are available for driver-level cancel
- PostgreSQL: `connection.cancel()` now works on the generic path
- MySQL/MariaDB: `KILL QUERY` fallback via ephemeral admin connection; access-denied errors swallowed silently (DEBUG log only)
- Add `OperationCancelled` sentinel; workers emit `__CANCELLED__` consistently
- Cancel timeout: do not force-release `_query_lock` while worker thread is alive; mark connector `_abandoned` instead
- Add `force_disconnect()` to drop pooled connections as last resort

## Test plan

- [x] `uv run pytest tests/test_sql_cancel_nonblocking.py tests/test_query_download_worker.py tests/test_sql_worker_error_delivery.py -q` (30 passed)
- [x] `uv run ruff check` on changed source files
- [ ] Manual: `SELECT SLEEP(30)` / `pg_sleep(30)` → cancel → confirm query gone from server process list