### PR TITLE
fix(schema,oe): block db dropdown + OE focus-load + global crash guard

### DIFF
--- a/source/main.py
+++ b/source/main.py
@@ -100,6 +100,13 @@ def main():
     app.setOrganizationName("DataPyn")
     app.setStyle("Fusion")
 
+    # Global crash guard — must be installed before MainWindow is created so
+    # import/construction errors are also caught. The app NEVER exits on an
+    # unhandled exception; it surfaces a formatted dialog instead.
+    from src.core.crash_guard import install_crash_guard
+
+    install_crash_guard(app)
+
     # Splash o mais cedo possível (antes de fontes, tema e imports pesados)
     from src.ui.splash_screen import SplashScreen
 

--- a/source/src/core/crash_guard.py
+++ b/source/src/core/crash_guard.py
@@ -1,0 +1,254 @@
+"""Global exception interceptor — the app never closes on an unhandled error.
+
+Installs three safety nets so a Python/Qt exception surfaces a formatted
+crash dialog (with an optional "report to GitHub" action) instead of
+terminating the process:
+
+1. ``sys.excepthook`` — unhandled exceptions on the main (UI) thread that
+   escape the Qt event loop (e.g. raised at module top-level or after
+   ``app.exec()`` returns).
+2. ``threading.excepthook`` — unhandled exceptions on worker threads
+   (``QThread.run`` bodies, ``concurrent.futures``, etc.).
+3. ``QApplication.notify`` override — exceptions raised inside Qt event
+   dispatch (slots, timers, signal emissions). These are the most common
+   PyQt crash source and are NOT caught by ``sys.excepthook``.
+
+Every handler logs the full traceback (to ``datapyn.log`` and a rotating
+``crashes.log``), computes a stable signature, and schedules the crash
+dialog on the UI thread. Nothing here ever calls ``sys.exit``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import re
+import sys
+import threading
+import traceback
+from datetime import datetime
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_CRASH_LOG_NAME = "crashes.log"
+_CRASH_LOG_MAX_BYTES = 512 * 1024  # 512 KB
+_CRASH_LOG_BACKUP = 3
+
+_installed = False
+_reentry_guard = threading.Lock()
+_pending_dialog_scheduled = False
+_app_ref: Optional[object] = None
+
+
+def _crash_log_path() -> str:
+    """Return the path to the rotating crash log (next to datapyn.log)."""
+    try:
+        from src.core.workspace_service import get_workspace_service
+
+        ws = get_workspace_service()
+        base = ws.get_workspace_path()
+    except Exception:
+        base = os.getcwd()
+    return os.path.join(str(base or os.getcwd()), _CRASH_LOG_NAME)
+
+
+def _rotating_crash_logger() -> logging.Logger:
+    """Return a dedicated rotating logger for crashes (created once)."""
+    crash_logger = logging.getLogger("datapyn.crash")
+    if crash_logger.handlers:
+        return crash_logger
+    try:
+        from logging.handlers import RotatingFileHandler
+
+        handler = RotatingFileHandler(
+            _crash_log_path(),
+            maxBytes=_CRASH_LOG_MAX_BYTES,
+            backupCount=_CRASH_LOG_BACKUP,
+            encoding="utf-8",
+        )
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+        )
+        crash_logger.addHandler(handler)
+        crash_logger.setLevel(logging.ERROR)
+        crash_logger.propagate = False
+    except Exception as exc:
+        logger.debug("Could not attach crash log handler: %s", exc)
+    return crash_logger
+
+
+def _normalize_traceback(text: str) -> str:
+    """Strip memory addresses and line numbers for a stable signature.
+
+    File paths are kept (so we know which module), but volatile line numbers
+    and hex addresses are removed so the same bug maps to the same signature
+    across runs/edits.
+    """
+    if not text:
+        return ""
+    cleaned = re.sub(r", line \d+, in ", ", in ", text)
+    cleaned = re.sub(r"0x[0-9A-Fa-f]+", "0xADDR", cleaned)
+    cleaned = re.sub(r"<[^>]*object at 0xADDR>", "<OBJ>", cleaned)
+    return cleaned
+
+
+def _signature(traceback_text: str) -> str:
+    """Return a short stable signature for the given traceback."""
+    normalized = _normalize_traceback(traceback_text)
+    return hashlib.sha1(normalized.encode("utf-8", errors="replace")).hexdigest()[:12]
+
+
+def _app_version() -> str:
+    try:
+        from src.ui.splash_screen import _get_version
+
+        return _get_version() or "unknown"
+    except Exception:
+        return "unknown"
+
+
+def _format_report(exc_type, exc_value, exc_tb) -> str:
+    """Return the full traceback string for an exception triple."""
+    try:
+        return "".join(traceback.format_exception(exc_type, exc_value, exc_tb))
+    except Exception:
+        return f"{exc_type.__name__ if exc_type else 'Exception'}: {exc_value}"
+
+
+def _format_thread_report(args) -> str:
+    """Return a traceback string from a threading.ExceptHookArgs-like object."""
+    try:
+        return "".join(traceback.format_exception(args.exc_type, args.exc_value, args.exc_traceback))
+    except Exception:
+        return f"{getattr(args.exc_type, '__name__', 'Exception')}: {args.exc_value}"
+
+
+def _record_crash(traceback_text: str, signature: str, *, source: str) -> None:
+    """Persist the crash to the rotating crash log and the main log."""
+    header = (
+        f"\n{'=' * 60}\n"
+        f"CRASH [{source}] signature={signature} "
+        f"version={_app_version()} pid={os.getpid()} "
+        f"thread={threading.current_thread().name} "
+        f"ts={datetime.now().isoformat()}\n"
+        f"{'-' * 60}\n"
+    )
+    try:
+        _rotating_crash_logger().error(header + traceback_text)
+    except Exception:
+        pass
+    logger.error("Unhandled exception (%s, sig=%s):\n%s", source, signature, traceback_text)
+
+
+def _show_crash_dialog_on_ui(traceback_text: str, signature: str) -> None:
+    """Schedule the crash dialog on the UI thread (safe from any thread)."""
+    global _pending_dialog_scheduled
+    with _reentry_guard:
+        if _pending_dialog_scheduled:
+            return
+        _pending_dialog_scheduled = True
+
+    app = _app_ref
+    if app is None:
+        return
+
+    def _show() -> None:
+        global _pending_dialog_scheduled
+        try:
+            from PyQt6.QtWidgets import QApplication
+
+            app_obj = QApplication.instance()
+            if app_obj is None:
+                return
+            from src.ui.dialogs.crash_report_dialog import CrashReportDialog
+
+            parent = app_obj.activeWindow()
+            dialog = CrashReportDialog(
+                traceback_text=traceback_text,
+                signature=signature,
+                version=_app_version(),
+                parent=parent,
+            )
+            dialog.exec()
+        except Exception as exc:
+            logger.debug("Crash dialog itself failed: %s", exc)
+        finally:
+            with _reentry_guard:
+                _pending_dialog_scheduled = False
+
+    try:
+        from PyQt6.QtCore import QTimer
+
+        # singleShot(0, ...) from any thread posts the call to the UI thread.
+        QTimer.singleShot(0, _show)
+    except Exception as exc:
+        logger.debug("Could not schedule crash dialog: %s", exc)
+
+
+def _handle_exception(exc_type, exc_value, exc_tb) -> None:
+    """sys.excepthook replacement — never re-raises, never exits."""
+    if issubclass(exc_type, KeyboardInterrupt) if exc_type else False:
+        # Respect Ctrl+C as a normal exit signal.
+        sys.__excepthook__(exc_type, exc_value, exc_tb)
+        return
+    traceback_text = _format_report(exc_type, exc_value, exc_tb)
+    signature = _signature(traceback_text)
+    _record_crash(traceback_text, signature, source="sys.excepthook")
+    _show_crash_dialog_on_ui(traceback_text, signature)
+
+
+def _thread_excepthook(args) -> None:
+    """threading.excepthook replacement for worker threads."""
+    traceback_text = _format_thread_report(args)
+    signature = _signature(traceback_text)
+    _record_crash(traceback_text, signature, source=f"thread:{args.thread.name}")
+    _show_crash_dialog_on_ui(traceback_text, signature)
+
+
+def _make_notify_wrapper(original_notify):
+    """Wrap QApplication.notify so Qt event-dispatch exceptions are caught."""
+
+    def _notify(self, receiver, event):
+        try:
+            return original_notify(self, receiver, event)
+        except Exception:
+            exc_type, exc_value, exc_tb = sys.exc_info()
+            traceback_text = _format_report(exc_type, exc_value, exc_tb)
+            signature = _signature(traceback_text)
+            _record_crash(traceback_text, signature, source="QApplication.notify")
+            _show_crash_dialog_on_ui(traceback_text, signature)
+            return False
+
+    return _notify
+
+
+def install_crash_guard(app) -> None:
+    """Install all global exception interceptors for the given QApplication.
+
+    Idempotent. Must be called after ``QApplication`` is created and before
+    ``app.exec()`` so import/construction errors are also caught.
+    """
+    global _installed, _app_ref
+    if _installed:
+        return
+    _app_ref = app
+
+    sys.excepthook = _handle_exception
+    try:
+        threading.excepthook = _thread_excepthook
+    except Exception as exc:
+        logger.debug("Could not install threading.excepthook: %s", exc)
+
+    # QApplication.notify is the chokepoint for all Qt event dispatch
+    # (slots, timers, signals). Wrap it so exceptions there surface the
+    # crash dialog instead of crashing the event loop.
+    try:
+        original_notify = type(app).notify
+        type(app).notify = _make_notify_wrapper(original_notify)
+    except Exception as exc:
+        logger.debug("Could not wrap QApplication.notify: %s", exc)
+
+    _installed = True
+    logger.info("Crash guard installed — unhandled exceptions will surface a dialog instead of exiting.")

--- a/source/src/core/crash_guard.py
+++ b/source/src/core/crash_guard.py
@@ -30,6 +30,8 @@ import traceback
 from datetime import datetime
 from typing import Optional
 
+from PyQt6.QtCore import QObject, Qt, pyqtSignal
+
 logger = logging.getLogger(__name__)
 
 _CRASH_LOG_NAME = "crashes.log"
@@ -40,6 +42,47 @@ _installed = False
 _reentry_guard = threading.Lock()
 _pending_dialog_scheduled = False
 _app_ref: Optional[object] = None
+_dispatcher: Optional["_CrashDispatcher"] = None
+
+
+class _CrashDispatcher(QObject):
+    """Lives on the UI thread (parented to the QApplication) so a cross-thread
+    ``emit()`` is marshalled to the UI thread by Qt via QueuedConnection.
+
+    This mirrors the ``_signal_dispatch`` pattern used in
+    ``copilot_lsp_client.py`` / ``session_widget.py``: never call into Qt
+    widgets directly from a worker thread — always hop through a signal.
+    """
+
+    dispatch = pyqtSignal(str, str)  # traceback_text, signature
+
+    def __init__(self, parent) -> None:
+        super().__init__(parent)
+        self.dispatch.connect(self._on_dispatch, Qt.ConnectionType.QueuedConnection)
+
+    def _on_dispatch(self, traceback_text: str, signature: str) -> None:
+        global _pending_dialog_scheduled
+        try:
+            from PyQt6.QtWidgets import QApplication
+
+            app_obj = QApplication.instance()
+            if app_obj is None:
+                return
+            from src.ui.dialogs.crash_report_dialog import CrashReportDialog
+
+            parent = app_obj.activeWindow()
+            dialog = CrashReportDialog(
+                traceback_text=traceback_text,
+                signature=signature,
+                version=_app_version(),
+                parent=parent,
+            )
+            dialog.exec()
+        except Exception as exc:
+            logger.debug("Crash dialog itself failed: %s", exc)
+        finally:
+            with _reentry_guard:
+                _pending_dialog_scheduled = False
 
 
 def _crash_log_path() -> str:
@@ -143,48 +186,62 @@ def _record_crash(traceback_text: str, signature: str, *, source: str) -> None:
 
 
 def _show_crash_dialog_on_ui(traceback_text: str, signature: str) -> None:
-    """Schedule the crash dialog on the UI thread (safe from any thread)."""
+    """Schedule the crash dialog on the UI thread (safe from any thread).
+
+    Emits through ``_CrashDispatcher.dispatch`` (a signal connected with
+    QueuedConnection and parented to the QApplication, so it has UI-thread
+    affinity). Qt marshals the emission to the UI thread — no direct widget
+    call from a worker thread, which is the Qt6Core crash pattern we avoid.
+    """
     global _pending_dialog_scheduled
     with _reentry_guard:
         if _pending_dialog_scheduled:
             return
         _pending_dialog_scheduled = True
 
-    app = _app_ref
-    if app is None:
+    dispatcher = _dispatcher
+    if dispatcher is None:
+        # No dispatcher yet (e.g. install never ran) — fall back to a timer
+        # so we still surface something instead of silently dropping it.
+        try:
+            from PyQt6.QtCore import QTimer
+
+            def _show() -> None:
+                global _pending_dialog_scheduled
+                try:
+                    from PyQt6.QtWidgets import QApplication
+
+                    app_obj = QApplication.instance()
+                    if app_obj is None:
+                        return
+                    from src.ui.dialogs.crash_report_dialog import CrashReportDialog
+
+                    parent = app_obj.activeWindow()
+                    dialog = CrashReportDialog(
+                        traceback_text=traceback_text,
+                        signature=signature,
+                        version=_app_version(),
+                        parent=parent,
+                    )
+                    dialog.exec()
+                except Exception as exc:
+                    logger.debug("Crash dialog itself failed: %s", exc)
+                finally:
+                    with _reentry_guard:
+                        _pending_dialog_scheduled = False
+
+            QTimer.singleShot(0, _show)
+        except Exception as exc:
+            logger.debug("Could not schedule crash dialog: %s", exc)
         return
 
-    def _show() -> None:
-        global _pending_dialog_scheduled
-        try:
-            from PyQt6.QtWidgets import QApplication
-
-            app_obj = QApplication.instance()
-            if app_obj is None:
-                return
-            from src.ui.dialogs.crash_report_dialog import CrashReportDialog
-
-            parent = app_obj.activeWindow()
-            dialog = CrashReportDialog(
-                traceback_text=traceback_text,
-                signature=signature,
-                version=_app_version(),
-                parent=parent,
-            )
-            dialog.exec()
-        except Exception as exc:
-            logger.debug("Crash dialog itself failed: %s", exc)
-        finally:
-            with _reentry_guard:
-                _pending_dialog_scheduled = False
-
     try:
-        from PyQt6.QtCore import QTimer
-
-        # singleShot(0, ...) from any thread posts the call to the UI thread.
-        QTimer.singleShot(0, _show)
-    except Exception as exc:
-        logger.debug("Could not schedule crash dialog: %s", exc)
+        dispatcher.dispatch.emit(traceback_text, signature)
+    except RuntimeError as exc:
+        # Dispatcher QObject destroyed (app tearing down) — drop quietly.
+        logger.debug("Crash dispatcher destroyed, could not emit: %s", exc)
+        with _reentry_guard:
+            _pending_dialog_scheduled = False
 
 
 def _handle_exception(exc_type, exc_value, exc_tb) -> None:
@@ -230,10 +287,18 @@ def install_crash_guard(app) -> None:
     Idempotent. Must be called after ``QApplication`` is created and before
     ``app.exec()`` so import/construction errors are also caught.
     """
