### PR TITLE
fix(schema): populate per-block database dropdown on connect

### DIFF
--- a/source/src/editors/code_block.py
+++ b/source/src/editors/code_block.py
@@ -210,6 +210,7 @@ class BlockDatabasePanel(QFrame):
         super().__init__(parent)
         self._database_name = None
         self._available_databases: list = []
+        self._loading_feedback = False
         self._setup_ui()
         self.setAcceptDrops(True)
         self.setCursor(Qt.CursorShape.PointingHandCursor)
@@ -279,6 +280,8 @@ class BlockDatabasePanel(QFrame):
     def set_available_databases(self, databases: list):
         """Set the list of databases available for selection."""
         self._available_databases = list(databases) if databases else []
+        if self._available_databases:
+            self._restore_label_after_load()
 
     def get_available_databases(self) -> list:
         """Return list of available databases."""
@@ -290,11 +293,33 @@ class BlockDatabasePanel(QFrame):
             if self._available_databases:
                 self._show_database_menu()
             else:
-                # Empty dropdown: ask for the server database list (lazy connect),
-                # then fall back to the default click behavior.
+                # Empty dropdown: ask the host for the server database list (lazy
+                # connect / load still in flight) and show non-blocking feedback on
+                # the panel itself. ``set_available_databases`` restores the label
+                # once the list arrives, so the next click shows the real menu.
                 self.databases_requested.emit()
+                self._show_loading_feedback()
                 self.database_clicked.emit()
         super().mousePressEvent(event)
+
+    def _show_loading_feedback(self):
+        """Non-blocking 'loading databases' feedback on the panel label."""
+        from src.design_system.tokens import get_colors
+
+        self._loading_feedback = True
+        colors = get_colors()
+        self.name_label.setText(S.block.db_loading)
+        self.name_label.setStyleSheet(
+            f"color: {colors.text_tertiary}; font-size: 11px; font-style: italic;"
+        )
+
+    def _restore_label_after_load(self):
+        """Restore the panel label after loading feedback (called when dbs arrive)."""
+        if not getattr(self, "_loading_feedback", False):
+            return
+        self._loading_feedback = False
+        # Re-apply the current database label/style via set_database.
+        self.set_database(self._database_name)
 
     def _show_database_menu(self):
         """Show popup menu with available databases."""

--- a/source/src/language/en-US.json
+++ b/source/src/language/en-US.json
@@ -710,6 +710,7 @@
     "conn_tab_default": "Tab Default",
     "conn_first_block_locked": "First block uses the tab connection",
     "db_default": "Default DB",
+    "db_loading": "Loading databases...",
     "lang_python": "Python",
     "lang_sql": "SQL",
     "lang_cross_syntax": "Cross-Syntax",

--- a/source/src/language/pt-BR.json
+++ b/source/src/language/pt-BR.json
@@ -710,6 +710,7 @@
     "conn_tab_default": "Padrao da Aba",
     "conn_first_block_locked": "O primeiro bloco usa a conexao da aba",
     "db_default": "BD Padrao",
+    "db_loading": "Carregando bancos...",
     "lang_python": "Python",
     "lang_sql": "SQL",
     "lang_cross_syntax": "Cross-Syntax",

--- a/source/src/services/schema_service.py
+++ b/source/src/services/schema_service.py
@@ -132,7 +132,13 @@ class SchemaWorker(QObject):
             if self._cancelled:
                 return
 
-            load_databases = self._lazy_mode == SCHEMA_LAZY_FULL
+            # The server database/catalog list is a single cheap catalog query
+            # (sys.databases / SHOW DATABASES / SHOW CATALOGS / current_database).
+            # Load it even in minimal mode so the per-block database dropdown is
+            # populated right after connect -- the user must not see an empty
+            # combobox that only "comes alive" after a manual OE expand.
+            # Tables/columns/routines stay lazy (those are the expensive queries).
+            load_databases = self._lazy_mode in (SCHEMA_LAZY_FULL, SCHEMA_LAZY_MINIMAL)
             load_metadata = self._lazy_mode in (SCHEMA_LAZY_FULL, SCHEMA_LAZY_AUTOCOMPLETE)
 
             # Get list of all server databases (full schema / OE expand only)

--- a/tests/test_block_database.py
+++ b/tests/test_block_database.py
@@ -97,6 +97,42 @@ class TestBlockDatabasePanel:
         panel.mousePressEvent(event)
         assert len(clicked) == 1
 
