### PR TITLE
feat(app): open DPW files in running DataPyn instance

### DIFF
--- a/source/main.py
+++ b/source/main.py
@@ -98,6 +98,12 @@ def main():
     app = QApplication(sys.argv)
     app.setApplicationName("DataPyn")
     app.setOrganizationName("DataPyn")
+
+    from src.services.single_instance import try_forward_to_running_instance
+
+    if try_forward_to_running_instance(startup_files):
+        sys.exit(0)
+
     app.setStyle("Fusion")
 
     # Splash o mais cedo possível (antes de fontes, tema e imports pesados)
@@ -182,6 +188,18 @@ def main():
     from src.ui import MainWindow
 
     window = MainWindow(splash=splash)
+
+    from src.services.single_instance import install_single_instance_server
+
+    def _on_second_instance(paths: list[str], focus: bool) -> None:
+        if paths:
+            window.open_startup_files(paths)
+        if focus:
+            window.showNormal()
+            window.raise_()
+            window.activateWindow()
+
+    install_single_instance_server(app, _on_second_instance)
 
     splash.finish_with_window(window)
 

--- a/source/src/services/single_instance.py
+++ b/source/src/services/single_instance.py
@@ -1,0 +1,104 @@
+"""Forward open-file requests to an already running DataPyn process."""
+
+from __future__ import annotations
+
+import getpass
+import json
+import logging
+from collections.abc import Callable
+
+from PyQt6.QtCore import QObject, QTimer
+from PyQt6.QtNetwork import QLocalServer, QLocalSocket
+
+logger = logging.getLogger(__name__)
+
+_CONNECT_MS = 800
+_WRITE_MS = 2000
+
+
+def single_instance_socket_name() -> str:
+    """Stable per-user server id (short for Windows named pipes)."""
+    user = getpass.getuser() or "default"
+    return f"datapyn-ide-{user}"
+
+
+def encode_open_files_message(paths: list[str], *, focus: bool = True) -> bytes:
+    payload = {"paths": [str(path) for path in paths], "focus": bool(focus)}
+    return json.dumps(payload, ensure_ascii=False).encode("utf-8")
+
+
+def decode_open_files_message(data: bytes) -> tuple[list[str], bool]:
+    if not data:
+        return [], True
+    obj = json.loads(data.decode("utf-8"))
+    if not isinstance(obj, dict):
+        return [], True
+    raw_paths = obj.get("paths", [])
+    paths = [str(path) for path in raw_paths if path] if isinstance(raw_paths, list) else []
+    return paths, bool(obj.get("focus", True))
+
+
+def try_forward_to_running_instance(paths: list[str], *, focus: bool = True) -> bool:
+    """Send paths to the primary instance. True => exit this process."""
+    socket = QLocalSocket()
+    socket.connectToServer(single_instance_socket_name())
+    if not socket.waitForConnected(_CONNECT_MS):
+        return False
+
+    try:
+        socket.write(encode_open_files_message(paths, focus=focus))
+        socket.flush()
+        socket.waitForBytesWritten(_WRITE_MS)
+        return True
+    finally:
+        socket.disconnectFromServer()
+
+
+class SingleInstanceServer(QObject):
+    """Listen for file-open requests from secondary DataPyn launches."""
+
+    def __init__(
+        self,
+        on_open_files: Callable[[list[str], bool], None],
+        parent: QObject | None = None,
+    ):
+        super().__init__(parent)
+        self._on_open_files = on_open_files
+        self._server = QLocalServer(self)
+        self._server.newConnection.connect(self._handle_new_connection)
+
+    def listen(self) -> bool:
+        name = single_instance_socket_name()
+        if self._server.listen(name):
+            return True
+        QLocalServer.removeServer(name)
+        return self._server.listen(name)
+
+    def _handle_new_connection(self) -> None:
+        while self._server.hasPendingConnections():
+            client = self._server.nextPendingConnection()
+            if client is None:
+                continue
+            client.readyRead.connect(lambda c=client: self._read_client(c))
+
+    def _read_client(self, client: QLocalSocket) -> None:
+        data = bytes(client.readAll())
+        client.disconnectFromServer()
+        try:
+            paths, focus = decode_open_files_message(data)
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            logger.warning("Ignored malformed single-instance message: %s", exc)
+            return
+        QTimer.singleShot(0, lambda p=paths, f=focus: self._on_open_files(p, f))
+
+
+def install_single_instance_server(
+    app: QObject,
+    on_open_files: Callable[[list[str], bool], None],
+) -> SingleInstanceServer | None:
+    server = SingleInstanceServer(on_open_files, app)
+    if not server.listen():
+        logger.warning("Single-instance server could not listen")
+        return None
+    app._datapyn_single_instance_server = server  # type: ignore[attr-defined]
+    return server

--- a/tests/test_single_instance.py
+++ b/tests/test_single_instance.py
@@ -1,0 +1,37 @@
+"""Tests for single-instance file forwarding."""
+
+from __future__ import annotations
+
+import json
+
+from src.services.single_instance import (
+    decode_open_files_message,
+    encode_open_files_message,
+    single_instance_socket_name,
+)
+
+
+class TestSingleInstanceMessages:
+    def test_roundtrip_paths_and_focus(self):
+        raw = encode_open_files_message([r"C:\work\foo.dpw", r"D:\bar.sql"], focus=True)
+        paths, focus = decode_open_files_message(raw)
+        assert paths == [r"C:\work\foo.dpw", r"D:\bar.sql"]
+        assert focus is True
+
+    def test_decode_empty_payload(self):
+        paths, focus = decode_open_files_message(b"")
+        assert paths == []
+        assert focus is True
+
+    def test_decode_ignores_empty_path_entries(self):
+        raw = json.dumps({"paths": ["", "ok.dpw"], "focus": False}).encode("utf-8")
+        paths, focus = decode_open_files_message(raw)
+        assert paths == ["ok.dpw"]
+        assert focus is False
+
+
+class TestSingleInstanceSocketName:
+    def test_socket_name_is_stable_string(self):
+        name = single_instance_socket_name()
+        assert name.startswith("datapyn-ide-")
+        assert single_instance_socket_name() == name


### PR DESCRIPTION
## Summary

When DataPyn is already running, double-clicking a `.dpw` (or passing a file path on the CLI) forwards the open request to the existing window instead of starting a second process.

- Per-user `QLocalServer` / `QLocalSocket` IPC (`datapyn-ide-<user>`)
- Secondary launch exits immediately after forwarding
- Primary instance opens the file via `open_startup_files` and raises the main window

## Test plan

- [x] `uv run pytest tests/test_single_instance.py tests/test_file_import_service.py`
- [ ] Manual: start DataPyn, double-click a `.dpw` in Explorer — new tab in same window, no second app
- [ ] Manual: launch `datapyn.exe other.dpw` while app is open — same behavior
- [ ] Manual: first launch (no instance) still opens normally