-    global _installed, _app_ref
+    global _installed, _app_ref, _dispatcher
     if _installed:
         return
     _app_ref = app
+
+    # UI-thread dispatcher: parented to the app so it has main-thread affinity.
+    # Emitting ``dispatch`` from any worker thread is marshalled to the UI thread
+    # by Qt (QueuedConnection) — the crash-safe way to show the dialog.
+    try:
+        _dispatcher = _CrashDispatcher(app)
+    except Exception as exc:
+        logger.debug("Could not create crash dispatcher: %s", exc)
 
     sys.excepthook = _handle_exception
     try:

--- a/source/src/editors/block_editor.py
+++ b/source/src/editors/block_editor.py
@@ -166,6 +166,7 @@ class BlockEditor(QWidget):
     # Signal when focused block changes (for Object Explorer tracking)
     block_focused = pyqtSignal(object)  # CodeBlock that gained focus
     sql_schema_requested = pyqtSignal(object)  # CodeBlock
+    databases_requested = pyqtSignal(object)  # CodeBlock (empty dropdown clicked)
 
     # Signal when any block text changes and shared {{parameters}} should be rescanned
     shared_parameters_scan_needed = pyqtSignal()

--- a/source/src/editors/code_block.py
+++ b/source/src/editors/code_block.py
@@ -204,6 +204,7 @@ class BlockDatabasePanel(QFrame):
     database_clicked = pyqtSignal()  # User clicked on panel
     database_dropped = pyqtSignal(str)  # database_name (drag & drop from Object Explorer)
     database_selected = pyqtSignal(str)  # database_name (selected from popup menu)
+    databases_requested = pyqtSignal()  # empty dropdown clicked -> request server db list
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -289,6 +290,9 @@ class BlockDatabasePanel(QFrame):
             if self._available_databases:
                 self._show_database_menu()
             else:
+                # Empty dropdown: ask for the server database list (lazy connect),
+                # then fall back to the default click behavior.
+                self.databases_requested.emit()
                 self.database_clicked.emit()
         super().mousePressEvent(event)
 
@@ -835,6 +839,7 @@ class CodeBlock(QFrame):
         self.db_panel.database_clicked.connect(self._on_database_panel_clicked)
         self.db_panel.database_dropped.connect(self._on_database_dropped)
         self.db_panel.database_selected.connect(self._on_database_selected)
+        self.db_panel.databases_requested.connect(self._on_databases_requested)
         self.run_btn.clicked.connect(self._on_run_btn_clicked)
         self.maximize_btn.clicked.connect(lambda: self.maximize_requested.emit(self))
         self.remove_btn.clicked.connect(lambda: self.remove_requested.emit(self))
@@ -1135,6 +1140,12 @@ class CodeBlock(QFrame):
         editor = getattr(self, "_block_editor", None)
         if editor is not None and hasattr(editor, "sql_schema_requested"):
             editor.sql_schema_requested.emit(self)
+
+    def _on_databases_requested(self) -> None:
+        """Empty per-block database dropdown clicked -> request server db list."""
+        editor = getattr(self, "_block_editor", None)
+        if editor is not None and hasattr(editor, "databases_requested"):
+            editor.databases_requested.emit(self)
 
     def _on_completion_requested(self, prefix: str, suffix: str, line: int, column: int):
         """Handle completion request from Monaco editor."""

--- a/source/src/language/en-US.json
+++ b/source/src/language/en-US.json
@@ -1768,5 +1768,19 @@
     "failed": "Download failed: {error}",
     "btn_cancel": "Cancel",
     "btn_close": "Close"
+  },
+  "crash": {
+    "title": "DataPyn encountered a problem",
+    "message": "An unexpected error occurred while running this action. The app is still running — you can continue working. Please report it so we can fix it.",
+    "traceback_label": "Error details",
+    "report_btn": "Report on GitHub",
+    "copy": "Copy",
+    "continue_btn": "Continue",
+    "copied": "Error details copied to clipboard.",
+    "reporting": "Reporting...",
+    "report_success": "Reported. Track it at {url}",
+    "report_failed": "Could not report automatically: {error}",
+    "signature": "signature",
+    "report_browser_fallback": "Opening your browser to create the issue..."
   }
 }

--- a/source/src/language/pt-BR.json
+++ b/source/src/language/pt-BR.json
@@ -1768,5 +1768,19 @@
     "failed": "Falha no download: {error}",
     "btn_cancel": "Cancelar",
     "btn_close": "Fechar"
+  },
+  "crash": {
+    "title": "O DataPyn encontrou um problema",
+    "message": "Ocorreu um erro inesperado ao executar esta acao. O aplicativo continua rodando - voce pode continuar trabalhando. Por favor, reporte para que possamos corrigir.",
+    "traceback_label": "Detalhes do erro",
+    "report_btn": "Reportar no GitHub",
+    "copy": "Copiar",
+    "continue_btn": "Continuar",
+    "copied": "Detalhes do erro copiados para a area de transferencia.",
+    "reporting": "Reportando...",
+    "report_success": "Reportado. Acompanhe em {url}",
+    "report_failed": "Nao foi possivel reportar automaticamente: {error}",
+    "signature": "assinatura",
+    "report_browser_fallback": "Abrindo seu navegador para criar a issue..."
   }
 }

--- a/source/src/services/auto_update_service.py
+++ b/source/src/services/auto_update_service.py
@@ -387,6 +387,9 @@ class AutoUpdateService(QObject):
             try:
                 thread.quit()
                 if not thread.wait(3000):
+                    logger.warning(
+                        "Auto-update QThread did not stop after quit(); terminating as last resort"
+                    )
                     thread.terminate()
                     thread.wait(1000)
             except RuntimeError:

--- a/source/src/services/copilot/copilot_client_sdk.py
+++ b/source/src/services/copilot/copilot_client_sdk.py
@@ -433,6 +433,9 @@ class ThreadSafeToolExecutor(QObject):
 
         self._execute_requested.connect(
             self._do_execute_on_main_thread,
+            # BlockingQueuedConnection: caller blocks until the main thread runs the slot.
+            # Safe while the main thread is not itself blocked on the same worker thread
+            # (e.g. during a Pynia chat turn that uses threading.Event, not QEventLoop).
             Qt.ConnectionType.BlockingQueuedConnection,
         )
 

--- a/source/src/services/copilot/copilot_lsp_client.py
+++ b/source/src/services/copilot/copilot_lsp_client.py
@@ -17,7 +17,7 @@ import time
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
-from PyQt6.QtCore import QObject, QThread, pyqtSignal, pyqtSlot, QTimer
+from PyQt6.QtCore import QObject, QThread, pyqtSignal, pyqtSlot, QTimer, Qt
 from src.services.copilot.copilot_settings import get_copilot_settings
 
 logger = logging.getLogger(__name__)
@@ -65,9 +65,14 @@ class CopilotLSPClient(QObject):
     error = pyqtSignal(str)
     status_changed = pyqtSignal(str)
     log_message = pyqtSignal(str, str)  # message, level