+    def test_empty_click_requests_databases_and_shows_loading(self, qapp):
+        """Clicking an empty dropdown requests the db list and shows loading feedback."""
+        panel = BlockDatabasePanel()
+        requested = []
+        panel.databases_requested.connect(lambda: requested.append(True))
+
+        from PyQt6.QtGui import QMouseEvent
+        from PyQt6.QtCore import QEvent
+
+        event = QMouseEvent(
+            QEvent.Type.MouseButtonPress,
+            QPointF(10, 10),
+            Qt.MouseButton.LeftButton,
+            Qt.MouseButton.LeftButton,
+            Qt.KeyboardModifier.NoModifier,
+        )
+        panel.mousePressEvent(event)
+
+        assert len(requested) == 1
+        assert panel._loading_feedback is True
+        assert panel.name_label.text() == "Loading databases..."
+
+    def test_set_available_databases_restores_label_after_load(self, qapp):
+        """When databases arrive after loading feedback, the label is restored."""
+        panel = BlockDatabasePanel()
+        panel.set_database("AppDb")
+
+        # Simulate the empty-click loading feedback path.
+        panel._show_loading_feedback()
+        assert panel.name_label.text() == "Loading databases..."
+
+        # Host pushes the freshly loaded database list.
+        panel.set_available_databases(["AppDb", "Other"])
+        assert panel._loading_feedback is False
+        assert panel.name_label.text() == "AppDb"
+
     def test_panel_drop_emits_signal(self, qapp):
         """Drop de banco deve emitir database_dropped(name)"""
         panel = BlockDatabasePanel()

--- a/tests/test_schema_service_lazy.py
+++ b/tests/test_schema_service_lazy.py
@@ -12,16 +12,24 @@ from src.services.schema_service import (
 )
 
 
-def test_schema_worker_minimal_skips_metadata_queries():
+def test_schema_worker_minimal_loads_databases_only():
+    """Minimal mode loads the cheap server database list but skips tables/columns/routines."""
     connector = MagicMock()
     connector.db_type = "sqlserver"
     connector.get_current_database.return_value = "AppDb"
     connector.get_current_database_context.return_value = "AppDb"
+    connector.execute_query.return_value = None
 
     worker = SchemaWorker(connector, lazy_mode=SCHEMA_LAZY_MINIMAL)
     worker.run()
 
-    connector.execute_query.assert_not_called()
+    calls = [str(call.args[0]) for call in connector.execute_query.call_args_list]
+    # The single cheap catalog query for the server database list.
+    assert any("sys.databases" in q for q in calls)
+    # No tables/columns/routines metadata in minimal mode.
+    assert not any("INFORMATION_SCHEMA.TABLES" in q for q in calls)
+    assert not any("INFORMATION_SCHEMA.COLUMNS" in q for q in calls)
+    assert not any("INFORMATION_SCHEMA.ROUTINES" in q for q in calls)
 
 
 def test_schema_worker_autocomplete_loads_tables_not_databases():


### PR DESCRIPTION
## Summary
The per-block database combobox stayed empty after a lazy connect: minimal mode (the default on connect) only fetched the server database list in `SCHEMA_LAZY_FULL`, so `schema["databases"]` was `[]` and clicking the dropdown did nothing visible (the list never arrived). The user only saw `Schema loaded (Gecon): 0 tables, 0 columns`.

- **`SchemaWorker` minimal mode now loads the server database list** — the cheap single catalog query (`sys.databases` / `SHOW DATABASES` / `SHOW CATALOGS` / `current_database`) runs in minimal mode too, so `schema["databases"]` is populated right after connect. `_apply_loaded_schema_to_blocks` then pushes it to every SQL block via `set_available_databases`. Tables/columns/routines stay lazy (those are the expensive queries).
- **Non-blocking "Loading databases..." feedback** on the panel label when the empty dropdown is clicked (load still in flight or failed), restored automatically once the list arrives via `set_available_databases`.

## Test plan
- [x] `tests/test_schema_service_lazy.py` — minimal mode now loads databases but still skips tables/columns/routines; `load_databases` still emits `databases_loaded`.
- [x] `tests/test_block_database.py` — empty click emits `databases_requested` and shows loading feedback; `set_available_databases` restores the label.
- [x] `uv run ruff check source/` clean.
- [ ] CI green on push.
