### PR TITLE
fix(connections): resolve saved connections by group and name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ override-dependencies = [
     "click>=8.3.3",
     "pillow>=12.3.0",
     "setuptools>=83.0.0",
+    "gitpython>=3.1.55",
 ]
 
 

--- a/source/src/core/connection_ref.py
+++ b/source/src/core/connection_ref.py
@@ -73,10 +73,10 @@ def resolve_by_name_only(manager: ConnectionManager, name: str) -> Optional[Conn
     ungrouped = [ref for ref in matches if not ref.group]
     if len(ungrouped) == 1:
         return ungrouped[0]
-    logger.warning(
-        "Ambiguous connection name %r (%d matches); using first match %s",
+    logger.error(
+        "Ambiguous connection name %r (%d matches in different groups); "
+        "specify connection_group and connection_name",
         name,
         len(matches),
-        matches[0].display(),
     )
-    return matches[0]
+    return None

--- a/source/src/core/session.py
+++ b/source/src/core/session.py
@@ -456,9 +456,11 @@ class Session(QObject):
         if self._connection_name and connection_manager:
             ref = self.connection_ref
             if ref is None:
-                ref = resolve_by_name_only(connection_manager, self._connection_name)
-            if ref is None:
                 return
+            if not ref.group:
+                resolved = resolve_by_name_only(connection_manager, ref.name)
+                if resolved is not None:
+                    ref = resolved
 
             connector = connection_manager.get_connection(ref.group, ref.name)
             if connector and connector.is_connected():

--- a/source/src/database/block_connector_pool.py
+++ b/source/src/database/block_connector_pool.py
@@ -6,6 +6,7 @@ import logging
 import time
 from typing import Dict, List, Optional
 
+from src.core.connection_ref import ConnectionRef
 from src.database.database_connector import DatabaseConnector, get_connector_database_context
 
 logger = logging.getLogger(__name__)
@@ -59,6 +60,10 @@ def connect_connector_from_config(
     return connector
 
 
+def _connection_storage_key(connection_group: str, connection_name: str) -> str:
+    return ConnectionRef(group=connection_group or "", name=connection_name).storage_key()
+
+
 class BlockConnectorPool:
     """Keeps one live connector per block key (isolated sessions)."""
 
@@ -68,14 +73,16 @@ class BlockConnectorPool:
     def peek_connected(
         self,
         block_key: str,
+        connection_group: str,
         connection_name: str,
         *,
         database: Optional[str] = None,
         database_context: Optional[str] = None,
     ) -> Optional[DatabaseConnector]:
         """Return an existing live connector without opening a new connection."""
+        storage_key = _connection_storage_key(connection_group, connection_name)
         entry = self._entries.get(block_key)
-        if not entry or entry.get("connection_name") != connection_name:
+        if not entry or entry.get("connection_key") != storage_key:
             return None
         connector = entry.get("connector")
         if connector is None or not connector.is_connected():
@@ -87,6 +94,7 @@ class BlockConnectorPool:
     def get(
         self,
         block_key: str,
+        connection_group: str,
         connection_name: str,
         config: dict,
         *,
@@ -94,8 +102,9 @@ class BlockConnectorPool:
         database: Optional[str] = None,
         database_context: Optional[str] = None,
     ) -> DatabaseConnector:
+        storage_key = _connection_storage_key(connection_group, connection_name)
         entry = self._entries.get(block_key)
-        if entry and entry.get("connection_name") == connection_name:
+        if entry and entry.get("connection_key") == storage_key:
             connector = entry.get("connector")
             if connector is not None and connector.is_connected():
                 self._touch(block_key)
@@ -119,19 +128,25 @@ class BlockConnectorPool:
 
         self._entries[block_key] = {
             "connector": connector,
-            "connection_name": connection_name,
+            "connection_key": storage_key,
             "last_used_at": time.monotonic(),
         }
         return connector
 
-    def register(self, block_key: str, connection_name: str, connector: DatabaseConnector) -> None:
+    def register(
+        self,
+        block_key: str,
+        connection_group: str,
+        connection_name: str,
+        connector: DatabaseConnector,
+    ) -> None:
         """Adopt an already-connected connector (e.g. after auto-connect worker)."""
         existing = self._entries.get(block_key)
         if existing and existing.get("connector") is not connector:
             self._disconnect(existing.get("connector"))
         self._entries[block_key] = {
             "connector": connector,
-            "connection_name": connection_name,
+            "connection_key": _connection_storage_key(connection_group, connection_name),
             "last_used_at": time.monotonic(),
         }
 

--- a/source/src/editors/block_editor.py
+++ b/source/src/editors/block_editor.py
@@ -152,7 +152,7 @@ class BlockEditor(QWidget):
     block_removed = pyqtSignal(object)  # CodeBlock
 
     # Signal when connection is dropped on editor area (to connect session)
-    connection_drop_requested = pyqtSignal(str)  # connection_name
+    connection_drop_requested = pyqtSignal(str, str)  # group, name
 
     # Signal when data file is dropped (to show import dialog)
     file_dropped = pyqtSignal(str)  # file_path
@@ -1284,7 +1284,11 @@ class BlockEditor(QWidget):
 
                 # Restore custom connection only for blocks after the first
                 if "connection_name" in data:
-                    block.set_connection_name(data["connection_name"], data.get("db_type"))
+                    block.set_connection_name(
+                        data["connection_name"],
+                        data.get("db_type"),
+                        connection_group=data.get("connection_group"),
+                    )
 
             # Restore block name
             if "block_name" in data and data["block_name"]:
@@ -1484,12 +1488,15 @@ class BlockEditor(QWidget):
         and optionally the database.
         """
         conn_name = ""
+        conn_group = ""
         db_type = ""
         color = ""
         db_name = ""
 
         if mime_data.hasFormat("application/x-connection-name"):
             conn_name = bytes(mime_data.data("application/x-connection-name")).decode("utf-8")
+        if mime_data.hasFormat("application/x-connection-group"):
+            conn_group = bytes(mime_data.data("application/x-connection-group")).decode("utf-8")
         if mime_data.hasFormat("application/x-db-type"):
             db_type = bytes(mime_data.data("application/x-db-type")).decode("utf-8")
         if mime_data.hasFormat("application/x-connection-color"):
@@ -1500,7 +1507,12 @@ class BlockEditor(QWidget):
         block = self.add_block(language="sql", isolate_sql_context=True)
 
         if conn_name:
-            block.set_connection_name(conn_name, db_type=db_type or None, color=color or None)
+            block.set_connection_name(
+                conn_name,
+                db_type=db_type or None,
+                color=color or None,
+                connection_group=conn_group or None,
+            )
 
         if db_name:
             block.set_database_name(db_name)

--- a/source/src/services/copilot/mcp_tools.py
+++ b/source/src/services/copilot/mcp_tools.py
@@ -1390,6 +1390,7 @@ class MCPToolRegistry(QObject):
     def _connect_database(self, args: Dict[str, Any]) -> Dict[str, Any]:
         """Connect the current session to a database."""
         connection_name = args.get("connection_name", "")
+        connection_group = str(args.get("connection_group") or "")
         if not connection_name:
             return {"error": "connection_name is required."}
 
@@ -1398,20 +1399,27 @@ class MCPToolRegistry(QObject):
         if not conn_manager:
             return {"error": "Connection manager not available."}
 
-        config = conn_manager.get_connection_config_by_name(connection_name)
+        config = conn_manager.get_connection_config(connection_group, connection_name)
         if not config:
-            saved = [ref.display() for ref in conn_manager.get_saved_connections()]
-            return {"error": f"Connection '{connection_name}' not found. Available: {saved}"}
-
-        ref = conn_manager.get_connection_ref_by_name(connection_name)
-        group = ref.group if ref else ""
+            if not connection_group:
+                ref = conn_manager.get_connection_ref_by_name(connection_name)
+                if ref is None:
+                    saved = [ref.display() for ref in conn_manager.get_saved_connections()]
+                    return {
+                        "error": f"Connection '{connection_name}' not found or ambiguous. Available: {saved}"
+                    }
+                connection_group = ref.group
+                config = conn_manager.get_connection_config(connection_group, connection_name)
+            if not config:
+                saved = [ref.display() for ref in conn_manager.get_saved_connections()]
+                return {"error": f"Connection '{connection_name}' not found. Available: {saved}"}
 
         session_widget = self._get_active_session_widget()
         if not session_widget:
             return {"error": "No active session."}
 
         if hasattr(session_widget, "connect_to_database"):
-            session_widget.connect_to_database(group, connection_name)
+            session_widget.connect_to_database(connection_group, connection_name)
             return {
                 "content": [{"type": "text", "text": f"Connection request sent for '{connection_name}'."}]
             }
@@ -1451,6 +1459,7 @@ class MCPToolRegistry(QObject):
     def _open_connection(self, args: Dict[str, Any]) -> Dict[str, Any]:
         """Open a saved connection in a NEW TAB."""
         connection_name = args.get("connection_name", "")
+        connection_group = str(args.get("connection_group") or "")
         if not connection_name:
             return {"error": "connection_name is required."}
 
@@ -1459,14 +1468,19 @@ class MCPToolRegistry(QObject):
         if not conn_manager:
             return {"error": "Connection manager not available."}
 
-        config = conn_manager.get_connection_config(connection_name)
+        config = conn_manager.get_connection_config(connection_group, connection_name)
+        if not config and not connection_group:
+            ref = conn_manager.get_connection_ref_by_name(connection_name)
+            if ref is not None:
+                connection_group = ref.group
+                config = conn_manager.get_connection_config(connection_group, connection_name)
         if not config:
-            saved = list(conn_manager.saved_configs.get("connections", {}).keys())
+            saved = [ref.display() for ref in conn_manager.get_saved_connections()]
             return {"error": f"Connection '{connection_name}' not found. Available: {saved}"}
 
         # Use _connect_new_tab which always creates a new tab
         if hasattr(mw, "_connect_new_tab"):
-            mw._connect_new_tab(connection_name)
+            mw._connect_new_tab(connection_group, connection_name)
             current_widget = mw._get_current_session_widget() if hasattr(mw, "_get_current_session_widget") else None
             session = getattr(current_widget, "session", None) if current_widget else None
             if getattr(session, "session_id", None):
@@ -2732,14 +2746,16 @@ class MCPToolRegistry(QObject):
 
     # === Database Intelligence Tool Implementations ===
 
-    def _get_connector(self, connection_name: str = ""):
+    def _get_connector(self, connection_name: str = "", connection_group: str = ""):
         """Get a database connector — a named one, or the current session's."""
         name = (connection_name or "").strip()
+        group = (connection_group or "").strip()
+        session = self._get_active_session()
         if not name:
-            session = self._get_active_session()
             if not session or not session.connection_name:
                 return None, "No database connection in current session."
             name = session.connection_name
+            group = getattr(session, "connection_group", None) or ""
 
         mw = self._main_window
         conn_manager = getattr(mw, "_connection_manager", None)
@@ -2751,7 +2767,7 @@ class MCPToolRegistry(QObject):
             except Exception as e:
                 return None, f"Cannot access connection manager: {e}"
 
-        connector = conn_manager.get_connection(name)
+        connector = conn_manager.get_connection(group, name)
         if not connector:
             return None, f"Connection '{name}' not found."
 

--- a/source/src/ui/components/results_viewer.py
+++ b/source/src/ui/components/results_viewer.py
@@ -2567,11 +2567,12 @@ class ResultsViewer(QWidget):
 
     def _sync_connection_color_from_session(self):
         connection_name = getattr(self._session, "connection_name", "") if self._session is not None else ""
+        connection_group = getattr(self._session, "connection_group", "") or "" if self._session is not None else ""
         if not connection_name:
             return
         try:
             from src.database.connection_manager import ConnectionManager
-            config = ConnectionManager().get_connection_config(connection_name)
+            config = ConnectionManager().get_connection_config(connection_group, connection_name)
             color = config.get("color", "") if config else ""
         except Exception:
             color = ""

--- a/source/src/ui/components/session_widget.py
+++ b/source/src/ui/components/session_widget.py
@@ -172,10 +172,12 @@ class BlockAutoConnectWorker(QObject):
         connection_name: str,
         connection_manager=None,
         *,
+        connection_group: str = "",
         database_name: str | None = None,
     ):
         super().__init__()
         self.connection_name = connection_name
+        self.connection_group = connection_group or ""
         self._manager = connection_manager
         self._database_name = database_name
 
@@ -186,7 +188,7 @@ class BlockAutoConnectWorker(QObject):
                 from src.database.connection_manager import ConnectionManager
                 manager = ConnectionManager()
 
-            config = manager.get_connection_config(self.connection_name)
+            config = manager.get_connection_config(self.connection_group, self.connection_name)
             if not config:
                 self.finished.emit(None, f"Connection config not found: {self.connection_name}")
                 return
@@ -246,7 +248,7 @@ class SessionWidget(QWidget):
     execute_python = pyqtSignal(str)  # code
     status_changed = pyqtSignal(str)  # status message
     connection_changed = pyqtSignal(str, str)  # (connection_name, database)
-    connection_drop_requested = pyqtSignal(str)  # connection_name
+    connection_drop_requested = pyqtSignal(str, str)  # group, name
     block_connection_changed = pyqtSignal(object, str)  # (CodeBlock, connection_name)
     block_database_changed = pyqtSignal(object, str)  # (CodeBlock, database_name)
     execution_started = pyqtSignal()  # Emitted when execution starts (for running indicator)
@@ -1123,6 +1125,18 @@ class SessionWidget(QWidget):
             return config.get("database", ""), target or None
         return target or config.get("database", ""), None
 
+    def _sql_connection_identity(self, block, connection_name=None):
+        """Return (group, name) for SQL execution on a block or session default."""
+        if connection_name:
+            group = ""
+            if block and hasattr(block, "get_connection_group"):
+                group = block.get_connection_group() or ""
+            return group, connection_name
+        conn = self.session.connection_name
+        if not conn:
+            return "", None
+        return self.session.connection_group or "", conn
+
     def _peek_sql_connector_for_block(
         self,
         block,
@@ -1133,12 +1147,12 @@ class SessionWidget(QWidget):
         if block is None or not hasattr(block, "get_block_key"):
             return self.session.connector if self.session.is_connected else None
 
-        conn_name = connection_name or self.session.connection_name
+        conn_group, conn_name = self._sql_connection_identity(block, connection_name)
         if not conn_name:
             return None
 
         manager = self._get_connection_manager()
-        config = manager.get_connection_config(conn_name)
+        config = manager.get_connection_config(conn_group, conn_name)
         if not config:
             return None
 
@@ -1147,6 +1161,7 @@ class SessionWidget(QWidget):
         )
         return self._block_connector_pool.peek_connected(
             block.get_block_key(),
+            conn_group,
             conn_name,
             database=connect_db,
             database_context=db_context,
@@ -1207,7 +1222,7 @@ class SessionWidget(QWidget):
         self._touch_db_activity()
 
         block = self.editor.get_current_executing_block()
-        conn_name = connection_name or self.session.connection_name
+        conn_group, conn_name = self._sql_connection_identity(block, connection_name)
         if not conn_name:
             self.append_output(S.session_widget.no_active_connection, error=True)
             self.status_changed.emit(S.session_widget.status_no_connection)
@@ -1226,6 +1241,7 @@ class SessionWidget(QWidget):
             worker = BlockAutoConnectWorker(
                 conn_name,
                 connection_manager=manager,
+                connection_group=conn_group,
                 database_name=database_name or (block.get_database_name() if block else None),
             )
             worker.moveToThread(thread)
@@ -1303,7 +1319,7 @@ class SessionWidget(QWidget):
             return
 
         block = self.editor.get_current_executing_block()
-        conn_name = connection_name or self.session.connection_name
+        conn_group, conn_name = self._sql_connection_identity(block, connection_name)
         if not conn_name:
             self.append_output(S.session_widget.no_active_connection, error=True)
             self.status_changed.emit(S.session_widget.status_no_connection)
@@ -1322,6 +1338,7 @@ class SessionWidget(QWidget):
             worker = BlockAutoConnectWorker(
                 conn_name,
                 connection_manager=manager,
+                connection_group=conn_group,
                 database_name=database_name or (block.get_database_name() if block else None),
             )
             worker.moveToThread(thread)
@@ -1426,9 +1443,11 @@ class SessionWidget(QWidget):
 
         self._touch_db_activity()
 
-        conn_name = connection_name or self.session.connection_name
+        conn_group, conn_name = self._sql_connection_identity(block, connection_name)
         if block is not None and conn_name and hasattr(block, "get_block_key"):
-            self._block_connector_pool.register(block.get_block_key(), conn_name, connector)
+            self._block_connector_pool.register(
+                block.get_block_key(), conn_group, conn_name, connector
+            )
 
         self._execute_sql_with_connector(connector, query, block_name, connection_name, database_name, sql_parameters)
 

--- a/source/src/ui/controllers/connection_controller.py
+++ b/source/src/ui/controllers/connection_controller.py
@@ -252,9 +252,10 @@ class ConnectionController(QObject):
         
         if session and session.is_connected:
             conn_name = session.connection_name
-            
+            conn_group = session.connection_group or ""
+
             # Get connection config
-            config = self.connection_manager.get_connection_config(conn_name)
+            config = self.connection_manager.get_connection_config(conn_group, conn_name)
             host = config.get("host", "localhost") if config else "localhost"
             db = config.get("database", "") if config else ""
             db_type = config.get("db_type", "") if config else ""

--- a/source/src/ui/controllers/session_controller.py
+++ b/source/src/ui/controllers/session_controller.py
@@ -88,14 +88,18 @@ class SessionController(QObject):
         try:
             # Capture active session connection BEFORE creating new one
             previous_connection = None
+            previous_group = ""
             previous_color = None
             
             if inherit_connection:
                 current_widget = self.get_current_session_widget()
                 if current_widget and hasattr(current_widget, "session"):
                     previous_connection = current_widget.session.connection_name
+                    previous_group = getattr(current_widget.session, "connection_group", None) or ""
                     if previous_connection:
-                        config = self.connection_manager.get_connection_config(previous_connection)
+                        config = self.connection_manager.get_connection_config(
+                            previous_group, previous_connection
+                        )
                         if config:
                             previous_color = config.get("color", "#007ACC") or "#007ACC"
             
@@ -112,7 +116,7 @@ class SessionController(QObject):
             # Defer connection to background with delay
             if previous_connection:
                 QTimer.singleShot(150, lambda: self._connect_session_background(
-                    widget, session, previous_connection, previous_color
+                    widget, session, previous_group, previous_connection, previous_color
                 ))
             
             self.session_created.emit(widget)
@@ -161,7 +165,8 @@ class SessionController(QObject):
         
         # Apply tab color based on session connection
         if hasattr(session, "_connection_name") and session._connection_name:
-            config = self.connection_manager.get_connection_config(session._connection_name)
+            conn_group = getattr(session, "_connection_group", None) or ""
+            config = self.connection_manager.get_connection_config(conn_group, session._connection_name)
             if config:
                 color = config.get("color", "#007ACC") or "#007ACC"
                 self.session_tabs.set_tab_connection_color(index, color)
@@ -190,7 +195,7 @@ class SessionController(QObject):
             lambda block, conn_name: self._main._on_block_connection_changed(block, conn_name)
         )
         widget.connection_drop_requested.connect(
-            lambda conn_name: self._main._quick_connect(conn_name)
+            lambda group, name: self._main._quick_connect(group, name)
         )
         widget.block_database_changed.connect(
             lambda block, db_name: self._main._on_block_database_changed(block, db_name)
@@ -231,7 +236,7 @@ class SessionController(QObject):
             lambda ns, w=widget: w.editor.refresh_completion_context()
         )
     
-    def _connect_session_background(self, widget, session, connection_name, color):
+    def _connect_session_background(self, widget, session, connection_group, connection_name, color):
         """Connect session in background thread to avoid UI freeze"""
         
         import weakref
@@ -239,9 +244,10 @@ class SessionController(QObject):
         class ConnectionWorker(QObject):
             finished = pyqtSignal(bool)
 
-            def __init__(self, session, connection_name):
+            def __init__(self, session, connection_group, connection_name):
                 super().__init__()
                 self._session_ref = weakref.ref(session)
+                self._connection_group = connection_group or ""
                 self._connection_name = connection_name
                 self._cancelled = False
 
@@ -257,7 +263,7 @@ class SessionController(QObject):
                     self.finished.emit(False)
                     return
                 try:
-                    result = session_ref.connect(self._connection_name)
+                    result = session_ref.connect(self._connection_group, self._connection_name)
                     if self._cancelled:
                         self.finished.emit(False)
                         return
@@ -267,7 +273,7 @@ class SessionController(QObject):
                     self.finished.emit(False)
 
         thread = QThread()
-        worker = ConnectionWorker(session, connection_name)
+        worker = ConnectionWorker(session, connection_group, connection_name)
 
         def on_connected(success):
             if success and color:
@@ -417,7 +423,8 @@ class SessionController(QObject):
             # Inherit connection
             if hasattr(widget, "session") and widget.session.connection_name:
                 try:
-                    session.connect(widget.session.connection_name)
+                    src = widget.session
+                    session.connect(src.connection_group or "", src.connection_name)
                 except Exception:
                     pass
             
@@ -437,7 +444,9 @@ class SessionController(QObject):
             
             # Apply tab color
             if session.connection_name:
-                config = self.connection_manager.get_connection_config(session.connection_name)
+                config = self.connection_manager.get_connection_config(
+                    session.connection_group or "", session.connection_name
+                )
                 if config:
                     color = config.get("color", "#007ACC") or "#007ACC"
                     self.session_tabs.set_tab_connection_color(tab_index, color)

--- a/source/src/ui/main_window/_connections.py
+++ b/source/src/ui/main_window/_connections.py
@@ -194,7 +194,10 @@ class ConnectionsMixin:
             widget.connection_changed.emit(connection_name, display_name)
 
         # --- Update connection panel ---
-        config = self.connection_manager.get_connection_config(connection_name)
+        connection_group = ""
+        if widget and hasattr(widget, "session"):
+            connection_group = getattr(widget.session, "connection_group", None) or ""
+        config = self.connection_manager.get_connection_config(connection_group, connection_name)
         if config:
             host = config.get("host", "localhost")
             db_type = config.get("db_type", "")

--- a/source/src/ui/main_window/_file_io.py
+++ b/source/src/ui/main_window/_file_io.py
@@ -118,18 +118,22 @@ class FileIOMixin:
         try:
             # Capture connection from current tab BEFORE creating new one
             previous_connection = None
+            previous_group = ""
             previous_color = None
             previous_database_context = ""
             current_widget = self._get_current_session_widget()
             if current_widget and hasattr(current_widget, "session"):
                 previous_connection = current_widget.session.connection_name
+                previous_group = getattr(current_widget.session, "connection_group", None) or ""
                 previous_database_context = getattr(current_widget.session, "database_context", "") or ""
                 if not previous_database_context:
                     previous_database_context = get_connector_database_context(
                         getattr(current_widget.session, "connector", None)
                     )
                 if previous_connection:
-                    config = self.connection_manager.get_connection_config(previous_connection)
+                    config = self.connection_manager.get_connection_config(
+                        previous_group, previous_connection
+                    )
                     if config:
                         previous_color = config.get("color", "#007ACC") or "#007ACC"
 
@@ -271,7 +275,7 @@ class FileIOMixin:
             if previous_connection:
                 from PyQt6.QtCore import QTimer
                 QTimer.singleShot(150, lambda: self._connect_session_background(
-                    widget, session, previous_connection, previous_color, previous_database_context
+                    widget, session, previous_group, previous_connection, previous_color, previous_database_context
                 ))
 
         except Exception as e:
@@ -822,7 +826,8 @@ class FileIOMixin:
 
             if session_widget.session.connection_name:
                 conn_name = session_widget.session.connection_name
-                config = self.connection_manager.get_connection_config(conn_name)
+                conn_group = session_widget.session.connection_group or ""
+                config = self.connection_manager.get_connection_config(conn_group, conn_name)
                 if not config:
                     connector = getattr(session_widget.session, "connector", None)
                     connector_params = getattr(connector, "connection_params", None)

--- a/source/src/ui/main_window/_layout.py
+++ b/source/src/ui/main_window/_layout.py
@@ -418,12 +418,6 @@ class LayoutMixin:
         """Updates the saved connections list"""
         self.connection_panel.refresh_connections()
 
-    def _on_connection_double_click(self, item: QListWidgetItem):
-        """Connects on double click on connection"""
-        conn_name = item.data(Qt.ItemDataRole.UserRole)
-        if conn_name:
-            self._quick_connect(conn_name)
-
     def _toggle_panel_visibility(self, panel_name: str, visible: bool):
         """Controls visibility of a panel"""
         if visible:

--- a/source/src/ui/main_window/_sessions.py
+++ b/source/src/ui/main_window/_sessions.py
@@ -96,7 +96,8 @@ class SessionsMixin:
             # Inherit connection from original session
             if hasattr(widget, "session") and widget.session.connection_name:
                 try:
-                    connected = session.connect(widget.session.connection_name)
+                    src = widget.session
+                    connected = session.connect(src.connection_group or "", src.connection_name)
                     if not connected:
                         pass  # Connection failed, session remains without connection
                 except Exception:
@@ -111,7 +112,7 @@ class SessionsMixin:
                 lambda block, conn_name: self._on_block_connection_changed(block, conn_name)
             )
             new_widget.connection_drop_requested.connect(
-                lambda conn_name: self._quick_connect(conn_name)
+                lambda group, name: self._quick_connect(group, name)
             )
             new_widget.block_database_changed.connect(
                 lambda block, db_name: self._on_block_database_changed(block, db_name)
@@ -146,7 +147,8 @@ class SessionsMixin:
 
             # Apply tab color if original session had connection
             if session.connection_name:
-                config = self.connection_manager.get_connection_config(session.connection_name)
+                conn_group = getattr(widget.session, "connection_group", None) or ""
+                config = self.connection_manager.get_connection_config(conn_group, session.connection_name)
                 if config:
                     color = config.get("color", "#007ACC") or "#007ACC"
                     self.session_tabs.set_tab_connection_color(tab_index, color)
@@ -237,7 +239,13 @@ class SessionsMixin:
 
         session = getattr(widget, "session", None)
         block_connection_name = block.get_connection_name() if hasattr(block, "get_connection_name") else ""
+        block_connection_group = ""
+        if hasattr(block, "get_connection_group"):
+            block_connection_group = block.get_connection_group() or ""
         connection_name = block_connection_name or getattr(session, "connection_name", "")
+        connection_group = block_connection_group if block_connection_name else (
+            getattr(session, "connection_group", None) or ""
+        )
         if not connection_name:
             self.statusBar().showMessage(S.entity_info.no_connection, 4000)
             return
@@ -246,13 +254,13 @@ class SessionsMixin:
         session_connector = getattr(session, "connector", None)
         existing_connector = None
         if block_connection_name:
-            candidate = self.connection_manager.get_connection(connection_name)
+            candidate = self.connection_manager.get_connection(connection_group, connection_name)
             if candidate and self._connector_is_connected(candidate):
                 existing_connector = candidate
         elif session_connector and self._connector_is_connected(session_connector):
             existing_connector = session_connector
 
-        connection_config = self.connection_manager.get_connection_config(connection_name)
+        connection_config = self.connection_manager.get_connection_config(connection_group, connection_name)
         connector = None if connection_config else existing_connector
 
         if connector is None and connection_config is None and existing_connector is None:
@@ -348,18 +356,22 @@ class SessionsMixin:
         try:
             # Capture active session connection BEFORE creating new one
             previous_connection = None
+            previous_group = ""
             previous_color = None
             previous_database_context = ""
             current_widget = self._get_current_session_widget() if inherit_connection else None
             if current_widget and hasattr(current_widget, "session"):
                 previous_connection = current_widget.session.connection_name
+                previous_group = getattr(current_widget.session, "connection_group", None) or ""
                 previous_database_context = getattr(current_widget.session, "database_context", "") or ""
                 if not previous_database_context:
                     previous_database_context = get_connector_database_context(
                         getattr(current_widget.session, "connector", None)
                     )
                 if previous_connection:
-                    config = self.connection_manager.get_connection_config(previous_connection)
+                    config = self.connection_manager.get_connection_config(
+                        previous_group, previous_connection
+                    )
                     if config:
                         previous_color = config.get("color", "#007ACC") or "#007ACC"
 
@@ -376,7 +388,7 @@ class SessionsMixin:
             if previous_connection:
                 from PyQt6.QtCore import QTimer
                 QTimer.singleShot(150, lambda: self._connect_session_background(
-                    widget, session, previous_connection, previous_color, previous_database_context
+                    widget, session, previous_group, previous_connection, previous_color, previous_database_context
                 ))
         finally:
             self._creating_session = False
@@ -592,7 +604,9 @@ class SessionsMixin:
         ):
             self._stop_orphan_connection(thread, worker)
 
-    def _connect_session_background(self, widget, session, connection_name, color, database_context=""):
+    def _connect_session_background(
+        self, widget, session, connection_group, connection_name, color, database_context=""
+    ):
         """Connect session in a true background thread to avoid UI freeze."""
         from PyQt6.QtCore import QThread, pyqtSignal, QObject
 
@@ -602,10 +616,11 @@ class SessionsMixin:
         class ConnectionWorker(QObject):
             finished = pyqtSignal(bool)
 
-            def __init__(self, session, connection_name, database_context, widget=None):
+            def __init__(self, session, connection_group, connection_name, database_context, widget=None):
                 super().__init__()
                 self._session_ref = weakref.ref(session)
                 self._widget_ref = weakref.ref(widget) if widget is not None else None
+                self._connection_group = connection_group or ""
                 self._connection_name = connection_name
                 self._database_context = database_context
                 self._cancelled = False
@@ -637,7 +652,7 @@ class SessionsMixin:
                 try:
                     if self._database_context:
                         session.database_context = self._database_context
-                    result = session.connect(self._connection_name)
+                    result = session.connect(self._connection_group, self._connection_name)
                     if self._ignore_result():
                         self.finished.emit(False)
                         return
@@ -667,7 +682,7 @@ class SessionsMixin:
         # Create and start background thread
         thread = QThread()
         thread.setObjectName("SessionBackgroundConnection")
-        worker = ConnectionWorker(session, connection_name, database_context, widget)
+        worker = ConnectionWorker(session, connection_group, connection_name, database_context, widget)
         self._adopt_connection_thread(thread, worker)
 
         def cleanup_connection_thread(active_thread=thread, active_worker=worker):
@@ -727,12 +742,15 @@ class SessionsMixin:
     def _handle_empty_state_connection_drop(self, mime_data):
         """Handle connection/database drop on empty state - creates new session with SQL block."""
         conn_name = ""
+        conn_group = ""
         db_type = ""
         color = ""
         db_name = ""
 
         if mime_data.hasFormat("application/x-connection-name"):
             conn_name = bytes(mime_data.data("application/x-connection-name")).decode("utf-8")
+        if mime_data.hasFormat("application/x-connection-group"):
+            conn_group = bytes(mime_data.data("application/x-connection-group")).decode("utf-8")
         if mime_data.hasFormat("application/x-db-type"):
             db_type = bytes(mime_data.data("application/x-db-type")).decode("utf-8")
         if mime_data.hasFormat("application/x-connection-color"):
@@ -743,7 +761,7 @@ class SessionsMixin:
         # Connect session using _quick_connect (creates tab, connects, loads schema,
         # updates Object Explorer, sets tab color)
         if conn_name:
-            self._quick_connect(conn_name)
+            self._quick_connect(conn_group, conn_name)
         else:
             self._new_session()
 
@@ -761,7 +779,12 @@ class SessionsMixin:
         block.set_language("sql")
 
         if conn_name:
-            block.set_connection_name(conn_name, db_type=db_type or None, color=color or None)
+            block.set_connection_name(
+                conn_name,
+                db_type=db_type or None,
+                color=color or None,
+                connection_group=conn_group or None,
+            )
 
         if db_name:
             block.set_database_name(db_name)
@@ -968,7 +991,7 @@ class SessionsMixin:
             lambda block, conn_name: self._on_block_connection_changed(block, conn_name)
         )
         widget.connection_drop_requested.connect(
-            lambda conn_name: self._quick_connect(conn_name)
+            lambda group, name: self._quick_connect(group, name)
         )
         widget.block_database_changed.connect(
             lambda block, db_name: self._on_block_database_changed(block, db_name)
@@ -1025,7 +1048,8 @@ class SessionsMixin:
 
         # During restoration, apply tab color based on session connection
         if hasattr(session, "_connection_name") and session._connection_name:
-            config = self.connection_manager.get_connection_config(session._connection_name)
+            conn_group = getattr(session, "_connection_group", None) or ""
+            config = self.connection_manager.get_connection_config(conn_group, session._connection_name)
             if config:
                 color = config.get("color", "#007ACC") or "#007ACC"
                 self.session_tabs.set_tab_connection_color(index, color)
@@ -1332,7 +1356,9 @@ class SessionsMixin:
             """)
 
             # Update active connection panel
-            config = self.connection_manager.get_connection_config(session.connection_name)
+            config = self.connection_manager.get_connection_config(
+                session.connection_group or "", session.connection_name
+            )
             current_db = get_connector_database_context(session.connector) or getattr(session, "database_context", "")
             if config:
                 self.connection_panel.set_active_connection(
@@ -1395,7 +1421,8 @@ class SessionsMixin:
             connection_name: Connection name
             database: Nome do banco de dados atual
         """
-        config = self.connection_manager.get_connection_config(connection_name)
+        connection_group = session.connection_group or ""
+        config = self.connection_manager.get_connection_config(connection_group, connection_name)
         if not config:
             return
 
@@ -1417,11 +1444,14 @@ class SessionsMixin:
             if not hasattr(self, "_oe_current_connection"):
                 self._oe_current_connection = {}
             self._oe_current_connection[session.session_id] = connection_name
-            self._schema_service.invalidate_cache(connection_name, session_id=session.session_id)
+            self._schema_service.invalidate_cache(
+                connection_name, session_id=session.session_id, connection_group=connection_group
+            )
             self._load_schema_with_loading(
                 session.connector,
                 connection_name,
                 session_id=session.session_id,
+                connection_group=connection_group,
             )
 
         # UI updates only for the focused session tab.
@@ -1710,8 +1740,8 @@ class SessionsMixin:
 
     def _queue_legacy_saved_connection_if_needed(self):
         """Queues the legacy workspace active connection onto the focused tab."""
-        connection_name = getattr(self, "_pending_legacy_active_connection", None)
-        if not connection_name:
+        legacy = getattr(self, "_pending_legacy_active_connection", None)
+        if not legacy:
             return
 
         current_widget = self._get_current_session_widget()
@@ -1722,7 +1752,16 @@ class SessionsMixin:
             self._pending_legacy_active_connection = None
             return
 
-        self._queue_restored_session_connection(current_widget.session.session_id, connection_name)
+        from src.core.connection_ref import ConnectionRef
+
+        group, name = "", str(legacy)
+        if "\x1f" in name:
+            ref = ConnectionRef.from_storage_key(name)
+            group, name = ref.group, ref.name
+
+        self._queue_restored_session_connection(
+            current_widget.session.session_id, name, group
+        )
         self._pending_legacy_active_connection = None
 
     def _connect_next_restored_session(self):

--- a/source/src/ui/main_window/_sessions.py
+++ b/source/src/ui/main_window/_sessions.py
@@ -1421,7 +1421,7 @@ class SessionsMixin:
             connection_name: Connection name
             database: Nome do banco de dados atual
         """
-        connection_group = session.connection_group or ""
+        connection_group = getattr(session, "connection_group", None) or ""
         config = self.connection_manager.get_connection_config(connection_group, connection_name)
         if not config:
             return

--- a/tests/test_block_connection.py
+++ b/tests/test_block_connection.py
@@ -355,6 +355,7 @@ class TestConnectionResolution:
         block = MagicMock()
         block.get_block_key.return_value = "block-key"
         block.get_database_name.return_value = None
+        block.get_connection_group.return_value = ""
 
         with patch.object(widget.editor, "get_current_executing_block", return_value=block):
             with patch("src.database.connection_manager.ConnectionManager") as MockMgr:
@@ -367,7 +368,7 @@ class TestConnectionResolution:
                     "username": "u",
                     "password": "",
                 }
-                widget._block_connector_pool.register("block-key", "BlockConn", mock_connector)
+                widget._block_connector_pool.register("block-key", "", "BlockConn", mock_connector)
 
                 with patch.object(widget, "_execute_sql_with_connector") as mock_exec:
                     widget._on_execute_sql("SELECT 1", block_name="bloco1", connection_name="BlockConn")

--- a/tests/test_block_connector_pool.py
+++ b/tests/test_block_connector_pool.py
@@ -24,8 +24,8 @@ def test_pool_reuses_connector_for_same_block_key():
         "src.database.block_connector_pool.connect_connector_from_config",
         return_value=connector,
     ) as connect_mock:
-        first = pool.get("block-a", "conn", config)
-        second = pool.get("block-a", "conn", config)
+        first = pool.get("block-a", "", "conn", config)
+        second = pool.get("block-a", "", "conn", config)
 
     assert first is second
     connect_mock.assert_called_once()
@@ -49,29 +49,56 @@ def test_pool_creates_separate_connectors_per_block_key():
         "src.database.block_connector_pool.connect_connector_from_config",
         side_effect=connectors,
     ):
-        a = pool.get("block-a", "conn", config)
-        b = pool.get("block-b", "conn", config)
+        a = pool.get("block-a", "", "conn", config)
+        b = pool.get("block-b", "", "conn", config)
 
     assert a is connectors[0]
     assert b is connectors[1]
     assert a is not b
 
 
+def test_pool_distinguishes_same_name_in_different_groups():
+    pool = BlockConnectorPool()
+    config_prod = {
+        "db_type": "postgresql",
+        "host": "prod",
+        "port": 5432,
+        "database": "db1",
+        "username": "u",
+        "password": "",
+    }
+    config_dev = dict(config_prod)
+    config_dev["host"] = "dev"
+    connectors = [MagicMock(), MagicMock()]
+    for c in connectors:
+        c.is_connected.return_value = True
+
+    with patch(
+        "src.database.block_connector_pool.connect_connector_from_config",
+        side_effect=connectors,
+    ):
+        prod = pool.get("block-a", "Prod", "conn", config_prod)
+        dev = pool.get("block-a", "Dev", "conn", config_dev)
+
+    assert prod is connectors[0]
+    assert dev is connectors[1]
+
+
 def test_peek_connected_returns_none_without_entry():
     pool = BlockConnectorPool()
-    assert pool.peek_connected("block-a", "conn") is None
+    assert pool.peek_connected("block-a", "", "conn") is None
 
 
 def test_peek_connected_reuses_live_connector_without_connect():
     pool = BlockConnectorPool()
     connector = MagicMock()
     connector.is_connected.return_value = True
-    pool.register("block-a", "conn", connector)
+    pool.register("block-a", "", "conn", connector)
 
     with patch(
         "src.database.block_connector_pool.connect_connector_from_config",
     ) as connect_mock:
-        found = pool.peek_connected("block-a", "conn")
+        found = pool.peek_connected("block-a", "", "conn")
 
     assert found is connector
     connect_mock.assert_not_called()

--- a/tests/test_block_connector_pool_reaper.py
+++ b/tests/test_block_connector_pool_reaper.py
@@ -4,6 +4,11 @@ import time
 from unittest.mock import MagicMock, patch
 
 from src.database.block_connector_pool import BlockConnectorPool
+from src.core.connection_ref import ConnectionRef
+
+
+def _conn_key(name: str = "conn", group: str = "") -> str:
+    return ConnectionRef(group=group, name=name).storage_key()
 
 
 def test_reap_idle_releases_stale_connector():
@@ -13,7 +18,7 @@ def test_reap_idle_releases_stale_connector():
     connector.is_query_busy.return_value = False
     pool._entries["block-a"] = {
         "connector": connector,
-        "connection_name": "conn",
+        "connection_key": _conn_key(),
         "last_used_at": time.monotonic() - 600,
     }
 
@@ -31,7 +36,7 @@ def test_reap_idle_skips_active_connector():
     connector.is_query_busy.return_value = False
     pool._entries["block-a"] = {
         "connector": connector,
-        "connection_name": "conn",
+        "connection_key": _conn_key(),
         "last_used_at": time.monotonic(),
     }
 
@@ -49,7 +54,7 @@ def test_reap_idle_skips_busy_query():
     connector.is_query_busy.return_value = True
     pool._entries["block-a"] = {
         "connector": connector,
-        "connection_name": "conn",
+        "connection_key": _conn_key(),
         "last_used_at": time.monotonic() - 600,
     }
 
@@ -64,7 +69,7 @@ def test_reap_idle_disabled_when_timeout_zero():
     connector = MagicMock()
     pool._entries["block-a"] = {
         "connector": connector,
-        "connection_name": "conn",
+        "connection_key": _conn_key(),
         "last_used_at": 0.0,
     }
 

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -75,6 +75,28 @@ class TestConnectionManager:
         assert connection_manager.get_connection_config("Prod", "Server")["host"] == "prod"
         assert connection_manager.get_connection_config("Dev", "Server")["host"] == "dev"
 
+    def test_resolve_by_name_only_ambiguous_returns_none(self, connection_manager):
+        connection_manager.save_connection_config(
+            name="Server", db_type="mssql", host="prod", port=1433, database="db", group="Prod"
+        )
+        connection_manager.save_connection_config(
+            name="Server", db_type="mssql", host="dev", port=1433, database="db", group="Dev"
+        )
+
+        from src.core.connection_ref import resolve_by_name_only
+
+        assert resolve_by_name_only(connection_manager, "Server") is None
+
+    def test_get_connection_config_by_name_ambiguous_returns_none(self, connection_manager):
+        connection_manager.save_connection_config(
+            name="Server", db_type="mssql", host="prod", port=1433, database="db", group="Prod"
+        )
+        connection_manager.save_connection_config(
+            name="Server", db_type="mssql", host="dev", port=1433, database="db", group="Dev"
+        )
+
+        assert connection_manager.get_connection_config_by_name("Server") is None
+
     def test_duplicate_in_same_group_raises(self, connection_manager):
         connection_manager.save_connection_config(
             name="Dup", db_type="mssql", host="localhost", port=1433, database="db", group="Prod"

--- a/tests/test_results_viewer.py
+++ b/tests/test_results_viewer.py
@@ -764,13 +764,14 @@ class TestResultsViewerMultiTab:
 
     def test_set_session_resolves_connection_color(self, viewer):
         """Setting a session should sync the result tab color from the connection config."""
-        session = MagicMock(connection_name="analytics")
+        session = MagicMock(connection_name="analytics", connection_group="Prod")
         manager = MagicMock()
         manager.get_connection_config.return_value = {"color": "#8b5cf6"}
 
         with patch("src.database.connection_manager.ConnectionManager", return_value=manager):
             viewer.set_session(session)
 
+        manager.get_connection_config.assert_called_once_with("Prod", "analytics")
         assert viewer._connection_color == "#8b5cf6"
         assert viewer._result_tabs.tabBar()._connection_color == "#8b5cf6"
 

--- a/tests/test_schema_cache_invalidation.py
+++ b/tests/test_schema_cache_invalidation.py
@@ -356,8 +356,12 @@ def test_on_session_connection_changed_clears_autocomplete_before_schema_reload(
     assert widget.editor._sql_schema == {}
     widget.editor.set_database_context.assert_called_once_with("")
     session_block.set_sql_schema.assert_called_once_with({})
-    main_window._schema_service.invalidate_cache.assert_called_once_with("Conn", session_id="sid-1")
-    main_window._load_schema_with_loading.assert_called_once_with(connector, "Conn", session_id="sid-1")
+    main_window._schema_service.invalidate_cache.assert_called_once_with(
+        "Conn", session_id="sid-1", connection_group=""
+    )
+    main_window._load_schema_with_loading.assert_called_once_with(
+        connector, "Conn", session_id="sid-1", connection_group=""
+    )
     session_block.db_panel.set_database.assert_called_once_with("newdb")
 
 
@@ -376,10 +380,10 @@ def test_on_session_connection_changed_ignores_unfocused_session(qapp):
     widget.editor.set_database_context.assert_not_called()
     # Unfocused tabs still refresh schema cache (MCP / autocomplete), but skip UI updates.
     main_window._schema_service.invalidate_cache.assert_called_once_with(
-        "Conn", session_id="sid-1"
+        "Conn", session_id="sid-1", connection_group=""
     )
     main_window._load_schema_with_loading.assert_called_once_with(
-        connector, "Conn", session_id="sid-1"
+        connector, "Conn", session_id="sid-1", connection_group=""
     )
 
 

--- a/tests/test_session_widget_sql_worker.py
+++ b/tests/test_session_widget_sql_worker.py
@@ -1,6 +1,6 @@
 """Regression tests for SessionWidget SQL worker lifecycle."""
 
-import time
+import threading
 from unittest.mock import MagicMock
 
 import pytest
@@ -68,12 +68,18 @@ class _ThreadHost(QWidget, SessionsMixin):
   """Minimal MainWindow stand-in for background-thread adoption tests."""
 
 
-class _SlowConnector:
+class _BlockingConnector:
     db_type = "mssql"
 
+    def __init__(self):
+        self._release = threading.Event()
+
     def execute_query(self, query, parameters=None):
-        time.sleep(3.0)
+        self._release.wait(timeout=30)
         return None
+
+    def release(self):
+        self._release.set()
 
 
 def test_cleanup_orphans_sql_thread_without_destroy_while_running(qtbot, monkeypatch):
@@ -90,7 +96,8 @@ def test_cleanup_orphans_sql_thread_without_destroy_while_running(qtbot, monkeyp
     qtbot.addWidget(widget)
 
     thread = QThread()
-    worker = SessionSqlWorker(_SlowConnector(), "SELECT 1")
+    connector = _BlockingConnector()
+    worker = SessionSqlWorker(connector, "SELECT 1")
     worker.moveToThread(thread)
     widget._sql_thread = thread
     widget._sql_worker = worker
@@ -104,10 +111,12 @@ def test_cleanup_orphans_sql_thread_without_destroy_while_running(qtbot, monkeyp
     from PyQt6 import sip
 
     widget.cleanup()
+    QApplication.processEvents()
 
     assert not sip.isdeleted(thread)
     assert thread.isRunning() or id(thread) in getattr(host, "_adopted_connection_threads", {})
 
+    connector.release()
     stop_qthread = __import__(
         "src.utils.qt_threading", fromlist=["stop_qthread"]
     ).stop_qthread

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,7 @@ resolution-markers = [
 [manifest]
 overrides = [
     { name = "click", specifier = ">=8.3.3" },
+    { name = "gitpython", specifier = ">=3.1.55" },
     { name = "msgpack", specifier = ">=1.2.1" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "setuptools", specifier = ">=83.0.0" },
@@ -535,7 +536,7 @@ wheels = [
 
 [[package]]
 name = "datapyn"
-version = "1.53.2"
+version = "1.54.1"
 source = { virtual = "." }
 dependencies = [
     { name = "azure-identity" },
@@ -777,14 +778,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.50"
+version = "3.1.57"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/0d/132ed135c871b6bf91adf16a0e43797cd535b81d4973b5d09291c54fc5ee/gitpython-3.1.57.tar.gz", hash = "sha256:c493ec57c0ef6b19743798b6a5af859c71814b524e7e6f97baa2f8e658961488", size = 225898, upload-time = "2026-07-26T07:33:26.351Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
+    { url = "https://files.pythonhosted.org/packages/41/6e/2139de986d9c7c3ac86f1f8be43858ce90bdfe2f7175e6c80c650ba15242/gitpython-3.1.57-py3-none-any.whl", hash = "sha256:4ccf7d73c10f5c9e76043fbb2675ac5a1b3ff5b41e648f56bcbed5f63792ecaf", size = 217151, upload-time = "2026-07-26T07:33:24.838Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Resolve saved connections using composite key `(group, name)` instead of name-only lookups that picked the first match when the same name existed in different groups.
- Propagate `connection_group` through session inherit/reconnect, drag-and-drop, block SQL auto-connect, and `BlockConnectorPool` (storage_key).
- `resolve_by_name_only` now returns `None` on ambiguous names; ungrouped single-match legacy paths still work.

## Test plan

- [x] `uv run pytest` on connection/block/session restore modules (106 tests)
- [x] `uv run ruff check source/`
- [ ] Manual: two connections with the same name in different groups — connect each from sidebar
- [ ] Manual: new tab inherits correct group+name from current tab
- [ ] Manual: drag connection from grouped tree onto empty state / block