+    _signal_dispatch = pyqtSignal(object, tuple)  # internal: marshal emits to main thread
     
     def __init__(self, server_path: str, parent=None):
         super().__init__(parent)
+        self._signal_dispatch.connect(
+            self._dispatch_signal_emit,
+            Qt.ConnectionType.QueuedConnection,
+        )
         
         self._server_path = server_path
         self._process: Optional[subprocess.Popen] = None
@@ -166,14 +171,24 @@ class CopilotLSPClient(QObject):
         self._degraded_reason = ""
         self._log("Copilot inline completion restored", "info")
 
+    def _dispatch_signal_emit(self, signal, args: tuple) -> None:
+        try:
+            signal.emit(*args)
+        except RuntimeError:
+            pass  # QObject destroyed
+
+    def _emit_on_main(self, signal, *args) -> None:
+        """Marshal a pyqtSignal emission to the Qt main thread."""
+        try:
+            self._signal_dispatch.emit(signal, args)
+        except RuntimeError:
+            pass  # QObject destroyed
+
     def _queue_completion(self, text: str, uri: str = "") -> None:
         """Deliver the completion result on the Qt main thread."""
         target_uri = uri or self._pending_completion_uri or ""
         payload_text = text or ""
-        QTimer.singleShot(
-            0,
-            lambda u=target_uri, t=payload_text: self.completion_ready.emit(u, t),
-        )
+        self._emit_on_main(self.completion_ready, target_uri, payload_text)
     
     def _set_authenticated(self, value: bool, source: str = "unknown") -> None:
         """Set authentication state with logging."""
@@ -188,7 +203,7 @@ class CopilotLSPClient(QObject):
             logger.debug(f"[LSP] {message}")
         else:
             logger.info(f"[LSP] {message}")
-        self.log_message.emit(f"[LSP] {message}", level)
+        self._emit_on_main(self.log_message, f"[LSP] {message}", level)
 
     def _emit_authenticated(self, username: str) -> None:
         """Emit authenticated signal.
@@ -197,7 +212,7 @@ class CopilotLSPClient(QObject):
         via its signal handler.
         """
         self._set_authenticated(True, "_emit_authenticated")
-        self.authenticated.emit(username)
+        self._emit_on_main(self.authenticated, username)
 
     def start(self) -> bool:
         """
@@ -316,7 +331,7 @@ class CopilotLSPClient(QObject):
         def on_init_response(result, error):
             if error:
                 logger.error(f"[LSP] Initialize failed: {error}")
-                self.error.emit(f"Initialize failed: {error}")
+                self._emit_on_main(self.error, f"Initialize failed: {error}")
                 return
             
             logger.info("[LSP] Initialize response received")
@@ -333,7 +348,7 @@ class CopilotLSPClient(QObject):
             })
             
             self._initialized = True
-            self.initialized.emit()
+            self._emit_on_main(self.initialized)
             
             # Check authentication status
             self.check_status()
@@ -379,7 +394,7 @@ class CopilotLSPClient(QObject):
 
             # LSP returns "OK" or "SignedIn" when authenticated
             self._set_authenticated(status in ("SignedIn", "OK"), f"on_status({status})")
-            QTimer.singleShot(0, lambda s=status: self.status_changed.emit(s))
+            self._emit_on_main(self.status_changed, status)
 
             if self._is_authenticated:
                 self._clear_degraded()
@@ -412,7 +427,7 @@ class CopilotLSPClient(QObject):
             
             if error:
                 self._log(f"signIn error: {error}", "error")
-                self.error.emit(f"Sign-in failed: {error}")
+                self._emit_on_main(self.error, f"Sign-in failed: {error}")
                 # Note: CopilotAuthService handles lock release via error signal
                 return
             
@@ -428,7 +443,7 @@ class CopilotLSPClient(QObject):
                 user = result.get("user", "GitHub User")
                 self._log(f"Signed in as {user}", "info")
                 self._emit_authenticated(user)
-                self.status_changed.emit("SignedIn")
+                self._emit_on_main(self.status_changed, "SignedIn")
             
             elif status == "PromptUserDeviceFlow":
                 # Device flow - userCode is already in the response
@@ -437,7 +452,7 @@ class CopilotLSPClient(QObject):
                 
                 if user_code:
                     self._log(f"Device flow: enter code {user_code} at {verification_uri}", "info")
-                    self.auth_required.emit(user_code, verification_uri)
+                    self._emit_on_main(self.auth_required, user_code, verification_uri)
                 
                 # Execute finishDeviceFlow to poll for completion
                 command = result.get("command", {})
@@ -452,7 +467,7 @@ class CopilotLSPClient(QObject):
                 
                 if user_code:
                     self._log(f"Device flow: enter code {user_code} at {verification_uri}", "info")
-                    self.auth_required.emit(user_code, verification_uri)
+                    self._emit_on_main(self.auth_required, user_code, verification_uri)
                     
                     # Execute the finish command to complete device flow
                     command = result.get("command", {})
@@ -470,7 +485,7 @@ class CopilotLSPClient(QObject):
                 user = result.get("user", "GitHub User")
                 self._log(f"Already signed in as {user}", "info")
                 self._emit_authenticated(user)
-                self.status_changed.emit("SignedIn")
+                self._emit_on_main(self.status_changed, "SignedIn")
             
             else:
                 self._log(f"Unexpected signIn status: {status}", "warning")
@@ -481,7 +496,7 @@ class CopilotLSPClient(QObject):
         """Sign out from Copilot."""
         def on_sign_out(result, error):
             self._set_authenticated(False, "sign_out")
-            self.status_changed.emit("SignedOut")
+            self._emit_on_main(self.status_changed, "SignedOut")
             # Mark as logged out in centralized settings
             get_copilot_settings().on_lsp_logged_out()
         
@@ -492,7 +507,7 @@ class CopilotLSPClient(QObject):
         def on_result(result, error):
             if error:
                 self._log(f"finishDeviceFlow error: {error}", "error")
-                self.error.emit(f"Device flow failed: {error}")
+                self._emit_on_main(self.error, f"Device flow failed: {error}")
                 # Note: CopilotAuthService handles lock release via error signal
                 return
             
@@ -509,7 +524,7 @@ class CopilotLSPClient(QObject):
                 user = result.get("user", "GitHub User")
                 self._log(f"Signed in as {user}", "info")
                 self._emit_authenticated(user)
-                self.status_changed.emit("SignedIn")
+                self._emit_on_main(self.status_changed, "SignedIn")
                 return
             
             # Look for device code in the response
@@ -518,7 +533,7 @@ class CopilotLSPClient(QObject):
             
             if user_code:
                 self._log(f"Device flow: enter code {user_code} at {verification_uri}", "info")
-                self.auth_required.emit(user_code, verification_uri)
+                self._emit_on_main(self.auth_required, user_code, verification_uri)
                 # Poll for completion
                 self._poll_for_auth_completion()
             else:
@@ -566,7 +581,7 @@ class CopilotLSPClient(QObject):
                         self._polling_active = False
                         self._log(f"Poll detected sign-in: {user}", "info")
                         self._emit_authenticated(user)
-                        self.status_changed.emit("SignedIn")
+                        self._emit_on_main(self.status_changed, "SignedIn")
                         return
                 
                 # Continue polling if not authenticated
@@ -976,10 +991,10 @@ class CopilotLSPClient(QObject):
             # Ignore "Unknown" - keep current state
             if status in ("SignedIn", "OK"):
                 self._set_authenticated(True, f"didChangeStatus({status})")
-                self.status_changed.emit(status)
+                self._emit_on_main(self.status_changed, status)
             elif status in ("NotSignedIn", "SignedOut"):
                 self._set_authenticated(False, f"didChangeStatus({status})")
-                self.status_changed.emit(status)
+                self._emit_on_main(self.status_changed, status)
             else:
                 # Unknown or other status - don't change auth state
                 logger.debug(f"[LSP] Ignoring unknown status: {status}")

--- a/source/src/services/crash_reporter_service.py
+++ b/source/src/services/crash_reporter_service.py
@@ -1,0 +1,218 @@
+"""Crash reporter — files/updates a GitHub issue for an unhandled exception.
+
+Strategy (per product decision):
+1. If the GitHub CLI (``gh``) is available AND authenticated, search the
+   repo's open issues for an existing report with the same crash signature.
+   - Found → add a comment with the new occurrence (dedupe).
+   - Not found → create a new issue labelled ``crash,bug``.
+2. If ``gh`` is missing or not authenticated, fall back to opening the
+   browser on the "new issue" page with a prefilled title/body.
+
+The signature marker ``datapyn-crash:<sig>`` is embedded in the issue
+title/body so the dedupe search is reliable.
+
+All ``gh`` calls run off the UI thread (``CrashReporterWorker``) with a
+generous timeout so the dialog stays responsive.
+"""
+
+from __future__ import annotations
+
+import logging
+import urllib.parse
+import webbrowser
+from typing import Optional
+
+from PyQt6.QtCore import QObject, QThread, pyqtSignal
+
+logger = logging.getLogger(__name__)
+
+REPO = "natharuc/datapyn"
+SIGNATURE_PREFIX = "datapyn-crash"
+_GH_TIMEOUT = 25.0
+
+
+def _gh_executable() -> str:
+    try:
+        from src.services.copilot.copilot_client_sdk import _gh_executable as _gh
+
+        return _gh() or ""
+    except Exception:
+        import shutil
+
+        return shutil.which("gh") or ""
+
+
+def _is_gh_logged_in(gh_path: str) -> bool:
+    try:
+        from src.services.copilot.copilot_client_sdk import _is_gh_logged_in
+
+        return bool(_is_gh_logged_in(gh_path))
+    except Exception:
+        return False
+
+
+def _run_gh(args: list[str], *, timeout: float = _GH_TIMEOUT) -> tuple[int, str]:
+    """Run a gh command hidden; return (returncode, combined_output)."""
+    gh = _gh_executable()
+    if not gh:
+        return 127, "gh not found"
+    try:
+        from src.services.copilot.copilot_process import run_hidden
+
+        result = run_hidden([gh, *args], text=True, timeout=timeout)
+        out = f"{result.stdout or ''}\n{result.stderr or ''}".strip()
+        return int(result.returncode or 0), out
+    except Exception as exc:
+        return 1, str(exc)
+
+
+def _find_existing_issue(signature: str) -> Optional[int]:
+    """Return the issue number of an open issue matching the signature, or None."""
+    marker = f"{SIGNATURE_PREFIX}:{signature}"
+    code, out = _run_gh(
+        [
+            "issue",
+            "list",
+            "--repo",
+            REPO,
+            "--state",
+            "open",
+            "--search",
+            marker,
+            "--limit",
+            "10",
+            "--json",
+            "number,title",
+        ]
+    )
+    if code != 0 or not out:
+        return None
+    try:
+        import json
+
+        items = json.loads(out)
+        for item in items:
+            title = str(item.get("title", ""))
+            if marker in title:
+                return int(item.get("number"))
+    except Exception as exc:
+        logger.debug("Could not parse gh issue list: %s", exc)
+    return None
+
+
+def _create_issue(title: str, body: str) -> Optional[str]:
+    """Create a new issue; return its URL or None."""
+    code, out = _run_gh(
+        [
+            "issue",
+            "create",
+            "--repo",
+            REPO,
+            "--title",
+            title,
+            "--body",
+            body,
+            "--label",
+            "crash,bug",
+        ]
+    )
+    if code == 0 and out:
+        return out.strip().splitlines()[-1].strip() if out.strip() else None
+    return None
+
+
+def _comment_issue(number: int, body: str) -> Optional[str]:
+    """Add a comment to an existing issue; return the issue URL."""
+    code, _out = _run_gh(
+        [
+            "issue",
+            "comment",
+            str(number),
+            "--repo",
+            REPO,
+            "--body",
+            body,
+        ]
+    )
+    if code == 0:
+        return f"https://github.com/{REPO}/issues/{number}"
+    return None
+
+
+def _browser_fallback(title: str, body: str) -> str:
+    """Open the browser on the new-issue page with prefilled content."""
+    url = (
+        f"https://github.com/{REPO}/issues/new?"
+        f"title={urllib.parse.quote(title)}&body={urllib.parse.quote(body)}"
+    )
+    try:
+        webbrowser.open(url)
+    except Exception as exc:
+        logger.debug("webbrowser.open failed: %s", exc)
+    return url
+
+
+def report_crash(
+    *, traceback_text: str, signature: str, summary: str
+) -> tuple[Optional[str], Optional[str]]:
+    """Report a crash. Returns (url, error).
+
+    - url: the issue URL created/commented/opened, or None on failure.
+    - error: an error message, or None on success.
+    """
+    title = f"{summary} [{SIGNATURE_PREFIX}:{signature}]"
+    body = traceback_text
+
+    gh = _gh_executable()
+    if not gh or not _is_gh_logged_in(gh):
+        # Browser fallback — still useful, and never fatal.
+        try:
+            url = _browser_fallback(title, body)
+            return url, None
+        except Exception as exc:
+            return None, str(exc)
+
+    existing = _find_existing_issue(signature)
+    if existing:
+        occurrence_body = (
+            f"New occurrence of crash `{SIGNATURE_PREFIX}:{signature}`.\n\n"
+            f"{body}"
+        )
+        url = _comment_issue(existing, occurrence_body)
+        if url:
+            return url, None
+        # Comment failed — fall through to create.
+
+    url = _create_issue(title, body)
+    if url:
+        return url, None
+
+    # gh present + authed but create failed — try browser as last resort.
+    try:
+        url = _browser_fallback(title, body)
+        return url, None
+    except Exception as exc:
+        return None, str(exc)
+
+
+class CrashReporterWorker(QObject):
+    """Runs ``report_crash`` off the UI thread."""
+
+    finished = pyqtSignal(str, str)  # (url, error)
+
+    def __init__(self, *, traceback_text: str, signature: str, summary: str) -> None:
+        super().__init__()
+        self._traceback = traceback_text
+        self._signature = signature
+        self._summary = summary
+
+    def run(self) -> None:  # pragma: no cover - thread body
+        try:
+            url, error = report_crash(
+                traceback_text=self._traceback,
+                signature=self._signature,
+                summary=self._summary,
+            )
+            self.finished.emit(url or "", error or "")
+        except Exception as exc:
+            self.finished.emit("", str(exc))

--- a/source/src/services/jedi_completer.py
+++ b/source/src/services/jedi_completer.py
@@ -338,6 +338,9 @@ class JediCompleter(QObject):
             if thread.isRunning():
                 thread.quit()
                 if not thread.wait(500):
+                    logger.warning(
+                        "Jedi completer QThread did not stop after quit(); terminating as last resort"
+                    )
                     thread.terminate()
                     thread.wait(500)
             thread.deleteLater()

--- a/source/src/services/pynia/subagents/orchestrator.py
+++ b/source/src/services/pynia/subagents/orchestrator.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
 import uuid
 from typing import Any, Callable, Dict, List, Optional, Tuple, TYPE_CHECKING
 
-from PyQt6.QtCore import QObject, QThread, QEventLoop, QTimer
+from PyQt6.QtCore import QObject, QThread
 
 from src.utils.qt_threading import qthread_is_running
 
@@ -20,7 +21,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 MAX_PARALLEL_EXPLORE = 4
-# Safety net for the nested event loop. A hung subagent (e.g. a stalled LLM
+# Safety net for parallel explore. A hung subagent (e.g. a stalled LLM
 # stream) must never freeze the whole chat turn — we bail with partial results.
 EXPLORE_PARALLEL_TIMEOUT_MS = 120_000
 EXPLORE_CANCEL_POLL_MS = 200
@@ -75,6 +76,9 @@ class SubagentOrchestrator(QObject):
                 if qthread_is_running(thread):
                     thread.quit()
                     if not thread.wait(300):
+                        logger.warning(
+                            "Explore QThread did not stop after quit(); terminating as last resort"
+                        )
                         thread.terminate()
                         thread.wait(300)
             except RuntimeError:
@@ -88,6 +92,9 @@ class SubagentOrchestrator(QObject):
                 if thread.isRunning():
                     thread.quit()
                     if not thread.wait(500):
+                        logger.warning(
+                            "Explore QThread did not stop after quit(); terminating as last resort"
+                        )
                         thread.terminate()
                         thread.wait(500)
             except RuntimeError:
@@ -105,8 +112,8 @@ class SubagentOrchestrator(QObject):
     ) -> List[ExploreTaskResult]:
         """Run up to MAX_PARALLEL_EXPLORE explore jobs; blocks until all finish.
 
