### PR TITLE
fix(connections): idle reaper must read is_periodic_active as property

### DIFF
--- a/source/src/ui/components/session_widget.py
+++ b/source/src/ui/components/session_widget.py
@@ -1059,7 +1059,7 @@ class SessionWidget(QWidget):
 
         if (
             self.session.is_connected
-            and not self.is_periodic_active()
+            and not self.is_periodic_active
             and not self._is_executing
             and not self._sql_stopping
             and not self._execution_queue


### PR DESCRIPTION
## Summary
- Hotfix for a crash introduced in #142 (merged in v1.52.0): the idle reaper called `self.is_periodic_active()` with parentheses, but `is_periodic_active` is a `@property` returning `bool`, not a method.
- This raised `TypeError: 'bool' object is not callable` on every reaper tick (60s after idle), crashing the app.
- Fix: drop the parentheses (`self.is_periodic_active`).

## Why hotfix
The bug is in production (v1.52.0) and crashes the app ~60s after the user goes idle on any connected session. No global exception interceptor exists yet (tracked separately).

## Test plan
- [x] `tests/test_block_connector_pool_reaper.py` passes locally
- [x] `ruff check source/src/ui/components/session_widget.py` clean
- [ ] CI green