-        The nested event loop is bounded by a safety timeout and (optionally)
-        a cancellation poll so a hung subagent can never freeze the chat turn.
+        Uses threading.Event with a safety timeout and (optionally) a
+        cancellation poll so a hung subagent can never freeze the chat turn.
         """
         if not tasks:
             return []
@@ -142,18 +149,20 @@ class SubagentOrchestrator(QObject):
             )
 
         results: Dict[str, ExploreTaskResult] = {}
-        pending = len(capped)
-        loop = QEventLoop()
         workers: List[ExploreSubagentWorker] = []
         timed_out = False
         cancelled = False
+        done_event = threading.Event()
+        done_lock = threading.Lock()
+        remaining = len(capped)
 
         def on_one_done(result: ExploreTaskResult) -> None:
-            nonlocal pending
             results[result.task_id] = result
-            pending -= 1
-            if pending <= 0:
-                loop.quit()
+            with done_lock:
+                nonlocal remaining
+                remaining -= 1
+                if remaining <= 0:
+                    done_event.set()
 
         threads: List[QThread] = []
         self.cancel_active_explore()
@@ -180,38 +189,28 @@ class SubagentOrchestrator(QObject):
         self._active_workers = workers
         self._active_threads = threads
 
-        # Safety timeout: a stalled subagent must not block the turn forever.
-        safety_timer = QTimer()
-        safety_timer.setSingleShot(True)
+        # Block with threading.Event — no Qt event loop on this worker thread.
+        deadline = time.monotonic() + timeout_ms / 1000.0
+        poll_s = EXPLORE_CANCEL_POLL_MS / 1000.0
 
-        def _on_timeout() -> None:
-            nonlocal timed_out
-            timed_out = True
-            logger.warning("Parallel explore timed out after %sms; cancelling workers", timeout_ms)
-            for w in workers:
-                w.cancel()
-            loop.quit()
-
-        safety_timer.timeout.connect(_on_timeout)
-        safety_timer.start(timeout_ms)
-
-        # Cancellation poll: respond to the user pressing Stop on the main turn.
-        cancel_timer = QTimer()
-        if is_cancelled is not None:
-            def _check_cancel() -> None:
-                nonlocal cancelled
-                if is_cancelled():
-                    cancelled = True
-                    for w in workers:
-                        w.cancel()
-                    loop.quit()
-
-            cancel_timer.timeout.connect(_check_cancel)
-            cancel_timer.start(EXPLORE_CANCEL_POLL_MS)
-
-        loop.exec()
-        safety_timer.stop()
-        cancel_timer.stop()
+        while not done_event.is_set():
+            remaining_s = deadline - time.monotonic()
+            if remaining_s <= 0:
+                timed_out = True
+                logger.warning(
+                    "Parallel explore timed out after %sms; cancelling workers", timeout_ms
+                )
+                for w in workers:
+                    w.cancel()
+                break
+            wait_s = min(poll_s, remaining_s)
+            if done_event.wait(timeout=wait_s):
+                break
+            if is_cancelled is not None and is_cancelled():
+                cancelled = True
+                for w in workers:
+                    w.cancel()
+                break
 
         # Wind down any worker that didn't finish on its own (timeout/cancel).
         for w in workers:

--- a/source/src/ui/components/object_explorer_panel.py
+++ b/source/src/ui/components/object_explorer_panel.py
@@ -158,8 +158,12 @@ class ObjectExplorerPanel(QWidget):
         self._db_type = ""  # Database type (mssql, postgresql, mysql, etc.)
         self._all_databases = []  # list of all databases from server
         self._filter_timer = None
+        self._databases_auto_requested = False  # focus-triggered load guard (per connection)
         self._setup_ui()
         self._apply_theme()
+        # Auto-load the server database list when the panel or its tree gains focus
+        self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        self.tree.installEventFilter(self)
 
     def _setup_ui(self):
         """Configure UI"""
@@ -490,11 +494,18 @@ class ObjectExplorerPanel(QWidget):
         
         self.set_loading(False)  # Hide loading when schema arrives
         self.info_label.setStyleSheet("color: #808080; font-size: 11px;")  # Reset error style
+        connection_changed = connection_name != self._current_connection
         self._current_schema = schema
         self._current_connection = connection_name
         self._db_type = db_type.lower() if db_type else ""
         if schema:
             self._all_databases = schema.get("databases", [])
+        # Reset the focus-triggered load guard when the connection changes, or
+        # mark it satisfied when the database list has already been loaded.
+        if connection_changed:
+            self._databases_auto_requested = False
+        if self._all_databases:
+            self._databases_auto_requested = True
         
         # Update connection header
         db_name = schema.get("database", "") if schema else ""
@@ -1303,6 +1314,40 @@ class ObjectExplorerPanel(QWidget):
         for child in to_remove:
             item.removeChild(child)
 
+    def focusInEvent(self, event):
+        """Auto-load the server database list when the panel gains focus."""
+        super().focusInEvent(event)
+        self._maybe_request_databases_on_focus()
+
+    def eventFilter(self, obj, event):
+        """Detect focus entering the tree so we can auto-load databases."""
+        if obj is self.tree and event.type() == event.Type.FocusIn:
+            self._maybe_request_databases_on_focus()
+        return super().eventFilter(obj, event)
+
+    def maybe_request_databases_on_visibility(self):
+        """Triggered when the OE dock becomes visible (before any focus event)."""
+        self._maybe_request_databases_on_focus()
+
+    def _maybe_request_databases_on_focus(self):
+        """Emit databases_requested once per connection when the OE is focused/visible.
+
+        Smart lazy load: instead of waiting for the user to manually expand the
+        "Databases" node, fetch the cheap single-query server database list as
+        soon as the OE panel is focused or shown — so the per-block dropdown and
+        the tree are populated proactively. Skipped when the list is already
+        loaded or already requested for the current connection.
+        """
+        if not self._current_connection:
+            return
+        if self._databases_auto_requested:
+            return
+        if self._all_databases:
+            self._databases_auto_requested = True
+            return
+        self._databases_auto_requested = True
+        self.databases_requested.emit()
+
     def _on_item_expanded(self, item: QTreeWidgetItem):
         """Handle item expansion for lazy loading."""
         if item is None:
@@ -1311,6 +1356,7 @@ class ObjectExplorerPanel(QWidget):
         data = item.data(0, Qt.ItemDataRole.UserRole)
         if not data:
             return
+
 
         # Check if this item needs lazy loading (has placeholder child)
         if not self._has_placeholder_child(item):

--- a/source/src/ui/components/session_widget.py
+++ b/source/src/ui/components/session_widget.py
@@ -1059,7 +1059,7 @@ class SessionWidget(QWidget):
 
         if (
             self.session.is_connected
-            and not self.is_periodic_active()
+            and not self.is_periodic_active
             and not self._is_executing
             and not self._sql_stopping
             and not self._execution_queue

--- a/source/src/ui/components/session_widget.py
+++ b/source/src/ui/components/session_widget.py
@@ -255,6 +255,7 @@ class SessionWidget(QWidget):
     block_focused = pyqtSignal(object)  # CodeBlock that gained focus (for OE tracking)
     periodic_changed = pyqtSignal(bool)  # True=started, False=stopped - for tab icon
     _persisted_variables_loaded = pyqtSignal(object)  # dict loaded off-thread (internal)
+    _restore_dispatch = pyqtSignal(object)  # marshal restore payload to UI thread
 
     def __init__(self, session: Session, theme_manager: ThemeManager = None, parent=None):
         super().__init__(parent)
@@ -343,6 +344,10 @@ class SessionWidget(QWidget):
         self._setup_ui()
         self._connect_signals()
         # Queued from the loader thread back onto the UI thread
+        self._restore_dispatch.connect(
+            self._emit_persisted_variables_loaded,
+            Qt.ConnectionType.QueuedConnection,
+        )
         self._persisted_variables_loaded.connect(self._apply_restored_variables)
 
         # Restore blocks if they exist
@@ -678,6 +683,12 @@ class SessionWidget(QWidget):
         """Restore DataFrame variables from the on-disk snapshot (manual action)."""
         return self._restore_variables_from_disk(require_enabled=False)
 
+    def _emit_persisted_variables_loaded(self, variables: object) -> None:
+        try:
+            self._persisted_variables_loaded.emit(variables)
+        except RuntimeError:
+            pass  # widget destroyed while loading
+
     def _restore_variables_from_disk(self, *, require_enabled: bool) -> bool:
         """Load snapshot in a background thread; apply on the UI thread via signal."""
         import threading
@@ -705,7 +716,7 @@ class SessionWidget(QWidget):
                 variables = None
             if variables:
                 try:
-                    self._persisted_variables_loaded.emit(variables)
+                    self._restore_dispatch.emit(variables)
                 except RuntimeError:
                     pass  # widget destroyed while loading
 

--- a/source/src/ui/components/session_widget.py
+++ b/source/src/ui/components/session_widget.py
@@ -949,6 +949,8 @@ class SessionWidget(QWidget):
 
         if hasattr(self.editor, "sql_schema_requested"):
             self.editor.sql_schema_requested.connect(self._on_editor_sql_schema_requested)
+        if hasattr(self.editor, "databases_requested"):
+            self.editor.databases_requested.connect(self._on_editor_databases_requested)
 
         # Drop data file (opens import dialog)
         self.editor.file_dropped.connect(self._on_file_dropped)
@@ -1074,6 +1076,13 @@ class SessionWidget(QWidget):
         main_window = self._get_main_window()
         if main_window is not None and hasattr(main_window, "request_lazy_schema_for_completion"):
             main_window.request_lazy_schema_for_completion(block, self)
+
+    def _on_editor_databases_requested(self, block) -> None:
+        """Empty per-block database dropdown clicked -> request server db list."""
+        self._touch_db_activity()
+        main_window = self._get_main_window()
+        if main_window is not None and hasattr(main_window, "request_databases_for_block"):
+            main_window.request_databases_for_block(block, self)
 
     # === SQL EXECUTION ===
 

--- a/source/src/ui/dialogs/connection_edit_dialog.py
+++ b/source/src/ui/dialogs/connection_edit_dialog.py
@@ -2,6 +2,8 @@
 Unified dialog for creating and editing connections
 """
 
+import logging
+
 from PyQt6.QtWidgets import (
     QDialog,
     QVBoxLayout,
@@ -41,6 +43,8 @@ try:
     HAS_QTAWESOME = True
 except ImportError:
     HAS_QTAWESOME = False
+
+logger = logging.getLogger(__name__)
 
 
 class ConnectionTestWorker(QThread):
@@ -604,8 +608,13 @@ class ConnectionEditDialog(QDialog):
         """Cancels the ongoing connection test"""
         self._test_cancelled = True
         if hasattr(self, 'test_worker') and self.test_worker.isRunning():
-            self.test_worker.terminate()
-            self.test_worker.wait(2000)
+            self.test_worker.quit()
+            if not self.test_worker.wait(2000):
+                logger.warning(
+                    "Connection test QThread did not stop after quit(); terminating as last resort"
+                )
+                self.test_worker.terminate()
+                self.test_worker.wait(2000)
 
     def _on_test_finished(self, success: bool, message: str):
         """Callback when connection test finishes"""

--- a/source/src/ui/dialogs/crash_report_dialog.py
+++ b/source/src/ui/dialogs/crash_report_dialog.py
@@ -1,0 +1,263 @@
+"""Crash report dialog — surfaces an unhandled exception without closing the app.
+
+Frameless, design-system styled. Shows the formatted traceback and offers:
+- "Reportar no GitHub" — creates/comments a GitHub issue (gh CLI, browser fallback).
+- "Copiar" — copies the traceback to the clipboard.
+- "Continuar" — dismisses the dialog; the app keeps running.
+
+There is intentionally no "Close/Quit" button — dismissing never terminates
+the process.
+"""
+
+from __future__ import annotations
+
+import platform
+from datetime import datetime
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QFont, QGuiApplication
+from PyQt6.QtWidgets import (
+    QApplication,
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QPlainTextEdit,
+    QProgressBar,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.design_system.button import GhostButton, PrimaryButton, SecondaryButton
+from src.design_system.frameless_dialog import (
+    frameless_body_stylesheet,
+    install_frameless_shell,
+)
+from src.design_system.tokens import RADIUS, SCROLLBAR_STYLE, TYPOGRAPHY, get_colors
+from src.language import S
+
+try:
+    import qtawesome as qta
+
+    HAS_QTAWESOME = True
+except ImportError:
+    HAS_QTAWESOME = False
+
+
+class CrashReportDialog(QDialog):
+    """Modal (but non-fatal) dialog that shows an unhandled exception."""
+
+    reported = pyqtSignal(str)  # issue URL
+
+    def __init__(
+        self,
+        *,
+        traceback_text: str,
+        signature: str,
+        version: str = "",
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._traceback = traceback_text or ""
+        self._signature = signature or ""
+        self._version = version or ""
+        self._result_url = ""
+        self._setup_ui()
+
+    # ------------------------------------------------------------------ UI
+
+    def _setup_ui(self) -> None:
+        colors = get_colors()
+
+        self.setWindowTitle(S.crash.title)
+        self.resize(720, 520)
+
+        layout = install_frameless_shell(
+            self,
+            S.crash.title,
+            min_width=520,
+            min_height=360,
+            content_margins=(22, 16, 22, 18),
+            content_spacing=14,
+            resizable=True,
+            show_close=False,
+        )
+        self.setStyleSheet(self.styleSheet() + frameless_body_stylesheet())
+
+        # Header: icon + title + short message
+        header_row = QHBoxLayout()
+        header_row.setSpacing(12)
+        icon_label = QLabel()
+        icon_label.setAlignment(Qt.AlignmentFlag.AlignTop)
+        if HAS_QTAWESOME:
+            icon_label.setPixmap(qta.icon("mdi.alert-circle-outline", color=colors.danger).pixmap(30, 30))
+        header_text = QVBoxLayout()
+        header_text.setSpacing(4)
+        title = QLabel(S.crash.title)
+        title.setStyleSheet(f"color: {colors.text_primary}; font-size: 16px; font-weight: 600;")
+        message = QLabel(S.crash.message)
+        message.setWordWrap(True)
+        message.setStyleSheet(f"color: {colors.text_secondary}; font-size: 12px;")
+        header_text.addWidget(title)
+        header_text.addWidget(message)
+        header_row.addWidget(icon_label)
+        header_row.addLayout(header_text, 1)
+        layout.addLayout(header_row)
+
+        # Meta footer (version / OS / signature / timestamp)
+        meta = QLabel(self._meta_text())
+        meta.setStyleSheet(f"color: {colors.text_tertiary}; font-size: 11px;")
+        meta.setWordWrap(True)
+        layout.addWidget(meta)
+
+        # Traceback area
+        tb_label = QLabel(S.crash.traceback_label)
+        tb_label.setStyleSheet(f"color: {colors.text_secondary}; font-size: 12px; font-weight: 600;")
+        layout.addWidget(tb_label)
+
+        self._traceback_view = QPlainTextEdit(self._traceback)
+        self._traceback_view.setReadOnly(True)
+        mono = QFont("Consolas")
+        mono.setStyleHint(QFont.StyleHint.TypeWriter)
+        self._traceback_view.setFont(mono)
+        self._traceback_view.setStyleSheet(
+            f"""
+            QPlainTextEdit {{
+                background-color: {colors.bg_tertiary};
+                color: {colors.text_primary};
+                border: 1px solid {colors.border_default};
+                border-radius: {RADIUS.radius_sm}px;
+                padding: 8px;
+                font-size: 11px;
+            }}
+            {SCROLLBAR_STYLE}
+            """
+        )
+        layout.addWidget(self._traceback_view, 1)
+
+        # Progress (hidden until reporting)
+        self._progress = QProgressBar()
+        self._progress.setRange(0, 0)
+        self._progress.setTextVisible(False)
+        self._progress.setFixedHeight(4)
+        self._progress.hide()
+        layout.addWidget(self._progress)
+
+        # Status label for report result / errors
+        self._status = QLabel("")
+        self._status.setWordWrap(True)
+        self._status.setStyleSheet(f"color: {colors.text_secondary}; font-size: 11px;")
+        self._status.hide()
+        layout.addWidget(self._status)
+
+        layout.addLayout(self._build_buttons(colors))
+
+    def _meta_text(self) -> str:
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        return (
+            f"DataPyn {self._version or '?'}  •  {platform.system()} {platform.release()}  "
+            f"•  {S.crash.signature}: {self._signature}  •  {ts}"
+        )
+
+    def _build_buttons(self, colors) -> QHBoxLayout:
+        row = QHBoxLayout()
+        row.setSpacing(8)
+        row.addStretch(1)
+
+        self._copy_btn = GhostButton(S.crash.copy)
+        self._copy_btn.clicked.connect(self._on_copy)
+
+        self._continue_btn = SecondaryButton(S.crash.continue_btn)
+        self._continue_btn.clicked.connect(self.accept)
+
+        self._report_btn = PrimaryButton(S.crash.report_btn)
+        self._report_btn.clicked.connect(self._on_report)
+        self._report_btn.setDefault(True)
+
+        row.addWidget(self._copy_btn)
+        row.addWidget(self._continue_btn)
+        row.addWidget(self._report_btn)
+        return row
+
+    # -------------------------------------------------------------- Actions
+
+    def _on_copy(self) -> None:
+        clip = QGuiApplication.clipboard()
+        if clip is not None:
+            clip.setText(self._full_report_text())
+        self._flash_status(S.crash.copied, ok=True)
+
+    def _on_report(self) -> None:
+        self._progress.show()
+        self._status.hide()
+        self._report_btn.setEnabled(False)
+        self._copy_btn.setEnabled(False)
+
+        from PyQt6.QtCore import QThread
+
+        from src.services.crash_reporter_service import CrashReporterWorker
+
+        self._worker = CrashReporterWorker(
+            traceback_text=self._full_report_text(),
+            signature=self._signature,
+            summary=self._short_summary(),
+        )
+        self._worker_thread = QThread(self)
+        self._worker.moveToThread(self._worker_thread)
+        self._worker_thread.started.connect(self._worker.run)
+        self._worker.finished.connect(self._on_report_finished)
+        self._worker.finished.connect(self._worker_thread.quit)
+        self._worker_thread.finished.connect(self._worker_thread.deleteLater)
+        self._worker_thread.start()
+
+    def _on_report_finished(self, url: str, error: str) -> None:
+        self._progress.hide()
+        self._report_btn.setEnabled(True)
+        self._copy_btn.setEnabled(True)
+        if error:
+            self._flash_status(S.crash.report_failed.format(error=error), ok=False)
+            return
+        if url:
+            self._result_url = url
+            self.reported.emit(url)
+            self._flash_status(S.crash.report_success.format(url=url), ok=True)
+            # Open the issue in the browser so the user can follow up
+            try:
+                import webbrowser
+
+                webbrowser.open(url)
+            except Exception:
+                pass
+        else:
+            self._flash_status(S.crash.report_failed.format(error="no URL"), ok=False)
+
+    def _flash_status(self, text: str, *, ok: bool) -> None:
+        colors = get_colors()
+        color = colors.success if ok else colors.danger
+        self._status.setStyleSheet(f"color: {color}; font-size: 11px;")
+        self._status.setText(text)
+        self._status.show()
+
+    # ----------------------------------------------------------- Helpers
+
+    def _short_summary(self) -> str:
+        """One-line summary derived from the last frame of the traceback."""
+        lines = [ln.strip() for ln in self._traceback.splitlines() if ln.strip()]
+        exc_line = ""
+        for ln in reversed(lines):
+            if ln and not ln.startswith((" ", "File ", "Traceback")):
+                exc_line = ln
+                break
+        exc_line = (exc_line or "Unhandled exception")[:120]
+        return f"Crash: {exc_line}"
+
+    def _full_report_text(self) -> str:
+        return (
+            f"DataPyn crash report\n"
+            f"version: {self._version or '?'}\n"
+            f"os: {platform.system()} {platform.release()}\n"
+            f"python: {platform.python_version()}\n"
+            f"signature: datapyn-crash:{self._signature}\n"
+            f"timestamp: {datetime.now().isoformat()}\n"
+            f"\n---- traceback ----\n{self._traceback}\n"
+        )

--- a/source/src/ui/main_window/_main.py
+++ b/source/src/ui/main_window/_main.py
@@ -556,6 +556,9 @@ class MainWindow(
                     if thread and thread.isRunning():
                         thread.quit()
                         if not thread.wait(3000):
+                            logger.warning(
+                                "Background QThread did not stop after quit(); terminating as last resort"
+                            )
                             thread.terminate()
                             thread.wait(1000)
                 except RuntimeError:

--- a/source/src/ui/main_window/_schema.py
+++ b/source/src/ui/main_window/_schema.py
@@ -82,6 +82,49 @@ class SchemaMixin:
         sid = self._session_id_for_object_explorer_sender() or self._get_active_session_id()
         self._schema_service.load_databases(connector, connection_name, session_id=sid or "")
 
+    # DB types that expose a server-wide database/catalog list worth fetching
+    # automatically so the per-block database dropdown is populated.
+    _SERVER_DB_LIST_TYPES = frozenset(("mssql", "sqlserver", "mysql", "mariadb", "databricks"))
+
+    def _maybe_auto_request_databases(
+        self, schema: dict, connection_name: str, db_type: str, session_id: str
+    ) -> None:
+        """After a lazy/minimal schema load, fetch the server database list once.
+
+        Minimal mode (default on connect) loads neither tables nor the server
+        database list, so the per-block database dropdown would stay empty until
+        the user manually expands the OE "Databases" node. Trigger the cheap
+        single-query list load automatically instead.
+        """
+        if not connection_name or not session_id:
+            return
+        if not schema.get("lazy"):
+            return
+        if schema.get("databases"):
+            return
+        if str(db_type or "").lower() not in self._SERVER_DB_LIST_TYPES:
+            return
+
+        if not hasattr(self, "_auto_db_list_requested"):
+            self._auto_db_list_requested = set()
+        key = (connection_name, session_id)
+        if key in self._auto_db_list_requested:
+            return
+        self._auto_db_list_requested.add(key)
+
+        connector = None
+        widget = self._session_widgets.get(session_id) if hasattr(self, "_session_widgets") else None
+        if widget and hasattr(widget, "session") and widget.session:
+            connector = getattr(widget.session, "connector", None)
+        if (connector is None or not self._connector_is_connected(connector)) and connection_name:
+            get_connection = getattr(self.connection_manager, "get_connection", None)
+            if callable(get_connection):
+                connector = get_connection(connection_name)
+        if connector is None or not self._connector_is_connected(connector):
+            return
+
+        self._schema_service.load_databases(connector, connection_name, session_id=session_id)
+
     def _on_databases_loaded(self, connection_name: str, session_id: str, databases: list):
         """Merge on-demand database list into cached schema and refresh OE."""
         if not connection_name or not isinstance(databases, list):
@@ -102,6 +145,13 @@ class SchemaMixin:
                 db_type = self._get_connection_db_type(connection_name)
                 explorer.set_schema(merged, connection_name, db_type=db_type)
                 explorer.add_databases(databases)
+
+        # Push the freshly loaded database list to every SQL block of this session
+        # so the per-block database dropdown is populated (lazy connect path).
+        if sid:
+            self._apply_schema_to_session_blocks(
+                sid, connection_name, merged, db_type=self._get_connection_db_type(connection_name)
+            )
 
     def _on_oe_schemas_requested(self, catalog_name: str):
         """Load schemas for a Databricks catalog (lazy loading)."""
@@ -789,6 +839,11 @@ class SchemaMixin:
             ),
         )
 
+        # Lazy connect: minimal mode loads no server database list. Request it
+        # once so the per-block database dropdown and the OE get populated without
+        # forcing the user to expand the "Databases" node manually.
+        self._maybe_auto_request_databases(schema, connection_name, db_type, requesting_sid)
+
         # Update Object Explorer for the session that REQUESTED this schema
         # (not all sessions - each session has its own OE state)
         if hasattr(self, "_session_explorers"):
@@ -1099,6 +1154,44 @@ class SchemaMixin:
             if connection_name not in self._pending_block_schemas:
                 self._pending_block_schemas[connection_name] = []
             self._pending_block_schemas[connection_name].append(weakref.ref(block))
+
+    def request_databases_for_block(self, block, session_widget) -> None:
+        """Load the server database list when a block's empty dropdown is clicked.
+
+        This is the self-heal fallback for the lazy-connect path: the auto-request
+        in ``_on_schema_loaded`` may not have completed (or the connector was not
+        ready yet), so clicking the empty dropdown triggers the cheap single-query
+        database list load on demand. Results are merged back into the cached
+        schema and pushed to every block of the session via ``_on_databases_loaded``.
+        """
+        if block is None or session_widget is None:
+            return
+
+        session = getattr(session_widget, "session", None)
+        if session is None:
+            return
+
+        block_conn = block.get_connection_name() if hasattr(block, "get_connection_name") else None
+        connection_name = block_conn or getattr(session, "connection_name", "") or ""
+        if not connection_name:
+            return
+
+        sid = session.session_id
+        cached = self._schema_service.get_cached_schema(connection_name, session_id=sid) or {}
+        if cached.get("databases"):
+            return  # already populated
+
+        connector = None
+        if block_conn and hasattr(session_widget, "_peek_sql_connector_for_block"):
+            connector = session_widget._peek_sql_connector_for_block(block, block_conn, None)
+        if connector is None or not self._connector_is_connected(connector):
+            connector = getattr(session, "connector", None)
+        if connector is None or not self._connector_is_connected(connector):
+            connector = self.connection_manager.get_connection(connection_name)
+        if connector is None or not self._connector_is_connected(connector):
+            return
+
+        self._schema_service.load_databases(connector, connection_name, session_id=sid)
 
     def _on_block_connection_changed(self, block, connection_name: str):
         """Callback when an individual block connection changes.

--- a/source/src/ui/main_window/_ui_setup.py
+++ b/source/src/ui/main_window/_ui_setup.py
@@ -251,6 +251,21 @@ class UISetupMixin:
         # Hide until there is an active connection
         self.object_explorer_dock.hide()
 
+        # Smart lazy load: when the dock becomes visible, ask the active
+        # explorer to fetch the server database list (before any focus event).
+        self.object_explorer_dock.visibilityChanged.connect(self._on_object_explorer_visibility_changed)
+
+    def _on_object_explorer_visibility_changed(self, visible: bool) -> None:
+        """When the OE dock is shown, auto-load databases for the active session."""
+        if not visible:
+            return
+        sid = self._get_active_session_id() if hasattr(self, "_get_active_session_id") else ""
+        if not sid or not hasattr(self, "_session_explorers"):
+            return
+        explorer = self._session_explorers.get(sid)
+        if explorer is not None and hasattr(explorer, "maybe_request_databases_on_visibility"):
+            explorer.maybe_request_databases_on_visibility()
+
     def _get_session_explorer(self, session_id: str) -> ObjectExplorerPanel:
         """Returns the ObjectExplorerPanel for the session, creating if necessary."""
         if session_id in self._session_explorers:

--- a/source/src/utils/qt_threading.py
+++ b/source/src/utils/qt_threading.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Optional
 
 from PyQt6.QtCore import QThread
+
+logger = logging.getLogger(__name__)
 
 
 def qthread_is_alive(thread: Optional[QThread]) -> bool:
@@ -51,10 +54,12 @@ def stop_qthread(
         if not qthread_is_running(thread):
             return True
         if force_terminate:
+            logger.warning("Forcing QThread terminate (force_terminate=True)")
             thread.terminate()
             return thread.wait(wait_ms)
         thread.quit()
         if not thread.wait(min(wait_ms, 800)):
+            logger.warning("QThread did not stop after quit(); terminating as last resort")
             thread.terminate()
         return thread.wait(wait_ms)
     except RuntimeError:
@@ -98,6 +103,7 @@ def kick_qthread_stop(
         thread.quit()
         if thread.wait(300):
             return
+        logger.warning("QThread did not stop after quit(); terminating as last resort")
         thread.terminate()
         thread.wait(500)
     except RuntimeError:

--- a/tests/test_copilot_lsp_client.py
+++ b/tests/test_copilot_lsp_client.py
@@ -128,3 +128,31 @@ class TestInlineCompletion:
             {"message": "FetchError: connect ETIMEDOUT", "type": 2},
         )
         assert client.is_degraded
+
+
+class TestReaderThreadSignalMarshalling:
+    def test_did_change_status_emits_on_main_thread(self, qtbot):
+        import threading
+
+        from PyQt6.QtCore import QThread
+        from PyQt6.QtTest import QSignalSpy
+
+        client = CopilotLSPClient("mock-server")
+        spy = QSignalSpy(client.status_changed)
+        main_thread = QThread.currentThread()
+        emit_threads: list = []
+        client.status_changed.connect(lambda _s: emit_threads.append(QThread.currentThread()))
+
+        done = threading.Event()
+
+        def reader_work() -> None:
+            client._handle_notification("didChangeStatus", {"status": "SignedIn"})
+            done.set()
+
+        threading.Thread(target=reader_work, daemon=True).start()
+        assert done.wait(timeout=2.0)
+        qtbot.waitUntil(lambda: len(spy) >= 1, timeout=2000)
+
+        assert len(spy) >= 1
+        assert emit_threads
+        assert emit_threads[0] == main_thread

--- a/tests/test_crash_guard.py
+++ b/tests/test_crash_guard.py
@@ -10,11 +10,14 @@ def test_install_sets_excepthooks(qapp):
     from src.core import crash_guard
 
     crash_guard._installed = False
+    crash_guard._dispatcher = None
     crash_guard.install_crash_guard(qapp)
 
     assert sys.excepthook is crash_guard._handle_exception
     assert threading.excepthook is crash_guard._thread_excepthook
     assert crash_guard._installed is True
+    assert crash_guard._dispatcher is not None
+    assert crash_guard._dispatcher.parent() is qapp
 
     # Idempotent.
     crash_guard.install_crash_guard(qapp)
@@ -22,6 +25,7 @@ def test_install_sets_excepthooks(qapp):
 
     crash_guard._installed = False
     crash_guard._app_ref = None
+    crash_guard._dispatcher = None
     sys.excepthook = sys.__excepthook__
     try:
         threading.excepthook = threading.__excepthook__
@@ -78,6 +82,7 @@ def test_handle_exception_records_and_schedules_dialog(qapp, monkeypatch):
 
     crash_guard._installed = False
     crash_guard._app_ref = None
+    crash_guard._dispatcher = None
     sys.excepthook = sys.__excepthook__
     try:
         threading.excepthook = threading.__excepthook__
@@ -101,3 +106,59 @@ def test_notify_wrapper_records_and_returns_false(qapp, monkeypatch):
     assert result is False
     assert len(recorded) == 1
     assert recorded[0][1]["source"] == "QApplication.notify"
+
+
+def test_dispatcher_marshals_dialog_to_ui_thread(qapp, monkeypatch):
+    """Emitting dispatch from a worker thread must run the dialog on the UI thread."""
+    import threading as _threading
+
+    from PyQt6.QtCore import QThread
+    from PyQt6.QtTest import QSignalSpy
+
+    from src.core import crash_guard
+
+    crash_guard._installed = False
+    crash_guard._dispatcher = None
+    crash_guard.install_crash_guard(qapp)
+
+    shown = []
+    main_thread = QThread.currentThread()
+
+    class _FakeDialog:
+        def __init__(self, **kwargs):
+            shown.append(kwargs)
+
+        def exec(self):
+            return 0
+
+    monkeypatch.setattr(
+        "src.ui.dialogs.crash_report_dialog.CrashReportDialog", _FakeDialog, raising=False
+    )
+
+    done = _threading.Event()
+
+    def worker():
+        crash_guard._show_crash_dialog_on_ui("TB", "sig123")
+        done.set()
+
+    _threading.Thread(target=worker, daemon=True).start()
+    assert done.wait(timeout=2.0)
+
+    spy = QSignalSpy(crash_guard._dispatcher.dispatch)
+    qapp.processEvents()
+    # The queued emission must be delivered to the UI thread.
+    if len(spy) == 0:
+        qapp.processEvents()
+
+    assert shown, "dialog was not shown on the UI thread"
+    assert shown[0]["traceback_text"] == "TB"
+    assert shown[0]["signature"] == "sig123"
+
+    crash_guard._installed = False
+    crash_guard._app_ref = None
+    crash_guard._dispatcher = None
+    sys.excepthook = sys.__excepthook__
+    try:
+        threading.excepthook = threading.__excepthook__
+    except Exception:
+        pass

--- a/tests/test_crash_guard.py
+++ b/tests/test_crash_guard.py
@@ -1,0 +1,103 @@
+"""Crash guard — global exception interceptor tests."""
+
+import sys
+import threading
+
+import pytest
+
+
+def test_install_sets_excepthooks(qapp):
+    from src.core import crash_guard
+
+    crash_guard._installed = False
+    crash_guard.install_crash_guard(qapp)
+
+    assert sys.excepthook is crash_guard._handle_exception
+    assert threading.excepthook is crash_guard._thread_excepthook
+    assert crash_guard._installed is True
+
+    # Idempotent.
+    crash_guard.install_crash_guard(qapp)
+    assert crash_guard._installed is True
+
+    crash_guard._installed = False
+    crash_guard._app_ref = None
+    sys.excepthook = sys.__excepthook__
+    try:
+        threading.excepthook = threading.__excepthook__
+    except Exception:
+        pass
+
+
+def test_signature_is_stable_across_line_numbers():
+    from src.core import crash_guard
+
+    tb_a = (
+        'Traceback (most recent call last):\n'
+        '  File "source/foo.py", line 12, in bar\n'
+        '    raise ValueError("boom")\n'
+        'ValueError: boom\n'
+    )
+    tb_b = (
+        'Traceback (most recent call last):\n'
+        '  File "source/foo.py", line 999, in bar\n'
+        '    raise ValueError("boom")\n'
+        'ValueError: boom\n'
+    )
+    assert crash_guard._signature(tb_a) == crash_guard._signature(tb_b)
+
+
+def test_signature_differs_for_different_files():
+    from src.core import crash_guard
+
+    tb_a = 'File "source/foo.py", line 1, in bar\nValueError: boom\n'
+    tb_b = 'File "source/other.py", line 1, in bar\nValueError: boom\n'
+    assert crash_guard._signature(tb_a) != crash_guard._signature(tb_b)
+
+
+def test_handle_exception_records_and_schedules_dialog(qapp, monkeypatch):
+    from src.core import crash_guard
+
+    crash_guard._installed = False
+    crash_guard.install_crash_guard(qapp)
+
+    recorded = []
+    scheduled = []
+
+    monkeypatch.setattr(crash_guard, "_record_crash", lambda *a, **k: recorded.append((a, k)))
+    monkeypatch.setattr(crash_guard, "_show_crash_dialog_on_ui", lambda *a: scheduled.append(a))
+
+    try:
+        raise RuntimeError("kaboom")
+    except RuntimeError:
+        crash_guard._handle_exception(*sys.exc_info())
+
+    assert len(recorded) == 1
+    assert len(scheduled) == 1
+    assert "RuntimeError: kaboom" in scheduled[0][0]
+
+    crash_guard._installed = False
+    crash_guard._app_ref = None
+    sys.excepthook = sys.__excepthook__
+    try:
+        threading.excepthook = threading.__excepthook__
+    except Exception:
+        pass
+
+
+def test_notify_wrapper_records_and_returns_false(qapp, monkeypatch):
+    from src.core import crash_guard
+
+    def fake_notify(self, receiver, event):
+        raise RuntimeError("notify boom")
+
+    recorded = []
+    monkeypatch.setattr(crash_guard, "_record_crash", lambda *a, **k: recorded.append((a, k)))
+    monkeypatch.setattr(crash_guard, "_show_crash_dialog_on_ui", lambda *a: None)
+
+    wrapper = crash_guard._make_notify_wrapper(fake_notify)
+    result = wrapper(qapp, None, None)
+
+    assert result is False
+    assert len(recorded) == 1
+    assert recorded[0][1]["source"] == "QApplication.notify"

--- a/tests/test_crash_reporter_service.py
+++ b/tests/test_crash_reporter_service.py
@@ -1,0 +1,116 @@
+"""Crash reporter service — gh dedupe / create / browser fallback tests."""
+
+from unittest.mock import patch
+
+import pytest
+
+
+def test_browser_fallback_when_gh_missing():
+    from src.services import crash_reporter_service as svc
+
+    with (
+        patch.object(svc, "_gh_executable", return_value=""),
+        patch.object(svc, "_browser_fallback", return_value="https://example/issue") as fb,
+    ):
+        url, error = svc.report_crash(
+            traceback_text="tb", signature="abc123", summary="Boom"
+        )
+
+    assert url == "https://example/issue"
+    assert error is None
+    fb.assert_called_once()
+    title, body = fb.call_args.args
+    assert "datapyn-crash:abc123" in title
+    assert body == "tb"
+
+
+def test_browser_fallback_when_gh_not_logged_in():
+    from src.services import crash_reporter_service as svc
+
+    with (
+        patch.object(svc, "_gh_executable", return_value="/usr/bin/gh"),
+        patch.object(svc, "_is_gh_logged_in", return_value=False),
+        patch.object(svc, "_browser_fallback", return_value="https://example/issue") as fb,
+    ):
+        url, error = svc.report_crash(
+            traceback_text="tb", signature="abc123", summary="Boom"
+        )
+
+    assert url == "https://example/issue"
+    assert error is None
+    fb.assert_called_once()
+
+
+def test_dedupe_comments_on_existing_issue():
+    from src.services import crash_reporter_service as svc
+
+    with (
+        patch.object(svc, "_gh_executable", return_value="/usr/bin/gh"),
+        patch.object(svc, "_is_gh_logged_in", return_value=True),
+        patch.object(svc, "_find_existing_issue", return_value=42),
+        patch.object(svc, "_comment_issue", return_value="https://github.com/natharuc/datapyn/issues/42") as comment,
+        patch.object(svc, "_create_issue") as create,
+    ):
+        url, error = svc.report_crash(
+            traceback_text="tb", signature="abc123", summary="Boom"
+        )
+
+    assert url == "https://github.com/natharuc/datapyn/issues/42"
+    assert error is None
+    comment.assert_called_once()
+    create.assert_not_called()
+    # The comment body must include the signature marker.
+    assert "datapyn-crash:abc123" in comment.call_args.args[1]
+
+
+def test_creates_new_issue_when_no_match():
+    from src.services import crash_reporter_service as svc
+
+    with (
+        patch.object(svc, "_gh_executable", return_value="/usr/bin/gh"),
+        patch.object(svc, "_is_gh_logged_in", return_value=True),
+        patch.object(svc, "_find_existing_issue", return_value=None),
+        patch.object(svc, "_create_issue", return_value="https://github.com/natharuc/datapyn/issues/7") as create,
+        patch.object(svc, "_comment_issue") as comment,
+    ):
+        url, error = svc.report_crash(
+            traceback_text="tb", signature="abc123", summary="Boom"
+        )
+
+    assert url == "https://github.com/natharuc/datapyn/issues/7"
+    assert error is None
+    create.assert_called_once()
+    comment.assert_not_called()
+    title, body = create.call_args.args
+    assert "datapyn-crash:abc123" in title
+    assert body == "tb"
+
+
+def test_browser_fallback_when_create_fails():
+    from src.services import crash_reporter_service as svc
+
+    with (
+        patch.object(svc, "_gh_executable", return_value="/usr/bin/gh"),
+        patch.object(svc, "_is_gh_logged_in", return_value=True),
+        patch.object(svc, "_find_existing_issue", return_value=None),
+        patch.object(svc, "_create_issue", return_value=None),
+        patch.object(svc, "_browser_fallback", return_value="https://example/issue") as fb,
+    ):
+        url, error = svc.report_crash(
+            traceback_text="tb", signature="abc123", summary="Boom"
+        )
+
+    assert url == "https://example/issue"
+    assert error is None
+    fb.assert_called_once()
+
+
+def test_browser_fallback_url_is_quoted():
+    from src.services import crash_reporter_service as svc
+
+    with patch.object(svc.webbrowser, "open") as wb:
+        url = svc._browser_fallback("Boom [x]", "line 1\nline 2")
+
+    assert "github.com/natharuc/datapyn/issues/new" in url
+    assert "title=Boom%20%5Bx%5D" in url
+    wb.assert_called_once_with(url)

--- a/tests/test_object_explorer.py
+++ b/tests/test_object_explorer.py
@@ -2000,3 +2000,62 @@ class TestObjectExplorerEnhancedContextMenu:
         query = f"SELECT {cols_quoted}\nFROM {quoted_table}\nLIMIT 1000"
         assert "LIMIT 1000" in query
         assert "id" in query
+
+
+class TestObjectExplorerFocusAutoLoad:
+    """Smart lazy load: focus/visibility triggers databases_requested once per connection."""
+
+    def test_focus_emits_databases_requested_once(self, qtbot):
+        """Focusing the tree emits databases_requested once when the db list is empty."""
+        explorer = ObjectExplorerPanel()
+        qtbot.addWidget(explorer)
+
+        # Minimal schema (lazy, no server db list) for a SQL Server connection.
+        schema = {"database": "AppDb", "tables": [], "columns": {}, "lazy": True}
+        explorer.set_schema(schema, "Gecon", db_type="mssql")
+
+        emitted = []
+        explorer.databases_requested.connect(lambda: emitted.append(True))
+
+        # First focus must trigger the request.
+        explorer.tree.setFocus()
+        explorer._maybe_request_databases_on_focus()
+        assert len(emitted) == 1
+
+        # Second focus must NOT re-trigger (guard set).
+        explorer._maybe_request_databases_on_focus()
+        assert len(emitted) == 1
+
+    def test_focus_skipped_when_databases_loaded(self, qtbot):
+        """No request when the server db list is already populated."""
+        explorer = ObjectExplorerPanel()
+        qtbot.addWidget(explorer)
+
+        schema = {
+            "database": "AppDb",
+            "databases": ["AppDb", "master"],
+            "tables": [],
+            "columns": {},
+        }
+        explorer.set_schema(schema, "Gecon", db_type="mssql")
+
+        emitted = []
+        explorer.databases_requested.connect(lambda: emitted.append(True))
+        explorer._maybe_request_databases_on_focus()
+        assert emitted == []
+
+    def test_connection_change_resets_guard(self, qtbot):
+        """Switching connection resets the focus-trigger guard so it re-loads."""
+        explorer = ObjectExplorerPanel()
+        qtbot.addWidget(explorer)
+
+        explorer.set_schema({"database": "A", "tables": [], "columns": {}}, "conn1", db_type="mssql")
+        emitted = []
+        explorer.databases_requested.connect(lambda: emitted.append(True))
+        explorer._maybe_request_databases_on_focus()
+        assert len(emitted) == 1
+
+        # New connection -> guard resets.
+        explorer.set_schema({"database": "B", "tables": [], "columns": {}}, "conn2", db_type="mssql")
+        explorer._maybe_request_databases_on_focus()
+        assert len(emitted) == 2

--- a/tests/test_pynia_subagents.py
+++ b/tests/test_pynia_subagents.py
@@ -152,7 +152,7 @@ def test_run_explore_parallel_times_out(qtbot, monkeypatch):
 
 
 def test_run_explore_parallel_cancels(qtbot, monkeypatch):
-    """Pressing Stop (is_cancelled) unblocks the nested loop."""
+    """Pressing Stop (is_cancelled) unblocks the wait loop."""
     import time
 
     _install_hanging_worker(monkeypatch)
@@ -169,6 +169,19 @@ def test_run_explore_parallel_cancels(qtbot, monkeypatch):
 
     assert elapsed < 5, "cancellation should unblock promptly"
     assert results and results[0].summary == "Cancelled by user."
+
+
+def test_run_explore_parallel_no_qevent_loop_or_qtimer():
+    """Parallel explore must not import or use QEventLoop or QTimer."""
+    from pathlib import Path
+
+    src = Path("source/src/services/pynia/subagents/orchestrator.py").read_text(encoding="utf-8")
+    for line in src.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        assert "QEventLoop" not in line
+        assert "QTimer" not in line
 
 
 def test_should_delegate_matches_portuguese():

--- a/tests/test_schema_service_lazy.py
+++ b/tests/test_schema_service_lazy.py
@@ -53,3 +53,35 @@ def test_schema_worker_full_loads_databases():
 
     calls = [str(call.args[0]) for call in connector.execute_query.call_args_list]
     assert any("sys.databases" in q for q in calls)
+
+
+def test_load_databases_emits_databases_loaded(qtbot):
+    """SchemaService.load_databases fetches the server db list and emits databases_loaded."""
+    import pandas as pd
+
+    from src.services.schema_service import SchemaService
+
+    connector = MagicMock()
+    connector.db_type = "sqlserver"
+    connector.execute_query.return_value = pd.DataFrame({"name": ["master", "AppDb", "tempdb"]})
+
+    service = SchemaService()
+    captured: dict = {}
+
+    def _on_loaded(connection_name, session_id, databases):
+        captured["connection_name"] = connection_name
+        captured["session_id"] = session_id
+        captured["databases"] = list(databases or [])
+
+    service.databases_loaded.connect(_on_loaded)
+
+    service.load_databases(connector, "Gecon", session_id="sid-1")
+
+    qtbot.waitUntil(lambda: "databases" in captured, timeout=3000)
+
+    assert captured["connection_name"] == "Gecon"
+    assert captured["session_id"] == "sid-1"
+    assert captured["databases"] == ["master", "AppDb", "tempdb"]
+
+    service.cleanup()
+

--- a/tests/test_session_restore_signal_threading.py
+++ b/tests/test_session_restore_signal_threading.py
@@ -1,0 +1,63 @@
+"""Thread-affinity tests for session variable restore."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from PyQt6.QtCore import Qt, QThread, pyqtSignal
+from PyQt6.QtTest import QSignalSpy
+from PyQt6.QtWidgets import QWidget
+
+from src.ui.components.session_widget import SessionWidget
+
+
+class _RestoreHost(QWidget):
+    """Minimal QWidget stand-in for SessionWidget restore path."""
+
+    _persisted_variables_loaded = pyqtSignal(object)
+    _restore_dispatch = pyqtSignal(object)
+
+    def __init__(self, session_id: str = "s1", parent=None):
+        super().__init__(parent)
+        self.session = MagicMock(session_id=session_id)
+        self._restore_dispatch.connect(
+            self._emit_persisted_variables_loaded,
+            Qt.ConnectionType.QueuedConnection,
+        )
+
+    def _emit_persisted_variables_loaded(self, variables: object) -> None:
+        self._persisted_variables_loaded.emit(variables)
+
+
+def test_persisted_variables_loaded_emits_on_main_thread(qtbot):
+    host = _RestoreHost()
+    qtbot.addWidget(host)
+
+    main_thread = QThread.currentThread()
+    emit_threads: list = []
+    host._persisted_variables_loaded.connect(
+        lambda _v: emit_threads.append(QThread.currentThread())
+    )
+    spy = QSignalSpy(host._persisted_variables_loaded)
+
+    with (
+        patch(
+            "src.core.session_result_storage.is_session_result_restore_enabled",
+            return_value=True,
+        ),
+        patch(
+            "src.core.session_result_storage.has_persisted_snapshot",
+            return_value=True,
+        ),
+        patch(
+            "src.core.session_result_storage.SessionResultStorage.load",
+            return_value={"df": 1},
+        ),
+    ):
+        SessionWidget._restore_variables_from_disk(host, require_enabled=True)
+
+    qtbot.waitUntil(lambda: len(spy) >= 1, timeout=3000)
+
+    assert len(spy) >= 1
+    assert emit_threads
+    assert emit_threads[0] == main_thread

--- a/uv.lock
+++ b/uv.lock
@@ -535,7 +535,7 @@ wheels = [
 
 [[package]]
 name = "datapyn"
-version = "1.50.0"
+version = "1.52.0"
 source = { virtual = "." }
 dependencies = [
     { name = "azure-identity" },


### PR DESCRIPTION
## Summary
- **Block database dropdown empty after lazy connect**: push the server database list to every SQL block in `_on_databases_loaded`, auto-request `load_databases` once after a minimal connect (mssql/mysql/databricks), and self-heal on empty-dropdown click via a new `databases_requested` signal (DatabasePanel -> CodeBlock -> BlockEditor -> SessionWidget -> MainWindow).
- **Object Explorer lazy load on focus**: `focusInEvent` + dock `visibilityChanged` emit `databases_requested` once per connection so databases load when the user focuses/opens the OE, not only on manual expand.
- **Global crash interceptor**: `sys.excepthook` + `threading.excepthook` + `QApplication.notify` override surface a formatted frameless crash dialog (Report on GitHub via `gh` dedupe/comment-or-create with browser fallback, Copy, Continue) and **never** `sys.exit`. Crashes are logged to a rotating `crashes.log` with a stable signature. The dialog is marshalled to the UI thread via a `QueuedConnection` signal (pattern reused from `fix/application-crashes`).
- **Hotfix included**: idle reaper read `is_periodic_active` (a `@property`) as a method -> `TypeError` crash on every tick after idle; fixed by dropping the parens.
- **Merged `fix/application-crashes`**: cross-thread signal marshalling + graceful `quit()`-before-`terminate()` QThread shutdown. These root-cause fixes complement the crash guard (fewer cross-thread Qt6Core crashes reach the interceptor in the first place).

## Test plan
- [x] `tests/test_schema_service_lazy.py` — `load_databases` emits `databases_loaded`; minimal `load_schema` does NOT fetch databases.
- [x] `tests/test_object_explorer.py` — focus emits `databases_requested` once; skipped when already loaded; connection change resets the guard.
- [x] `tests/test_crash_guard.py` — installs hooks (idempotent), stable signature, `_handle_exception` records+schedules, `notify` wrapper returns False, dispatcher marshals dialog to UI thread from a worker thread.
- [x] `tests/test_crash_reporter_service.py` — gh dedupe (comment), create, browser fallback (quoted URL), no real network.
- [x] Merged-branch tests pass: `test_session_restore_signal_threading.py`, `test_pynia_subagents.py`, `test_copilot_lsp_client.py`.
- [x] `uv run ruff check source/` clean.
- [ ] CI green on push.
